### PR TITLE
Add sponsor button and update copyright year to 2022.

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,7 +25,20 @@ f<!doctype html>
 <!-- START: Header -->
 <header class="site-header">
   <div class="container text-center text-md-left">
-    <div class="personal-info clearfix"> <a href="#"> <img src="images/Interlisp-D.png" class="float-left" alt="Interlisp-D logo showing windows" width="50" height="50"></a>
+    <div class="personal-info clearfix"> 
+      <div class="float-left">
+        <a href="#"> <img src="images/Interlisp-D.png" alt="Interlisp-D logo showing windows" width="50" height="50"></a>
+
+        <button>
+          <a id="sponsor-button" aria-label="Sponsor @Interlisp" href="https://github.com/sponsors/Interlisp?o=esc" class="btn">
+            <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" stroke="#db61a2">
+              <path fill-rule="evenodd" d="M4.25 2.5c-1.336 0-2.75 1.164-2.75 3 0 2.15 1.58 4.144 3.365 5.682A20.565 20.565 0 008 13.393a20.561 20.561 0 003.135-2.211C12.92 9.644 14.5 7.65 14.5 5.5c0-1.836-1.414-3-2.75-3-1.373 0-2.609.986-3.029 2.456a.75.75 0 01-1.442 0C6.859 3.486 5.623 2.5 4.25 2.5zM8 14.25l-.345.666-.002-.001-.006-.003-.018-.01a7.643 7.643 0 01-.31-.17 22.075 22.075 0 01-3.434-2.414C2.045 10.731 0 8.35 0 5.5 0 2.836 2.086 1 4.25 1 5.797 1 7.153 1.802 8 3.02 8.847 1.802 10.203 1 11.75 1 13.914 1 16 2.836 16 5.5c0 2.85-2.045 5.231-3.885 6.818a22.08 22.08 0 01-3.744 2.584l-.018.01-.006.003h-.002L8 14.25zm0 0l.345.666a.752.752 0 01-.69 0L8 14.25z"></path>
+            </svg>
+            <span class="v-align-middle">Sponsor</span>
+        </a>
+        </button>
+      </div>
+
       <div class="infos float-left">
         <h1><a href="#">Medley Interlisp Project</a></h1>
         <p class="p-info"> Email: <a href="mailto:Interlisp@googlegroups.com" >Interlisp@googlegroups.com</a> <a href="https://groups.google.com/forum/#!topic/interlisp/jq0dJQEWDkU">(archives)</a><br>
@@ -181,6 +194,6 @@ are all under the <a href="https://github.com/interlisp/medley">Medley repositor
 <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/js/bootstrap.min.js" integrity="sha384-wfSDF2E50Y2D1uUdj0O3uMBJnjuUD4Ih7YwaYd1iqfktj0Uod8GCExl3Og8ifwB6" crossorigin="anonymous"></script> 
 <script
       src="https://cdn.rawgit.com/afeld/bootstrap-toc/v1.0.1/dist/bootstrap-toc.min.js"></script>
-      <footer class="site-footer" id="footer">© Copyright 2021 by <a href="https://www.interlisp.org">InterlispOrg Inc</a> </footer>    
+      <footer class="site-footer" id="footer">© Copyright 2022 by <a href="https://www.interlisp.org">InterlispOrg Inc</a> </footer>    
 </body>
 </html>


### PR DESCRIPTION
Add sponsor button to page header.  Templated from github's sponsor button.

![image](https://user-images.githubusercontent.com/22384842/154620561-b45bdc55-7ddd-4f09-9cb1-fc812b6a97ad.png)
