### PR TITLE
Bibliography: Add generator script, group by year, improve generation

### DIFF
--- a/data/bibliography.json
+++ b/data/bibliography.json
@@ -1,11025 +1,4184 @@
-[
-	{
-		"id": "http://zotero.org/groups/2914042/items/XMCBCFMT",
-		"type": "chapter",
-		"abstract": "CAST.FSM denotes a CAST tool which has been developed at the Institute of Systems Science at the University of Linz during the years 1986–1993. The first version of CAST.FSM was implemented in INTERLISP-D and LOOPS for the Siemens-Xerox workstation 5815 (“Dandelion”). CAST.FSM supports the application of the theory of finite state machines for hardware design tasks between the architecture level and the level of gate circuits. The application domain, to get practical experience for CAST.FSM, was the field of VLSI design of ASICS’s where the theory of finite state machines can be applied to improve the testability of such circuits (“design for testability”) and to optimise the required silicon area of the circuit (“floor planning”). An overview of CAST as a whole and of CAST.FSM as a CAST tool is given in [11]. In our presentation we want to report on the re-engineering of CAST.FSM and on new types of applications of CAST.FSM which are currently under investigation. In this context we will distinguish between three different problems:\n1.\nthe implementation of CAST.FSM in ANSI Common Lisp and the design of a new user interface by Rudolf Mittelmann [5].\n\n \n2.\nthe search for systemstheoretical concepts in modelling intelligent hierarchical systems based on the past work of Arthur Koestler [3] following the concepts presented by Franz Pichler in [10].\n\n \n3.\nthe construction of hierarchical formal models (of multi-layer type) to study attributes which are assumed for SOHO-structures (SOHO = Self Organizing Hierarchical Order) of A. Koestler.\n\n \nThe latter problem will deserve the main attention in our presentation. In the present paper we will build such a hierarchical model following the concepts of parallel decomposition of finite state machines (FSMs) and interpret it as a multi-layer type of model.",
-		"container-title": "Computer Aided Systems Theory — EUROCAST 2001",
-		"event-place": "Berlin",
-		"ISBN": "978-3-540-42959-3",
-		"language": "en",
-		"note": "collection-title: Lecture Notes in Computer Science\nDOI: 10.1007/3-540-45654-6_3",
-		"page": "36-44",
-		"publisher": "Springer Berlin Heidelberg",
-		"publisher-place": "Berlin",
-		"source": "DOI.org (Crossref)",
-		"title": "On CAST.FSM Computation of Hierarchical Multi-layer Networks of Automata",
-		"URL": "http://link.springer.com/10.1007/3-540-45654-6_3",
-		"volume": "2178",
-		"collection-editor": [
-			{
-				"family": "Goos",
-				"given": "Gerhard"
-			},
-			{
-				"family": "Hartmanis",
-				"given": "Juris"
-			},
-			{
-				"family": "Leeuwen",
-				"given": "Jan",
-				"non-dropping-particle": "van"
-			}
-		],
-		"editor": [
-			{
-				"family": "Moreno-Díaz",
-				"given": "Roberto"
-			},
-			{
-				"family": "Buchberger",
-				"given": "Bruno"
-			},
-			{
-				"family": "Luis Freire",
-				"given": "José"
-			}
-		],
-		"author": [
-			{
-				"family": "Affenzeller",
-				"given": "Michael"
-			},
-			{
-				"family": "Pichler",
-				"given": "Franz"
-			},
-			{
-				"family": "Mittelmann",
-				"given": "Rudolf"
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					4,
-					15
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"2001"
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/2B4J79N6",
-		"type": "article-journal",
-		"abstract": "Report of a meeting held by the Geological Information Group at the British Petroleum Research Centre, Sunbury, 24 January 1985\n\nThis meeting, concerned mainly with computer manipulation of petroleum exploration data, attracted c. 95 participants. In addition to eight papers presented, there were two computer demonstrations of log analysis systems and a number of poster displays.\n\nThe morning session, concerned with large-scale, integrated hardware and software systems, was chaired by R. Howarth. R. Till of British Petroleum gave the opening paper concerning BP Exploration’s integrated database system. BP Exploration databases fall into three main groups: those containing largely numerical data; databases specifically concerned with text handling; and well-based databases. The ‘numerical’ databases, implemented under the ULTRA database management system (dbms), include a seismic data system, a generalized cartographic database and an earth constants database. Textual databases include a library information system and a Petroconsultants scout data database, both implemented under the BASIS dbms. The well-based systems include a generalized well-data database, a wireline log archive, storage and retrieval system, and a master well index; all three are implemented under the INGRES dbms. Two related BASIS databases contain geochemical and biostratigraphical data.\n\nG. Baxter (co-author M. Hemingway) described the development of Britoil’s well log database which was prompted by the need to have rapid access to digitized wireline log data for c. 1500 wells on the UKCS. Early work involved both locating log information and digitizing those logs held in sepia form only. Each digitized log occupies approximately 1 Mbyte.",
-		"container-title": "Journal of the Geological Society of London",
-		"DOI": "10.1144/gsjgs.142.5.0925",
-		"ISSN": "0016-7649, 2041-479X",
-		"issue": "5",
-		"journalAbbreviation": "Journal of the Geological Society",
-		"language": "en",
-		"page": "925-926",
-		"source": "DOI.org (Crossref)",
-		"title": "Computer manipulation of geological exploration data",
-		"URL": "http://jgs.lyellcollection.org/lookup/doi/10.1144/gsjgs.142.5.0925",
-		"volume": "142",
-		"author": [
-			{
-				"family": "Burwell",
-				"given": "A. D. M."
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					4,
-					15
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"1985",
-					9,
-					1
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/8CFC7VH5",
-		"type": "article-journal",
-		"abstract": "The Dipmeter Advisor is a knowledge-base system, linked to a computer work-station, designed to aid in the interpretation of dipmeter results through interaction between the interpreter and the \"expert\" system.\n\nThe system utilizes dipmeter results, other wireline log data, computer processed results such as LITHO*, and user-input local geological knowledge as the framework for the interpretation. A work session proceeds through a number of phases, which leads to first a structural, then a stratigraphic interpretation of the well data.\n\nConclusions made by the Dipmeter Advisor can be accepted, modified, or rejected by the interpreter at any stage of the work session. The user may also make his own conclusions and comments, which are stored as part of the final interpretation and become part of an updated knowledge-base for input to further field studies.",
-		"container-title": "Bulletin of the Geological Society of Malaysia",
-		"DOI": "10.7186/bgsm21198703",
-		"ISSN": "01266187, 2637109X",
-		"journalAbbreviation": "BGSM",
-		"page": "37-54",
-		"source": "DOI.org (Crossref)",
-		"title": "The Dipmeter Advisor - A dipmeter interpretation workstation",
-		"URL": "https://gsm.org.my/content.php?id=54&pid=702001-101136",
-		"volume": "21",
-		"author": [
-			{
-				"family": "Shanor",
-				"given": "Gordy G."
-			},
-			{
-				"family": "Shanor",
-				"given": "Gordy G."
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					4,
-					15
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"1987",
-					12,
-					30
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/6TXI9U2K",
-		"type": "article-journal",
-		"abstract": "ISI is an off-campus research center in the University of Southern California's School of Engineering. The Institute engages in a broad set of research and application oriented projects in the computer sciences, ranging from advanced research efforts aimed at producing new concepts to operation of a major Arpanet computer facility.",
-		"container-title": "AI Magazine",
-		"DOI": "10.1609/aimag.v1i1.88",
-		"ISSN": "2371-9621, 0738-4602",
-		"issue": "1",
-		"journalAbbreviation": "AIMag",
-		"page": "22",
-		"source": "DOI.org (Crossref)",
-		"title": "Research in Progress at the Information Sciences Institute, University of Southern California",
-		"URL": "https://ojs.aaai.org/index.php/aimagazine/article/view/88",
-		"volume": "1",
-		"author": [
-			{
-				"family": "Balzer",
-				"given": "Robert"
-			},
-			{
-				"family": "Erman",
-				"given": "Lee"
-			},
-			{
-				"family": "Feather",
-				"given": "Martin"
-			},
-			{
-				"family": "Goldman",
-				"given": "Neil"
-			},
-			{
-				"family": "London",
-				"given": "Philip"
-			},
-			{
-				"family": "Wile",
-				"given": "David"
-			},
-			{
-				"family": "Wilczynski",
-				"given": "David"
-			},
-			{
-				"family": "Lingard",
-				"given": "Robert"
-			},
-			{
-				"family": "Mark",
-				"given": "William"
-			},
-			{
-				"family": "Mann",
-				"given": "William"
-			},
-			{
-				"family": "Moore",
-				"given": "James"
-			},
-			{
-				"family": "Pirtle",
-				"given": "Mel"
-			},
-			{
-				"family": "Dyer",
-				"given": "David"
-			},
-			{
-				"family": "Rizzi",
-				"given": "William"
-			},
-			{
-				"family": "Cohen",
-				"given": "Danny"
-			},
-			{
-				"family": "Barnett",
-				"given": "Jeff"
-			},
-			{
-				"family": "Kameny",
-				"given": "Iris"
-			},
-			{
-				"family": "Yemini",
-				"given": "Yechiam"
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					4,
-					15
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"2017",
-					7,
-					1
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/DNPJGUM8",
-		"type": "article-journal",
-		"abstract": "Expert systems are computer programmes that can reproduce the behaviour of human experts in specific problem domains. In many places, development of expert systems is the major focus of fifth generation software projects. Accordingly, enormous amounts of resources are being spent on work in this field. Expert systems have enjoyed considerable success in many scientific and technological applications but their application in the field of management. is relatively recent.\n            In this article, Rekha Jain presents an overview of expert systems and addresses several issues that will be of interest to managers who are likely to consider using expert systems in their organizations.",
-		"container-title": "Vikalpa: The Journal for Decision Makers",
-		"DOI": "10.1177/0256090919890404",
-		"ISSN": "0256-0909, 2395-3799",
-		"issue": "4",
-		"journalAbbreviation": "Vikalpa",
-		"language": "en",
-		"page": "17-28",
-		"source": "DOI.org (Crossref)",
-		"title": "Expert Systems: A Management Perspective",
-		"title-short": "Expert Systems",
-		"URL": "http://journals.sagepub.com/doi/10.1177/0256090919890404",
-		"volume": "14",
-		"author": [
-			{
-				"family": "Jain",
-				"given": "Rekha"
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					4,
-					15
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"1989",
-					10,
-					1
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/SSDLLJ65",
-		"type": "paper-conference",
-		"abstract": "In this paper we describe how we have combined a number of tools (most of which understand a particular programming language) into a single system to aid in the reading, writing, and running of programs. We discuss the efficacy and the structure of our system. For the last two years the system has been used to build itself; it currently consists of 500 kilobytes of machine code (25,000 lines of LISP/370 code) and approximately one hundred commands with large numbers of options. We will describe some of the experience we have gained in evolving this system. We first indicate the system components which users have found most important; some of the tools described here are new in the literature. Second, we emphasize how these tools form a synergistic union, and we illustrate this point with a number of examples. Third, we illustrate the use of various system commands in the development of a simple program. Fourth, we discuss the implementation of the system components and indicate how some of them have been generalized.",
-		"container-title": "Proceedings of the 8th ACM SIGPLAN-SIGACT symposium on Principles of programming languages  - POPL '81",
-		"DOI": "10.1145/567532.567543",
-		"event": "the 8th ACM SIGPLAN-SIGACT symposium",
-		"event-place": "Williamsburg, Virginia",
-		"ISBN": "978-0-89791-029-X",
-		"language": "en",
-		"page": "92-104",
-		"publisher": "ACM Press",
-		"publisher-place": "Williamsburg, Virginia",
-		"source": "DOI.org (Crossref)",
-		"title": "A program development tool",
-		"URL": "http://portal.acm.org/citation.cfm?doid=567532.567543",
-		"author": [
-			{
-				"family": "Alberga",
-				"given": "C. N."
-			},
-			{
-				"family": "Brown",
-				"given": "A. L."
-			},
-			{
-				"family": "Leeman",
-				"given": "G. B."
-			},
-			{
-				"family": "Mikelsons",
-				"given": "M."
-			},
-			{
-				"family": "Wegman",
-				"given": "M. N."
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					4,
-					15
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"1981"
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/C6TTQVYB",
-		"type": "article-journal",
-		"abstract": "The Interslip-D project was formed to develop a personal machine inplementation of Interlisp for use as an environment for research in artificial intelligence and cognitive science [Burton et al., 80b]. This note describes the principal developments since our last report almost a year ago [Burton et al., 80a].",
-		"container-title": "ACM SIGART Bulletin",
-		"DOI": "10.1145/1056743.1056745",
-		"ISSN": "0163-5719",
-		"issue": "77",
-		"journalAbbreviation": "SIGART Bull.",
-		"page": "31–32",
-		"source": "July 1981",
-		"title": "Interlisp-D: further steps in the flight from time-sharing",
-		"title-short": "Interlisp-D",
-		"URL": "https://doi.org/10.1145/1056743.1056745",
-		"author": [
-			{
-				"family": "Sheil",
-				"given": "Beau"
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					4,
-					15
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"1981",
-					7,
-					1
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/LSJRVJU8",
-		"type": "article-journal",
-		"abstract": "INTERLISP (INTERactive LISP) is a LISP system currently implemented on the DEC PDP-10 under the BBN TENEX time sharing system<*R1>. INTERLISP is designed to provide the user access to the large virtual memory allowed by TENEX, with a relatively small penalty in speed (using special paging techniques described in <*R2>). Additional data types have been added, including strings, arrays, and hash association tables (hash links). The system includes a compatible compiler and interpreter. Machine code can be intermixed with INTERLISP expressions via the assemble directive of the compiler. The compiler also contains a facility for \"block compilation\" which allows a group of functions to be compiled as a unit, suppressing internal names. Each successive level of computation, from interpreted through compiled, to block-compiled provides greater speed at a cost of debugging ease.",
-		"container-title": "ACM SIGART Bulletin",
-		"DOI": "10.1145/1056786.1056787",
-		"ISSN": "0163-5719",
-		"issue": "43",
-		"journalAbbreviation": "SIGART Bull.",
-		"page": "8-9",
-		"source": "December 1973",
-		"title": "INTERLISP",
-		"URL": "https://doi.org/10.1145/1056786.1056787",
-		"author": [
-			{
-				"family": "Teitelman",
-				"given": "Warren"
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					4,
-					15
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"1973",
-					12,
-					1
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/DVGRZ62H",
-		"type": "paper-conference",
-		"abstract": "I was first introduced to Lisp in 1962 as a first year graduate student at M.I.T. in a class taught by James Slagle. Having programmed in Fortran and assembly, I was impressed with Lisp's elegance. In particular, Lisp enabled expressing recursion in a manner that was so simple that many first time observers would ask the question, \"Where does the program do the work?\" (Answer - between the parentheses!) Lisp also provided the ability to manipulate programs, since Lisp programs were themselves data (S-expressions) the same as other list structures used to represent program data. This made Lisp an ideal language for writing programs that themselves constructed programs or proved things about programs. Since I was at M.I.T. to study Artificial Intelligence, program writing programs was something that interested me greatly.",
-		"collection-title": "LISP50",
-		"container-title": "Celebrating the 50th Anniversary of Lisp",
-		"DOI": "10.1145/1529966.1529971",
-		"event-place": "New York, NY, USA",
-		"ISBN": "978-1-60558-383-9",
-		"page": "1–5",
-		"publisher": "Association for Computing Machinery",
-		"publisher-place": "New York, NY, USA",
-		"source": "ACM Digital Library",
-		"title": "History of Interlisp",
-		"URL": "https://doi.org/10.1145/1529966.1529971",
-		"author": [
-			{
-				"family": "Teitelman",
-				"given": "Warren"
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					4,
-					15
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"2008",
-					10,
-					20
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/QQ4WARPF",
-		"type": "article-journal",
-		"abstract": "Documentation for INTERSLIP in the form of the INTERSLIP Reference Manual is now available and may be obtained from Warren Teitelman, Xerox Palo Alto Research Center. The new manual replaces all existing documentation, and is completely up to date (as to January, 1974). The manual is available in either loose-leaf or bound form. The lose-leaf version (binders not supplied) comes with printed separator tabs between the chapters. The bound version also includes colored divider pages between chapters, and is printed on somewhat thinner paper than the loose-leaf version, in an effort to make it 'portable' (the manual being approximately 700 pages long). Both versions contain a complete master index (approximately 1600 entries), as well as a separate index for each chapter. Although the manual is intended primarily to be used for reference, many chapters, e.g., the programmer's assistant, do-what-I-mean, CLISP, etc., include introductory and tutorial material. The manual is available in machine-readable form, and an on-line question-answering system using the manual as a data base is currently being implemented.",
-		"container-title": "ACM SIGART Bulletin",
-		"DOI": "10.1145/1045183.1045186",
-		"ISSN": "0163-5719",
-		"issue": "44",
-		"journalAbbreviation": "SIGART Bull.",
-		"page": "5-22",
-		"source": "February 1974",
-		"title": "INTERLISP documentation",
-		"URL": "https://doi.org/10.1145/1045183.1045186",
-		"author": [
-			{
-				"family": "Teitelman",
-				"given": "Warren"
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					4,
-					15
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"1974",
-					2,
-					1
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/EFHC285D",
-		"type": "paper-conference",
-		"abstract": "During my tenure as Chairman of the Department of Medicine at the University of Pittsburgh, 1955 to 1970, two points became clear in regard to diagnosis in internal medicine. The first was that the knowledge base in that field had become vastly too large for any single person to encompass it. The second point was that the busy practitioner, even though he knew the items of information pertinent to his patients correct diagnosis, often did not consider the right answer particularly if the diagnosis was an unusual disease. I resigned the position of Chairman in 1970 intending to resume my position as Professor of Medicine. However, the University saw fit to offer me the appointment as University Professor (Medicine). The University of Pittsburgh follows the practice of Harvard University, established by President James Bryant Conant in the late 1930s, in which a University Professor is a professor at large and reports only to the president of the university. He has no department, no school and is not under administrative supervision by a dean or vice-president. Thus the position allows maximal academic freedom. In this new position I felt strongly that I should conduct worthwhile research. It was almost fifteen years since I had worked in my chosen field of clinical investigation, namely splanchnic blood flow and metabolism, and I felt that research in that area had passed me by. Remembering the two points mentioned earlier — the excessive knowledge base of internal medicine and the problem of considering the correct diagnosis — I asked myself what could be done to correct these problems. It seemed that the computer with its huge memory could correct the first and I wondered if it could not help as well with the second. At that point I knew no more about computers than the average layman so I sought advice. Dr. Gerhard Werner, our Chairman of Pharmacology, was working with computers in an attempt to map all of the neurological centers of the human brain stem with particular reference to their interconnections and functions. He was particularly concerned about the actions of pharmacological agents on this complex system. Working with him on this problem was Dr. Harry Pople, a computer scientist with special interest in “artificial intelligence”. The problem chosen was so complex and difficult that Werner and Pople were making little progress. Gerhard listened patiently to my ideas and promptly stated that he thought the projects were feasible utilizing the computer. In regard to the diagnostic component of my ambition he strongly advised that “artificial intelligence” be used. Pople was brought into the discussion and was greatly interested, I believe because of the feasibility of the project and the recognition of its practical application to the practice of medicine. The upshot was that Pople joined me in my project and Werner and Pople abandoned the work on the brain stem. Pople knew nothing about medicine and I knew nothing about computer science. Thus the first step in our collaboration was my analysis for Pople of the diagnostic process. I chose a goodly number of actual cases from clinical pathological conferences (CPCs) because they contained ample clinical data and because the correct diagnoses were known. At each small step of the way through the diagnostic process I was required to explain what the clinical information meant in context and my reasons for considering certain diagnoses. This provided to Pople insight into the diagnostic process. After analyzing dozens of such cases I felt as though I had undergone a sort of “psychoanalysis”. From this experience Pople wrote the first computer diagnostic programs seeking to emulate my diagnostic process. This has led certain “wags” to nickname our project “Jack in the box”. For this initial attempt Pople used the LISP computer language. We were granted access to the PROPHET PDP-10, a time-sharing mainframe maintained in Boston by the National Institutes of Health (NIH) but devoted particularly to pharmacological research. Thus we were interlopers. The first name we applied to our project was DIALOG, for diagnostic logic, but this had to be dropped because the name was in conflict with a computer program already on the market and copyrighted. The next name chosen was INTERNIST for obvious reason. However, the American Society for Internal Medicine publishes a journal entitled “The Internist” and they objected to our use of INTERNIST although there seems to be little relationship or conflict between a printed journal and a computer software program. Rather than fight the issue we simply added the Roman numeral one to our title which then became INTERNIST-I, which continues to this day. Pople's initial effort was unsuccessful, however. He diligently had incorporated details regarding anatomy and much basic pathophysiology, I believe because in my initial CPC analyses I had brought into consideration such items of information so that Pople could understand how I got from A to B etc. The diagnostician in internal medicine knows, of course, much anatomy and patho-physiology but these are brought into consideration in only a minority of diagnostic problems. He knows, for example, that the liver is in the right upper quadrant and just beneath the right leaf of the diaphragm. In most diagnostic instances this information is “subconscious”. Our first computer diagnostic program included too many such details and as a result was very slow and frequently got into analytical “loops” from which it could not extricate itself. We decided that we had to simplify the program but by that juncture much of 1971 had passed on. The new program was INTERNIST-I and even today most of the basic structure devised in 1972 remains intact. INTERNIST-I is written in INTERLISP and has operated on the PDP-10 and the DEC 2060. It has also been adapted to the VAX 780. Certain younger people have contributed significantly to the program, particularly Dr. Zachary Moraitis and Dr. Randolph Miller. The latter interrupted his regular medical school education to spend the year 1974-75 as a fellow in our laboratory and since finishing his formal medical education in 1979 has been active as a full time faculty member of the team. Several Ph.D. candidates in computer science have also made significant contributions as have dozens of medical students during electives on the project. INTERNIST-I is really quite a simple system as far as its operating system or inference engine is concerned. Three basic numbers are concerned in and manipulated in the ranking of elicited disease hypotheses. The first of these is the importance (IMPORT) of each of the more than 4,100 manifestations of disease which are contained in the knowledge base. IMPORTS are a global representation of the clinical importance of a given finding graded from 1 to 5, the latter being maximal, focusing on how necessary it is to explain the manifestation regardless of the final diagnosis. Thus massive splenomegaly has an IMPORT of 5 whereas anorexia has an IMPORT of 1. Mathematical weights are assigned to IMPORT numbers on a non-linear scale. The second basic number is the evoking strength (EVOKS), the numbers ranging from 0 to 5. The number answers the question, that given a particular manifestation of disease, how strongly does one consider disease A versus all other diagnostic possibilities in a clinical situation. A zero indicates that a particular clinical manifestation is non-specific, i.e. so widely spread among diseases that the above question cannot be answered usefully. Again, anorexia is a good example of a non-specific manifestation. The EVOKS number 5, on the other hand, indicates that a manifestation is essentially pathognomonic for a particular disease. The third basic number is the frequency (FREQ) which answers the question that given a particular disease what is the frequency or incidence of occurrence of a particular clinical finding. FREQ numbers range from 1 to 5, one indicating that the finding is rare or unusual in the disease and 5 indicating that the finding is present in essentially all instances of the disease. Each diagnosis which is evoked is ranked mathematically on the basis of support for it, both positive and negative. Like the import number, the values for EVOKS and FREQ numbers increase in a non-linear fashion. The establishment or conclusion of a diagnosis is not based on any absolute score, as in Bayesian systems, but on how much better is the support of diagnosis A as compared to its nearest competitor. This difference is anchored to the value of an EVOKS of 5, a pathognomonic finding. When the list of evoked diagnoses is ranked mathematically on the basis of EVOKS, FREQ and IMPORT, the list is partitioned based upon the similarity of support for individual diagnoses. Thus a heart disease is compared with other heart diseases and not brain diseases since the patient may have a heart disorder and a brain disease concommitantly. Thus apples are compared with apples and not oranges. When a diagnosis is concluded, the computer consults a list of interrelationships among diseases (LINKS) and bonuses are awarded, again in a non-linear fashion for numbers ranging from 1 to 5 — 1 indicating a weak interrelationship and 5 a universal interrelationship. Thus multiple interrelated diagnoses are preferred over independent ones provided the support for the second and other diagnoses is adequate. Good clinicians use this same rule of thumb. LINKS are of various types: PCED is used when disease A precedes disease B, e.g. acute rheumatic fever precedes early rheumatic valvular disease; PDIS - disease A predisposes to disease B, e.g. AIDS predisposes to pneumocystis pneumonia; CAUS - disease A causes disease B, e.g. thrombophlebitis of the lower extremities may cause pulmonary embolism; and COIN - there is a statistical interrelationship between disease A and disease B but scientific medical information is not explicit on the relationship, e.g. Hashimoto's thyroiditis coincides with pernicious anemia, both so called autoimmune diseases. The maximal number of correct diagnoses made in a single case analysis is, to my recollection, eleven. In working with INTERNIST-I during the remainder of the 1970s several important points about the system were learned or appreciated. The first and foremost of these is the importance of a complete and accurate knowledge base. Omissions from a disease profile can be particularly troublesome. If a manifestation of disease is not listed on a disease profile the computer can only conclude that that manifestation does not occur in the disease, and if a patient demonstrates the particular manifestation it counts against the diagnosis. Fortunately, repeated exercise of the diagnostic system brings to attention many inadvertent omissions. It is important to establish the EVOKS and FREQ numbers as accurately as possible. Continual updating of the knowledge base, including newly described diseases and new information about diseases previously profiled, is critical. Dr. Edward Feigenbaum recognized the importance of the accuracy and completeness of knowledge bases as the prime requisite of expert systems of any sort. He emphasized this point in his keynote address to MEDINFO-86 (1). Standardized, clear and explicit nomenclature is required in expressing disease names and particularly in naming the thousands of individual manifestations of disease. Such rigidity can make the use of INTERNIST-I difficult for the uninitiated user. Therefore, in QMR more latitude and guidance is provided the user. For example, the user of INTERNIST-I must enter ABDOMEN PAIN RIGHT UPPER QUADRANT exactly whereas in QMR the user may enter PAI ABD RUQ and the system recognizes the term as above. The importance of “properties” attached to the great majority of clinical manifestations was solidly evident. Properties express such conditions that if A is true then B is automatically false (or true as the case may be). The properties also allow credit to be awarded for or against B as the case may be. Properties also provide order to the asking of questions in the interrogative mode. They also state prerequisites and unrequisites for various procedures. As examples, one generally does not perform a superficial lymph node biopsy unless lymph nodes are enlarged (prerequisite). Similarly, a percutaneous liver biopsy is inadvisable if the blood platelets are less than 50,000 (unrequisite). It became clear quite early in the utilization of INTERNIST-I that systemic or multisystem diseases had an advantage versus localized disorders in diagnosis. This is because systemic diseases have very long and more inclusive manifestation lists. It became necessary, therefore, to subdivide systemic diseases into various components when appropriate. Systemic lupus erythematosus provides a good example. Lupus nephritis must be compared in our system with other renal diseases and such comparison is allowed by our partitioning algorithm. Likewise, cerebral lupus must be differentiated from other central nervous system disorders. Furthermore, either renal lupus or cerebral lupus can occur at times without significant clinical evidence of other systemic involvement. In order to reassemble the components of a systemic disease we devised the systemic LINK (SYST) which expresses the interrelationship of each subcomponent to the parent systemic disease. It became apparent quite early that expert systems like INTERNIST do not deal with the time axis of a disease well at all, and this seems to be generally true of expert systems in “artificial intelligence”. Certain parameters dealing with time can be expressed by devising particular manifestations, e.g. a blood transfusion preceding the development of acute hepatitis B by 2 to 6 months. But time remains a problem which is yet to be solved satisfactorily including QMR. It has been clearly apparent over the years that both the knowledge base and the diagnostic consultant programs of both INTERNIST-I and QMR have considerable educational value. The disease profiles, the list of diseases in which a given clinical manifestation occurs (ordered by EVOKS and FREQ), and the interconnections among diseases (LINKS) provide a quick and ready means of acquiring at least orienting clinical information. Such has proved useful not only to medical students and residents but to clinical practitioners as well. In the interrogative mode of the diagnostic systems the student will frequently ask “Why was that question asked?” An instructor can either provide insight or ready consultation of the knowledge base by the student will provide a simple semi-quantitative reason for the question. Lastly, let the author state that working with INTERNIST-I and QMR over the years seems to have had real influence on his own diagnostic approaches and habits. Thus my original psycho-analysis when working with Pople has been reinforced.",
-		"collection-title": "HMI '87",
-		"container-title": "Proceedings of ACM conference on History of medical informatics",
-		"DOI": "10.1145/41526.41543",
-		"event-place": "New York, NY, USA",
-		"ISBN": "978-0-89791-248-8",
-		"page": "195–197",
-		"publisher": "Association for Computing Machinery",
-		"publisher-place": "New York, NY, USA",
-		"source": "ACM Digital Library",
-		"title": "The background of INTERNIST I and QMR",
-		"URL": "https://doi.org/10.1145/41526.41543",
-		"author": [
-			{
-				"family": "Myers",
-				"given": "J. D."
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					4,
-					15
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"1987",
-					12,
-					1
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/Y6GV46BI",
-		"type": "article-journal",
-		"abstract": "A fundamental shift in the preferred approach to building applied artificial intelligence (AI) systems has taken place since the late 1960s. Previous work focused on the construction of general-purpose intelligent systems; the emphasis was on powerful inference methods that could function efficiently even when the available domain-specific knowledge was relatively meager. Today the emphasis is on the role of specific and detailed knowledge, rather than on reasoning methods. The first successful application of this method, which goes by the name of knowledge-based or expert-system research, was the DENDRAL program at Stanford, a long-term collaboration between chemists and computer scientists for automating the determination of molecular structure from empirical formulas and mass spectral data. The key idea is that knowledge is power, for experts, be they human or machine, are often those who know more facts and heuristics about a domain than lesser problem solvers. The task of building an expert system, therefore, is predominantly one of “teaching” a system enough of these facts and heuristics to enable it to perform competently in a particular problem-solving context. Such a collection of facts and heuristics is commonly called a knowledge base. Knowledge-based systems are still dependent on inference methods that perform reasoning on the knowledge base, but experience has shown that simple inference methods like generate and test, backward-chaining, and forward-chaining are very effective in a wide variety of problem domains when they are coupled with powerful knowledge bases. If this methodology remains preeminent, then the task of constructing knowledge bases becomes the rate-limiting factor in expert-system development. Indeed, a major portion of the applied AI research in the last decade has been directed at developing techniques and tools for knowledge representation. We are now in the third generation of such efforts. The first generation was marked by the development of enhanced AI languages like Interlisp and PROLOG. The second generation saw the development of knowledge representation tools at AI research institutions; Stanford, for instance, produced EMYCIN, The Unit System, and MRS. The third generation is now producing fully supported commercial tools like KEE and S.1. Each generation has seen a substantial decrease in the amount of time needed to build significant expert systems. Ten years ago prototype systems commonly took on the order of two years to show proof of concept; today such systems are routinely built in a few months. Three basic methodologies—frames, rules, and logic—have emerged to support the complex task of storing human knowledge in an expert system. Each of the articles in this Special Section describes and illustrates one of these methodologies. “The Role of Frame-Based Representation in Reasoning,” by Richard Fikes and Tom Kehler, describes an object-centered view of knowledge representation, whereby all knowldge is partitioned into discrete structures (frames) having individual properties (slots). Frames can be used to represent broad concepts, classes of objects, or individual instances or components of objects. They are joined together in an inheritance hierarchy that provides for the transmission of common properties among the frames without multiple specification of those properties. The authors use the KEE knowledge representation and manipulation tool to illustrate the characteristics of frame-based representation for a variety of domain examples. They also show how frame-based systems can be used to incorporate a range of inference methods common to both logic and rule-based systems. \"Rule-Based Systems,” by Frederick Hayes-Roth, chronicles the history and describes the implementation of production rules as a framework for knowledge representation. In essence, production rules use IF conditions THEN conclusions and IF conditions THEN actions structures to construct a knowledge base. The autor catalogs a wide range of applications for which this methodology has proved natural and (at least partially) successful for replicating intelligent behavior. The article also surveys some already-available computational tools for facilitating the construction of rule-based knowledge bases and discusses the inference methods (particularly backward- and forward-chaining) that are provided as part of these tools. The article concludes with a consideration of the future improvement and expansion of such tools. The third article, “Logic Programming, ” by Michael Genesereth and Matthew Ginsberg, provides a tutorial introduction to the formal method of programming by description in the predicate calculus. Unlike traditional programming, which emphasizes how computations are to be performed, logic programming focuses on the what of objects and their behavior. The article illustrates the ease with which incremental additions can be made to a logic-oriented knowledge base, as well as the automatic facilities for inference (through theorem proving) and explanation that result from such formal descriptions. A practical example of diagnosis of digital device malfunctions is used to show how significantand complex problems can be represented in the formalism. A note to the reader who may infer that the AI community is being split into competing camps by these three methodologies: Although each provides advantages in certain specific domains (logic where the domain can be readily axiomatized and where complete causal models are available, rules where most of the knowledge can be conveniently expressed as experiential heuristics, and frames where complex structural descriptions are necessary to adequately describe the domain), the current view is one of synthesis rather than exclusivity. Both logic and rule-based systems commonly incorporate frame-like structures to facilitate the representation of large amounts of factual information, and frame-based systems like KEE allow both production rules and predicate calculus statements to be stored within and activated from frames to do inference. The next generation of knowledge representation tools may even help users to select appropriate methodologies for each particular class of knowledge, and then automatically integrate the various methodologies so selected into a consistent framework for knowledge.",
-		"container-title": "Communications of the ACM",
-		"DOI": "10.1145/4284.214937",
-		"ISSN": "0001-0782",
-		"issue": "9",
-		"journalAbbreviation": "Commun. ACM",
-		"page": "902–903",
-		"source": "Sept. 1985",
-		"title": "Special section on architectures for knowledge-based systems",
-		"URL": "https://doi.org/10.1145/4284.214937",
-		"volume": "28",
-		"author": [
-			{
-				"family": "Friedland",
-				"given": "Peter"
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					4,
-					15
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"1985",
-					9,
-					1
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/FKDCVZJ5",
-		"type": "paper-conference",
-		"abstract": "This paper introduces a special programming environment for the definition of grammars and for the implementation of corresponding parsers. In natural language processing systems it is advantageous to have linguistic knowledge and processing mechanisms separated. Our environment accepts grammars consisting of binary dependency relations and grammatical functions. Well-formed expressions of functions and relations provide constituent surroundings for syntactic categories in the form of two-way automata. These relations, functions, and automata are described in a special definition language.In focusing on high level descriptions a linguist may ignore computational details of the parsing process. He writes the grammar into a DPL-description and a compiler translates it into efficient LISP-code. The environment has also a tracing facility for the parsing process, grammar-sensitive lexical maintenance programs, and routines for the interactive graphic display of parse trees and grammar definitions. Translator routines are also available for the transport of compiled code between various LISP-dialects. The environment itself exists currently in INTERLISP and FRANZLISP. This paper focuses on knowledge engineering issues and does not enter linguistic argumentation.",
-		"collection-title": "EACL '85",
-		"container-title": "Proceedings of the second conference on European chapter of the Association for Computational Linguistics",
-		"DOI": "10.3115/976931.976946",
-		"event-place": "USA",
-		"page": "98–106",
-		"publisher": "Association for Computational Linguistics",
-		"publisher-place": "USA",
-		"source": "ACM Digital Library",
-		"title": "Language-based environment for natural language parsing",
-		"URL": "https://doi.org/10.3115/976931.976946",
-		"author": [
-			{
-				"family": "Lehtola",
-				"given": "A."
-			},
-			{
-				"family": "Jäppinen",
-				"given": "H."
-			},
-			{
-				"family": "Nelimarkka",
-				"given": "E."
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					4,
-					15
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"1985",
-					3,
-					27
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/AB5LEKGM",
-		"type": "paper-conference",
-		"abstract": "A file access system, flash, for use in building database systems is described. It supports access from several languages, including pascal, fortran, and interlisp. Flash provides record level access to a file with multiple indexes using symbolic keys. It is portable and written in Pascal with support routines in dec System 20 macro. The file access system is designed to run on computers of various sizes and capabilities, including micros. Concurrent and simultaneous access by several users is supported given that the operating systems provides multiprogramming. Flash is designed to be highly reliable. It assumes the existence of underlying operating system file services that read or write named files directly. Transfer to files occurs in units which are efficient, typically a block.",
-		"collection-title": "SIGMOD '80",
-		"container-title": "Proceedings of the 1980 ACM SIGMOD international conference on Management of data",
-		"DOI": "10.1145/582250.582274",
-		"event-place": "New York, NY, USA",
-		"ISBN": "978-0-89791-018-4",
-		"page": "151–156",
-		"publisher": "Association for Computing Machinery",
-		"publisher-place": "New York, NY, USA",
-		"source": "ACM Digital Library",
-		"title": "FLASH: a language-independent, portable file access system",
-		"title-short": "FLASH",
-		"URL": "https://doi.org/10.1145/582250.582274",
-		"author": [
-			{
-				"family": "Allchin",
-				"given": "James E."
-			},
-			{
-				"family": "Keller",
-				"given": "Arthur M."
-			},
-			{
-				"family": "Wiederhold",
-				"given": "Gio"
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					4,
-					15
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"1980",
-					5,
-					14
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/PE98QZ2L",
-		"type": "paper-conference",
-		"abstract": "Raster-scan display terminals can significantly improve the quality of interaction with conventional computer systems. The design of a graphics package to provide a “window” into the extensive programming environment of interlisp is presented. Two aspects of the package are described: first, the functional view of display output and interactive input facilities as seen by the programmer, and second, the methods used to link the display terminal to the main computer via a packet-switched computer network. Recommendations are presented for designing operating systems and programming languages so as to simplify attaching display terminals.",
-		"collection-title": "SIGGRAPH '79",
-		"container-title": "Proceedings of the 6th annual conference on Computer graphics and interactive techniques",
-		"DOI": "10.1145/800249.807428",
-		"event-place": "New York, NY, USA",
-		"ISBN": "978-0-89791-004-4",
-		"page": "83–93",
-		"publisher": "Association for Computing Machinery",
-		"publisher-place": "New York, NY, USA",
-		"source": "ACM Digital Library",
-		"title": "Raster graphics for interactive programming environments",
-		"URL": "https://doi.org/10.1145/800249.807428",
-		"author": [
-			{
-				"family": "Sproull",
-				"given": "Robert F."
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					4,
-					15
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"1979",
-					8,
-					1
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/6VAJEC9G",
-		"type": "article-journal",
-		"abstract": "This paper describes the A-TABLE Data-Type for LISP-based languages. The A-TABLE is introduced in an attempt to unify different structures such as the PASCAL-Record, SNOBOL-Table AND INTERLISP Funarg-Block.A set of functions is defined to apply A-TABLES to: (1) Creating, accessing and updating Records; (2) Managing associatively indexed tables; (3) Providing context-dependent computations in processes and coroutines; (4) Defining multivalued functions.We show how and why these functions can be efficiently implemented with respect to access, space, garbage-collection and page-faults. We compare the A-TABLE with other facilities - LIST, ARRAY, etc.It is suggested that the A-TABLE should be one of the data-types in LISP-based systems where it can fill the gap between types \"LIST\" and \"ARRAY\".",
-		"container-title": "ACM SIGPLAN Notices",
-		"DOI": "10.1145/953997.953998",
-		"ISSN": "0362-1340",
-		"issue": "10",
-		"journalAbbreviation": "SIGPLAN Not.",
-		"page": "36–47",
-		"source": "October 1979",
-		"title": "The A-TABLE data-type for LISP systems",
-		"URL": "https://doi.org/10.1145/953997.953998",
-		"volume": "14",
-		"author": [
-			{
-				"family": "Cohen",
-				"given": "Shimon"
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					4,
-					15
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"1979",
-					10,
-					1
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/4U7ANPQM",
-		"type": "article-journal",
-		"abstract": "The fully parenthesized Cambridge Polish syntax of Lisp, originally regarded as a temporary expedient to be replaced by more conventional syntax, possesses a peculiar virtue: A read procedure can parse it without knowing the syntax of any expressions, statements, definitions, or declarations it may represent. The result of that parsing is a list structure that establishes a standard representation for uninterpreted abstract syntax trees. This representation provides a convenient basis for macro processing, which allows the programmer to specify that some simple piece of abstract syntax should be replaced by some other, more complex piece of abstract syntax. As is well-known, this yields an abstraction mechanism that does things that procedural abstraction cannot, such as introducing new binding structures. The existence of that standard representation for uninterpreted abstract syntax trees soon led Lisp to a greater reliance upon macros than was common in other high-level languages. The importance of those features is suggested by the ten pages devoted to macros in an earlier ACM HOPL paper, “The Evolution of Lisp.” However, na'ive macro expansion was a leaky abstraction, because the movement of a piece of syntax from one place to another might lead to the accidental rebinding of a program’s identifiers. Although this problem was recognized in the 1960s, it was 20 years before a reliable solution was discovered, and another 10 before a solution was discovered that was reliable, flexible, and efficient. In this paper, we summarize that early history with greater focus on hygienic macros, and continue the story by describing the further development, adoption, and influence of hygienic and partially hygienic macro technology in Scheme. The interplay between the desire for standardization and the development of new algorithms is a major theme of that story. We then survey the ways in which hygienic macro technology has been adapted into recent non-parenthetical languages. Finally, we provide a short history of attempts to provide a formal account of macro processing.",
-		"container-title": "Proceedings of the ACM on Programming Languages",
-		"DOI": "10.1145/3386330",
-		"ISSN": "2475-1421",
-		"issue": "HOPL",
-		"journalAbbreviation": "Proc. ACM Program. Lang.",
-		"page": "80:1–80:110",
-		"source": "June 2020",
-		"title": "Hygienic macro technology",
-		"URL": "https://doi.org/10.1145/3386330",
-		"volume": "4",
-		"author": [
-			{
-				"family": "Clinger",
-				"given": "William D."
-			},
-			{
-				"family": "Wand",
-				"given": "Mitchell"
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					4,
-					15
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"2020",
-					6,
-					12
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/X8ZWGFKQ",
-		"type": "paper-conference",
-		"abstract": "Diagnostic messages generated by compilers and interpreters such as syntax error messages have been researched for over half of a century. Unfortunately, these messages which include error, warning, and run-time messages, present substantial difficulty and could be more effective, particularly for novices. Recent years have seen an increased number of papers in the area including studies on the effectiveness of these messages, improving or enhancing them, and their usefulness as a part of programming process data that can be used to predict student performance, track student progress, and tailor learning plans. Despite this increased interest, the long history of literature is quite scattered and has not been brought together in any digestible form. In order to help the computing education community (and related communities) to further advance work on programming error messages, we present a comprehensive, historical and state-of-the-art report on research in the area. In addition, we synthesise and present the existing evidence for these messages including the difficulties they present and their effectiveness. We finally present a set of guidelines, curated from the literature, classified on the type of evidence supporting each one (historical, anecdotal, and empirical). This work can serve as a starting point for those who wish to conduct research on compiler error messages, runtime errors, and warnings. We also make the bibtex file of our 300+ reference corpus publicly available. Collectively this report and the bibliography will be useful to those who wish to design better messages or those that aim to measure their effectiveness, more effectively.",
-		"collection-title": "ITiCSE-WGR '19",
-		"container-title": "Proceedings of the Working Group Reports on Innovation and Technology in Computer Science Education",
-		"DOI": "10.1145/3344429.3372508",
-		"event-place": "New York, NY, USA",
-		"ISBN": "978-1-4503-7567-2",
-		"page": "177–210",
-		"publisher": "Association for Computing Machinery",
-		"publisher-place": "New York, NY, USA",
-		"source": "ACM Digital Library",
-		"title": "Compiler Error Messages Considered Unhelpful: The Landscape of Text-Based Programming Error Message Research",
-		"title-short": "Compiler Error Messages Considered Unhelpful",
-		"URL": "https://dl.acm.org/doi/10.1145/3344429.3372508",
-		"author": [
-			{
-				"family": "Becker",
-				"given": "Brett A."
-			},
-			{
-				"family": "Denny",
-				"given": "Paul"
-			},
-			{
-				"family": "Pettit",
-				"given": "Raymond"
-			},
-			{
-				"family": "Bouchard",
-				"given": "Durell"
-			},
-			{
-				"family": "Bouvier",
-				"given": "Dennis J."
-			},
-			{
-				"family": "Harrington",
-				"given": "Brian"
-			},
-			{
-				"family": "Kamil",
-				"given": "Amir"
-			},
-			{
-				"family": "Karkare",
-				"given": "Amey"
-			},
-			{
-				"family": "McDonald",
-				"given": "Chris"
-			},
-			{
-				"family": "Osera",
-				"given": "Peter-Michael"
-			},
-			{
-				"family": "Pearce",
-				"given": "Janice L."
-			},
-			{
-				"family": "Prather",
-				"given": "James"
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					4,
-					15
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"2019",
-					12,
-					18
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/ETMY665Q",
-		"type": "paper-conference",
-		"abstract": "Fifty years since the beginning of the Internet, and three decades of the Dexter Hypertext Reference Model and the World Wide Web mark an opportune time to take stock and consider how hypermedia has developed, and in which direction it might be headed. The modern Web has on one hand turned into a place where very few, very large companies control all major platforms with some highly unfortunately consequences. On the other hand, it has also led to the creation of a highly flexible and nigh ubiquitous set of technologies and practices, which can be used as the basis for future hypermedia research with the rise of computational notebooks as a prime example of a new kind of collaborative and highly malleable applications.",
-		"collection-title": "HT '19",
-		"container-title": "Proceedings of the 30th ACM Conference on Hypertext and Social Media",
-		"DOI": "10.1145/3342220.3343666",
-		"event-place": "New York, NY, USA",
-		"ISBN": "978-1-4503-6885-8",
-		"page": "19–28",
-		"publisher": "Association for Computing Machinery",
-		"publisher-place": "New York, NY, USA",
-		"source": "ACM Digital Library",
-		"title": "From NoteCards to Notebooks: There and Back Again",
-		"title-short": "From NoteCards to Notebooks",
-		"URL": "https://doi.org/10.1145/3342220.3343666",
-		"author": [
-			{
-				"family": "Bouvin",
-				"given": "Niels Olof"
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					4,
-					15
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"2019",
-					9,
-					12
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/4QGNIKFU",
-		"type": "article-journal",
-		"abstract": "This article is a perspective on some important developments in semantics and in computational linguistics over the past forty years. It reviews two lines of research that lie at opposite ends of the field: semantics and morphology. The semantic part deals with issues from the 1970s such as discourse referents, implicative verbs, presuppositions, and questions. The second part presents a brief history of the application of finite-state transducers to linguistic analysis starting with the advent of two-level morphology in the early 1980s and culminating in successful commercial applications in the 1990s. It offers some commentary on the relationship, or the lack thereof, between computational and paper-and-pencil linguistics. The final section returns to the semantic issues and their application to currently popular tasks such as textual inference and question answering.",
-		"container-title": "Computational Linguistics",
-		"DOI": "10.1162/coli.2007.33.4.443",
-		"ISSN": "0891-2017",
-		"issue": "4",
-		"journalAbbreviation": "Comput. Linguist.",
-		"page": "443–467",
-		"source": "December 2007",
-		"title": "Word play",
-		"URL": "https://doi.org/10.1162/coli.2007.33.4.443",
-		"volume": "33",
-		"author": [
-			{
-				"family": "Karttunen",
-				"given": "Lauri"
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					4,
-					15
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"2007",
-					12,
-					1
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/8S6HBCNU",
-		"type": "paper-conference",
-		"abstract": "Dependently typed programming languages, such as Idris and Agda, feature rich interactive environments that use informative types to assist users with the construction of programs. However, these environments have been provided by the authors of the language, and users have not had an easy way to extend and customize them. We address this problem by extending Idris's metaprogramming facilities with primitives for describing new type-directed editing features, making Idris's editors as extensible as its elaborator.",
-		"collection-title": "TyDe 2018",
-		"container-title": "Proceedings of the 3rd ACM SIGPLAN International Workshop on Type-Driven Development",
-		"DOI": "10.1145/3240719.3241791",
-		"event-place": "New York, NY, USA",
-		"ISBN": "978-1-4503-5825-5",
-		"page": "38–50",
-		"publisher": "Association for Computing Machinery",
-		"publisher-place": "New York, NY, USA",
-		"source": "ACM Digital Library",
-		"title": "Extensible type-directed editing",
-		"URL": "https://doi.org/10.1145/3240719.3241791",
-		"author": [
-			{
-				"family": "Korkut",
-				"given": "Joomy"
-			},
-			{
-				"family": "Christiansen",
-				"given": "David Thrane"
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					4,
-					15
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"2018",
-					9,
-					27
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/6MUG9UQA",
-		"type": "paper-conference",
-		"abstract": "We show and analyze herein how Webstrates can augment the Web from a classical hypermedia perspective. Webstrates turns the DOM of Web pages into persistent and collaborative objects. We demonstrate how this can be applied to realize bidirectional links, shared collaborative annotations, and in-browser authorship and development.",
-		"collection-title": "HT '16",
-		"container-title": "Proceedings of the 27th ACM Conference on Hypertext and Social Media",
-		"DOI": "10.1145/2914586.2914622",
-		"event-place": "New York, NY, USA",
-		"ISBN": "978-1-4503-4247-6",
-		"page": "207–212",
-		"publisher": "Association for Computing Machinery",
-		"publisher-place": "New York, NY, USA",
-		"source": "ACM Digital Library",
-		"title": "Classical Hypermedia Virtues on the Web with Webstrates",
-		"URL": "https://doi.org/10.1145/2914586.2914622",
-		"author": [
-			{
-				"family": "Bouvin",
-				"given": "Niels Olof"
-			},
-			{
-				"family": "Klokmose",
-				"given": "Clemens Nylandsted"
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					4,
-					15
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"2016",
-					7,
-					10
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/JGAVW7VT",
-		"type": "article-journal",
-		"container-title": "Communications of the ACM",
-		"DOI": "10.1145/2892716",
-		"ISSN": "0001-0782",
-		"issue": "4",
-		"journalAbbreviation": "Commun. ACM",
-		"page": "22–24",
-		"source": "April 2016",
-		"title": "Marvin Minsky: 1927-2016",
-		"title-short": "Marvin Minsky",
-		"URL": "https://doi.org/10.1145/2892716",
-		"volume": "59",
-		"author": [
-			{
-				"family": "Fisher",
-				"given": "Lawrence M."
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					4,
-					15
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"2016",
-					3,
-					23
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/WSFPH78W",
-		"type": "paper-conference",
-		"abstract": "We present Tangible Actions, an ad-hoc, just-in-time, visual programming by example language designed for large multitouch interfaces. With the design of Tangible Actions, we contribute a continually-created system of programming tokens that occupy the same space as the objects they act on. Tangible Actions are created by the gestural actions of the user, and they allow the user to reuse and modify their own gestures with a lower interaction cost than the original gesture. We implemented Tangible Actions in three different tabletop applications, and ran an informal evaluation. While we found that study participants generally liked and understood Tangible Actions, having the objects and the actions co-located can lead to visual and interaction clutter.",
-		"collection-title": "ITS '11",
-		"container-title": "Proceedings of the ACM International Conference on Interactive Tabletops and Surfaces",
-		"DOI": "10.1145/2076354.2076373",
-		"event-place": "New York, NY, USA",
-		"ISBN": "978-1-4503-0871-7",
-		"page": "87–96",
-		"publisher": "Association for Computing Machinery",
-		"publisher-place": "New York, NY, USA",
-		"source": "ACM Digital Library",
-		"title": "Tangible actions",
-		"URL": "https://doi.org/10.1145/2076354.2076373",
-		"author": [
-			{
-				"family": "Freeman",
-				"given": "Dustin"
-			},
-			{
-				"family": "Balakrishnan",
-				"given": "Ravin"
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					4,
-					15
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"2011",
-					11,
-					13
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/RW2BE4YD",
-		"type": "paper-conference",
-		"abstract": "When performing software change tasks, software developers spend a substantial amount of their time navigating dependencies in the code. Despite the availability of numerous tools to aid such navigation, there is evidence to suggest that developers are not using these tools. In this paper, we introduce an active help system, called Spyglass, that suggests tools to aid program navigation as a developer works. We report on the results of a laboratory study that investigated two questions: will developers act upon suggestions from an active help system and will those suggestions improve developer behaviour? We found that with Spyglass we could make developers as aware of navigational tools as they are when requested to read a tutorial about such tools, with less up-front effort. We also found that we could improve developer behaviour as developers in the Spyglass group, after being given recommendations in the context of their work, navigated programming artifacts more efficiently than those in the tutorial group.",
-		"collection-title": "CASCON '10",
-		"container-title": "Proceedings of the 2010 Conference of the Center for Advanced Studies on Collaborative Research",
-		"DOI": "10.1145/1923947.1923951",
-		"event-place": "USA",
-		"page": "27–41",
-		"publisher": "IBM Corp.",
-		"publisher-place": "USA",
-		"source": "ACM Digital Library",
-		"title": "Improving program navigation with an active help system",
-		"URL": "https://doi.org/10.1145/1923947.1923951",
-		"author": [
-			{
-				"family": "Viriyakattiyaporn",
-				"given": "Petcharat"
-			},
-			{
-				"family": "Murphy",
-				"given": "Gail C."
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					4,
-					15
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"2010",
-					11,
-					1
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/AT72WQAN",
-		"type": "paper-conference",
-		"abstract": "Programmers spend much of their time interacting with Integrated Development Environments (IDEs), which help increase productivity by automating much of the clerical and administrative work. Like any useful software, IDEs are becoming more powerful and usable as new functionality is added and usability concerns addressed. In particular, the last decade has witnessed the rapid and steady growth of features and enhancements (changes) in major Java IDEs. It is of research interest to learn about the characteristics of these changes as well as salient patterns in their evolution trajectories as these can be useful to understand and guide both the design and evolution of similar systems. To this end, a total of 645 \"What's New\" entries in seven releases of the Eclipse IDE were analyzed both quantitatively and qualitatively under two models. Using the first, an activity-based, functional model, it is found that the vast majority of the changes are refinements or incremental additions to the feature architecture set up in early releases (1.0 and 2.0). Using the second, a usability-based model, a detailed usability analysis was performed to further characterize these changes in terms of their potential impact on how effectively programmers use the IDE. Findings and implications as well as results of selective comparison with two other popular IDEs are reported.",
-		"collection-title": "CASCON '09",
-		"container-title": "Proceedings of the 2009 Conference of the Center for Advanced Studies on Collaborative Research",
-		"DOI": "10.1145/1723028.1723044",
-		"event-place": "USA",
-		"page": "122–135",
-		"publisher": "IBM Corp.",
-		"publisher-place": "USA",
-		"source": "ACM Digital Library",
-		"title": "An empirical analysis of the evolution of user-visible features in an integrated development environment",
-		"URL": "https://doi.org/10.1145/1723028.1723044",
-		"author": [
-			{
-				"literal": "Daqing Hou"
-			},
-			{
-				"family": "Wang",
-				"given": "Yuejiao"
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					4,
-					15
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"2009",
-					11,
-					2
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/2KURWNZM",
-		"type": "paper-conference",
-		"abstract": "This paper summarizes a talk given at \"[email protected],\" the 50th Anniversary of Lisp workshop, Monday, October 20, 2008, an event co-located with the OOPSLA'08 in Nashville, TN, in which I offered my personal, subjective account of how I came to be involved with Common Lisp and the Common Lisp standard, and of what I learned from the process. The account highlights the role of luck in the way various details of history played out, emphasizing the importance of seizing and making the best of the chance opportunities that life presents. The account further underscores the importance of understanding the role of controlling influences such as funding and intellectual property in shaping processes and outcomes. As noted by Louis Pasteur, \"chance favors the prepared mind.\" The talk was presented extemporaneously from notes. As such, it covered the same general material as does this paper, although the two may differ in details of structure and content. It is suggested that the talk be viewed as an invitation to read this written text, and that the written account be deemed my position of record on all matters covered in the talk.",
-		"collection-title": "LISP50",
-		"container-title": "Celebrating the 50th Anniversary of Lisp",
-		"DOI": "10.1145/1529966.1529972",
-		"event-place": "New York, NY, USA",
-		"ISBN": "978-1-60558-383-9",
-		"page": "1–12",
-		"publisher": "Association for Computing Machinery",
-		"publisher-place": "New York, NY, USA",
-		"source": "ACM Digital Library",
-		"title": "Common Lisp: the untold story",
-		"title-short": "Common Lisp",
-		"URL": "https://doi.org/10.1145/1529966.1529972",
-		"author": [
-			{
-				"family": "Pitman",
-				"given": "Kent M."
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					4,
-					15
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"2008",
-					10,
-					20
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/HZRJT7NY",
-		"type": "paper-conference",
-		"abstract": "I worked on Lisp design and implementation from the late 1960s almost until I retired about 5 years ago---and since then I've remained in the community by helping organize Lisp conferences. This means I've been in the thick of Lisp for most of its lifetime. In my talk there were a couple of points I wanted to make. First, computer hardware over the years has imposed constraints on the design of Lisp, ranging from gigantic machines in the early days---gigantic in size but miniscule in computing power---to tiny ones today (whose computing power was once considered \"super\".) Second, it was certain mindsets of the people involved in the design and implementation of Lisp that most strongly influenced its design---in particular, it was their educational background, driven by interests and talents, that had a great impact on the language.",
-		"collection-title": "LISP50",
-		"container-title": "Celebrating the 50th Anniversary of Lisp",
-		"DOI": "10.1145/1529966.1529968",
-		"event-place": "New York, NY, USA",
-		"ISBN": "978-1-60558-383-9",
-		"page": "1–2",
-		"publisher": "Association for Computing Machinery",
-		"publisher-place": "New York, NY, USA",
-		"source": "ACM Digital Library",
-		"title": "From massively monster machines to microchips: forces affecting Lisp language design for five decades",
-		"title-short": "From massively monster machines to microchips",
-		"URL": "https://doi.org/10.1145/1529966.1529968",
-		"author": [
-			{
-				"family": "White",
-				"given": "Jon L."
-			},
-			{
-				"family": "Bourbaki",
-				"given": "Nickieben"
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					4,
-					15
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"2008",
-					10,
-					20
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/99WYJADK",
-		"type": "paper-conference",
-		"abstract": "Most approaches to programming language extensibility have worked by pairing syntactic extension with semantic extension. We present an approach that works through a combination of presentation extension and semantic extension. We also present an architecture for this approach, an Eclipse-based implementation targeting the Java programming language, and examples that show how presentation extension, both with and without semantic extension, can make programs more expressive.",
-		"collection-title": "AOSD '07",
-		"container-title": "Proceedings of the 6th international conference on Aspect-oriented software development",
-		"DOI": "10.1145/1218563.1218573",
-		"event-place": "New York, NY, USA",
-		"ISBN": "978-1-59593-615-7",
-		"page": "73–84",
-		"publisher": "Association for Computing Machinery",
-		"publisher-place": "New York, NY, USA",
-		"source": "ACM Digital Library",
-		"title": "Expressive programs through presentation extension",
-		"URL": "https://doi.org/10.1145/1218563.1218573",
-		"author": [
-			{
-				"family": "Eisenberg",
-				"given": "Andrew D."
-			},
-			{
-				"family": "Kiczales",
-				"given": "Gregor"
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					4,
-					15
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"2007",
-					3,
-					14
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/7BR3DH2V",
-		"type": "chapter",
-		"container-title": "ACM Turing award lectures",
-		"event-place": "New York, NY, USA",
-		"ISBN": "978-1-4503-1049-9",
-		"page": "396",
-		"publisher": "Association for Computing Machinery",
-		"publisher-place": "New York, NY, USA",
-		"source": "ACM Digital Library",
-		"title": "The paradigms of programming",
-		"URL": "https://doi.org/10.1145/1283920.1283934",
-		"author": [
-			{
-				"family": "Floyd",
-				"given": "Robert W."
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					4,
-					15
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"2007",
-					1,
-					1
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/22RNHVTR",
-		"type": "paper-conference",
-		"abstract": "When working on a large software system, a programmer typically spends an inordinate amount of time sifting through thousands of artifacts to find just the subset of information needed to complete an assigned task. All too often, before completing the task the programmer must switch to working on a different task. These task switches waste time as the programmer must repeatedly find and identify the information relevant to the task-at-hand. In this paper, we present a mechanism that captures, models, and persists the elements and relations relevant to a task. We show how our task context model reduces information overload and focuses a programmer's work by filtering and ranking the information presented by the development environment. A task context is created by monitoring a programmer's activity and extracting the structural relationships of program artifacts. Operations on task contexts integrate with development environment features, such as structure display, search, and change management. We have validated our approach with a longitudinal field study of Mylar, our implementation of task context for the Eclipse development environment. We report a statistically significant improvement in the productivity of 16 industry programmers who voluntarily used Mylar for their daily work.",
-		"collection-title": "SIGSOFT '06/FSE-14",
-		"container-title": "Proceedings of the 14th ACM SIGSOFT international symposium on Foundations of software engineering",
-		"DOI": "10.1145/1181775.1181777",
-		"event-place": "New York, NY, USA",
-		"ISBN": "978-1-59593-468-5",
-		"page": "1–11",
-		"publisher": "Association for Computing Machinery",
-		"publisher-place": "New York, NY, USA",
-		"source": "ACM Digital Library",
-		"title": "Using task context to improve programmer productivity",
-		"URL": "https://doi.org/10.1145/1181775.1181777",
-		"author": [
-			{
-				"family": "Kersten",
-				"given": "Mik"
-			},
-			{
-				"family": "Murphy",
-				"given": "Gail C."
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					4,
-					15
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"2006",
-					11,
-					5
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/X72SMLGJ",
-		"type": "paper-conference",
-		"abstract": "Twenty years after the general adoption of overlapping windows and the desktop metaphor, modern window systems differ mainly in minor details such as window decorations or mouse and keyboard bindings. While a number of innovative window management techniques have been proposed, few of them have been evaluated and fewer have made their way into real systems. We believe that one reason for this is that most of the proposed techniques have been designed using a low fidelity approach and were never made properly available. In this paper, we present Metisse, a fully functional window system specifically created to facilitate the design, the implementation and the evaluation of innovative window management techniques. We describe the architecture of the system, some of its implementation details and present several examples that illustrate its potential.",
-		"collection-title": "UIST '05",
-		"container-title": "Proceedings of the 18th annual ACM symposium on User interface software and technology",
-		"DOI": "10.1145/1095034.1095038",
-		"event-place": "New York, NY, USA",
-		"ISBN": "978-1-59593-271-2",
-		"page": "13–22",
-		"publisher": "Association for Computing Machinery",
-		"publisher-place": "New York, NY, USA",
-		"source": "ACM Digital Library",
-		"title": "Metisse is not a 3D desktop!",
-		"URL": "https://doi.org/10.1145/1095034.1095038",
-		"author": [
-			{
-				"family": "Chapuis",
-				"given": "Olivier"
-			},
-			{
-				"family": "Roussel",
-				"given": "Nicolas"
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					4,
-					15
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"2005",
-					10,
-					23
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/388RT566",
-		"type": "chapter",
-		"abstract": "The two elements of a computer program are the computations (the actions we want done) and the data (the things we want the actions done upon). The computations are defined using expressions in a computer language, combined to form procedures, which are in turn combined to form compound procedures and eventually programs. The ability to combine simple expressions into procedures is the key to using computer programs to model processes in the real world. Data is defined in a similar way: compound data objects are built from simple parts, like numbers, and combined to represent real-world objects that have complex properties. Compound procedures and compound data are used for the same purposes: to improve the modularity of the program and to raise the conceptual level of its design. One of the simplest and most widespread form of compound data is the list.",
-		"container-title": "Encyclopedia of Computer Science",
-		"event-place": "GBR",
-		"ISBN": "0-470-86412-5",
-		"page": "992-1000",
-		"publisher": "John Wiley and Sons Ltd.",
-		"publisher-place": "GBR",
-		"source": "ACM Digital Library",
-		"title": "List processing",
-		"URL": "https://dl.acm.org/doi/10.5555/1074100.1074544",
-		"author": [
-			{
-				"family": "Fuqua",
-				"given": "Paul"
-			},
-			{
-				"family": "Slagle",
-				"given": "James R."
-			},
-			{
-				"family": "Gini",
-				"given": "Maria L."
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					4,
-					15
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"2003",
-					1,
-					1
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/U5SNW5LI",
-		"type": "chapter",
-		"abstract": "Fortran (q.v.) is the only language in widespread use that is older than Lisp (LISt Processor). Lisp owes its longevity to two facts. First, its core elements occupy a kind of local optimum in the \"space\" of programming languages, given the resistance to purely notational changes. Recursive use of conditional expressions, representation of symbolic information externally by lists and internally by list data structures (q.v.), and the representation of programs in the same way as data will probably have a very long life.",
-		"container-title": "Encyclopedia of Computer Science",
-		"ISBN": "0-470-86412-5",
-		"page": "991–992",
-		"publisher": "John Wiley and Sons Ltd.",
-		"source": "ACM Digital Library",
-		"title": "Lisp",
-		"URL": "https://dl.acm.org/doi/10.5555/1074100.1074543",
-		"author": [
-			{
-				"family": "Fateman",
-				"given": "Richard"
-			},
-			{
-				"family": "McCarthy",
-				"given": "John"
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					4,
-					15
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"2003",
-					1,
-					1
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/YC7VFI2W",
-		"type": "chapter",
-		"abstract": "Terminology concerning linkers and loaders is confusing, having changed over the years as technology has changed. In older mainframe operating systems, processing of a program between compiling and execution took place in two distinct stages. The function of the linker (or linkage editor) was to combine a number of independently compiled or assembled object files into a single load module, resolving cross-references and incorporating routines from libraries as required. The loader then prepared this module for execution, physically loaded it into memeory, and started execution. Early versions of Unix (q.v.) blurred this distinction: the functions of the linker were incorporated into the C (q.v.) compiler in what was confusingly called the \"load phase,\" and the actual loading was done as part of the \"exec,\" operation that installed a new process image for execution.",
-		"container-title": "Encyclopedia of Computer Science",
-		"ISBN": "0-470-86412-5",
-		"page": "988–991",
-		"publisher": "John Wiley and Sons Ltd.",
-		"source": "ACM Digital Library",
-		"title": "Linkers and loaders",
-		"URL": "https://dl.acm.org/doi/10.5555/1074100.1074541",
-		"author": [
-			{
-				"family": "Barron",
-				"given": "David W."
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					4,
-					15
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"2003",
-					1,
-					1
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/YGCFZL8P",
-		"type": "article-journal",
-		"container-title": "Communications of the ACM",
-		"DOI": "10.1145/502269.502274",
-		"ISSN": "0001-0782",
-		"issue": "1",
-		"journalAbbreviation": "Commun. ACM",
-		"page": "116–122",
-		"source": "January 2002",
-		"title": "Inserting ilities by controlling communications",
-		"URL": "https://doi.org/10.1145/502269.502274",
-		"volume": "45",
-		"author": [
-			{
-				"family": "Filman",
-				"given": "Robert E."
-			},
-			{
-				"family": "Barrett",
-				"given": "Stuart"
-			},
-			{
-				"family": "Lee",
-				"given": "Diana D."
-			},
-			{
-				"family": "Linden",
-				"given": "Ted"
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					4,
-					15
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"2002",
-					1,
-					1
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/HLPX2KR5",
-		"type": "article-journal",
-		"abstract": "This paper provides a retrospective view of the adoption of CASE tools in organizations using some empirical data from various research studies in this field. First, relevant factors that influence the decision to adopt such a tool are discussed. Such factors include elements related to the organization adopting such a technology, as well as other characteristics associated with the application environment and the alternative development methods being used. Then, the advantages and disadvantages of using CASE tools are discussed and some critical success factors are identified. Finally, a taxonomy of CASE tools in the 90's is presented. The paper provides some explanations of why some organizations are successful in adopting CASE tools and gives recommendations for making a better use of such a technology.",
-		"container-title": "ACM SIGSOFT Software Engineering Notes",
-		"DOI": "10.1145/346057.346071",
-		"ISSN": "0163-5948",
-		"issue": "2",
-		"journalAbbreviation": "SIGSOFT Softw. Eng. Notes",
-		"page": "46–50",
-		"source": "March 2000",
-		"title": "A retrospective view of CASE tools adoption",
-		"URL": "https://doi.org/10.1145/346057.346071",
-		"volume": "25",
-		"author": [
-			{
-				"family": "Albizuri-Romero",
-				"given": "Miren Begoña"
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					4,
-					15
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"2000",
-					3,
-					1
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/ZA7Y6G47",
-		"type": "article-journal",
-		"abstract": "The Desert software engineering environment is a suite of tools developed to enhance programmer productivity through increased tool integration. It introduces an inexpensive form of data integration to provide additional tool capabilities and information sharing among tools, uses a common editor to give high-quality semantic feedback and to integrate different types of software artifacts, and builds virtual files on demand to address specific tasks. All this is done in an open and extensible environment capable of handling large software systems.",
-		"container-title": "ACM Transactions on Software Engineering and Methodology",
-		"DOI": "10.1145/322993.322994",
-		"ISSN": "1049-331X",
-		"issue": "4",
-		"journalAbbreviation": "ACM Trans. Softw. Eng. Methodol.",
-		"note": "Annotation: This is an example of an annotation on an item.",
-		"page": "297–342",
-		"source": "Oct. 1999",
-		"title": "The Desert environment",
-		"URL": "https://doi.org/10.1145/322993.322994",
-		"volume": "8",
-		"author": [
-			{
-				"family": "Reiss",
-				"given": "Steven P."
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					4,
-					15
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"1999",
-					10,
-					1
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/Q5YEP7XY",
-		"type": "article-journal",
-		"container-title": "ACM SIGSOFT Software Engineering Notes",
-		"DOI": "10.1145/308769.308771",
-		"ISSN": "0163-5948",
-		"issue": "1",
-		"journalAbbreviation": "SIGSOFT Softw. Eng. Notes",
-		"page": "68",
-		"source": "Jan. 1999",
-		"title": "ACM Fellow profile",
-		"URL": "https://doi.org/10.1145/308769.308771",
-		"volume": "24",
-		"author": [
-			{
-				"family": "Deutsch",
-				"given": "L. Peter"
-			},
-			{
-				"family": "Finkbine",
-				"given": "Ronald B."
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					4,
-					15
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"1999",
-					1,
-					1
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/ZRI4MHTQ",
-		"type": "article-journal",
-		"container-title": "Interactions",
-		"DOI": "10.1145/287821.287827",
-		"ISSN": "1072-5520",
-		"issue": "6",
-		"journalAbbreviation": "interactions",
-		"page": "36–47",
-		"source": "Nov./Dec. 1998",
-		"title": "A conversation with Austin Henderson",
-		"URL": "https://doi.org/10.1145/287821.287827",
-		"volume": "5",
-		"author": [
-			{
-				"family": "Ehrlich",
-				"given": "Kate"
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					4,
-					15
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"1998",
-					11,
-					1
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/VHAN5FPQ",
-		"type": "paper-conference",
-		"abstract": "Software performance measurement can be a difficult and tedious procedure, and this difficulty may explain the lack of interest shown in software performance optimisation in all but the most demanding areas, such as parallel computation and embedded systems. This paper describes the measurement shim. an approach to software perfor-mance which we have found to significantly reduce the effort required to make performance measurements. The measurement shim exploits the interfaces between software modules, and allows measurement at both data stream and procedure call interfaces. Experimental results indicate that the measurement shim provides high-quality data, and can he inserted with low impact on system performance.",
-		"collection-title": "WOSP '98",
-		"container-title": "Proceedings of the 1st international workshop on Software and performance",
-		"DOI": "10.1145/287318.287364",
-		"event-place": "New York, NY, USA",
-		"ISBN": "978-1-58113-060-7",
-		"page": "208–218",
-		"publisher": "Association for Computing Machinery",
-		"publisher-place": "New York, NY, USA",
-		"source": "ACM Digital Library",
-		"title": "Exploiting software interfaces for performance measurement",
-		"URL": "https://doi.org/10.1145/287318.287364",
-		"author": [
-			{
-				"family": "Konkin",
-				"given": "Douglas P."
-			},
-			{
-				"family": "Oster",
-				"given": "Gregory M."
-			},
-			{
-				"family": "Bunt",
-				"given": "Richard B."
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					4,
-					15
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"1998",
-					10,
-					1
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/RJS3SEKE",
-		"type": "paper-conference",
-		"abstract": "Finite-state morphology has been successful in the description and computational implementation of a wide variety of natural languages. However, the particular challenges of Arabic, and the limitations of some implementations of finite-state morphology, have led many researchers to believe that finite-state power was not sufficient to handle Arabic and other Semitic morphology. This paper illustrates how the morphotactics and the variation rules of Arabic have been described using only finite-state operations and how this approach has been implemented in a significant morphological analyzer/generator.",
-		"collection-title": "Semitic '98",
-		"container-title": "Proceedings of the Workshop on Computational Approaches to Semitic Languages",
-		"event-place": "USA",
-		"page": "50–57",
-		"publisher": "Association for Computational Linguistics",
-		"publisher-place": "USA",
-		"source": "ACM Digital Library",
-		"title": "Arabic morphology using only finite-state operations",
-		"URL": "https://dl.acm.org/doi/10.5555/1621753.1621763",
-		"author": [
-			{
-				"family": "Beesley",
-				"given": "Kenneth R."
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					4,
-					15
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"1998",
-					8,
-					16
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/VJ7M6CL5",
-		"type": "paper-conference",
-		"abstract": "This paper describes the design goals, micro-architecture. and implementation of the microprogrammed processor for a compact high-performance personal computer. This computer supports a range of high-level language environments and high bandwidth I/O devices. Besides the processor. it has a cache, a memory map, main storage. and an instruction fetch unit; these are described in other papers. The processor can be shared among 16 microcode tasks, performing microcode context switches on-demand with essentially no overhead. Conditional branches are done without any lookahead or delay. Micro-instructions are fairly tightly encoded and use an interesting variant on control field sharing. The processor implements a large number of internal registers. hardware stacks. acyclic shifter/masker, and an arithmetic/logic unit, together with external data paths for instruction fetching, memory interface, and I/O. in a compact, pipe-lined organization. The machine has a 50 ns microcycle, and can execute a simple macroinstruction in one cycle; the available I/O bandwidth is 640 Mbits/sec. The entire machine. including disk, display and network interfaces, is implemented with approximately 3000 NISI components, mostly EC:. 10K; the processor is about 35% of this. In addition, there are up to 4 storage modules, each with about 300 16K or 64K RAMS and 200 nisi components, for a total of 8 Mbytes. Several prototypes are currently running.",
-		"collection-title": "ISCA '98",
-		"container-title": "25 years of the international symposia on Computer architecture (selected papers)",
-		"DOI": "10.1145/285930.285978",
-		"event-place": "New York, NY, USA",
-		"ISBN": "978-1-58113-058-9",
-		"page": "180–194",
-		"publisher": "Association for Computing Machinery",
-		"publisher-place": "New York, NY, USA",
-		"source": "ACM Digital Library",
-		"title": "A processor for a high-performance personal computer",
-		"URL": "https://doi.org/10.1145/285930.285978",
-		"author": [
-			{
-				"family": "Lampson",
-				"given": "Butler W."
-			},
-			{
-				"family": "Pier",
-				"given": "Kenneth A."
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					4,
-					15
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"1998",
-					8,
-					1
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/5EF3R8PE",
-		"type": "article-journal",
-		"container-title": "Communications of the ACM",
-		"DOI": "10.1145/248448.248457",
-		"ISSN": "0001-0782",
-		"issue": "4",
-		"journalAbbreviation": "Commun. ACM",
-		"page": "38–43",
-		"source": "April 1997",
-		"title": "Debugging and the experience of immediacy",
-		"URL": "https://doi.org/10.1145/248448.248457",
-		"volume": "40",
-		"author": [
-			{
-				"family": "Ungar",
-				"given": "David"
-			},
-			{
-				"family": "Lieberman",
-				"given": "Henry"
-			},
-			{
-				"family": "Fry",
-				"given": "Christopher"
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					4,
-					15
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"1997",
-					4,
-					1
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/75HQGEMD",
-		"type": "article-journal",
-		"abstract": "This paper reviews empirical studies on debugging models and the findings associated with these models. There is a discussion on the evolution of program slicing applied to program debugging and different generations of debugging tools are analyzed and criticized.Finally, a programming environment section provides examples of program maintenance tools.",
-		"container-title": "ACM SIGSOFT Software Engineering Notes",
-		"DOI": "10.1145/251880.251926",
-		"ISSN": "0163-5948",
-		"issue": "2",
-		"journalAbbreviation": "SIGSOFT Softw. Eng. Notes",
-		"page": "43–47",
-		"source": "March 1997",
-		"title": "An overview of debugging tools",
-		"URL": "https://doi.org/10.1145/251880.251926",
-		"volume": "22",
-		"author": [
-			{
-				"family": "Law",
-				"given": "Rob"
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					4,
-					15
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"1997",
-					3,
-					1
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/UZ8MDDUJ",
-		"type": "chapter",
-		"abstract": "This paper outlines the history of the C++ programming language. The emphasis is on the ideas, constraints, and people that shaped the language, rather than the minutiae of language features. Key design decisions relating to language features are discussed, but the focus is one the overall design goals and practical constraints. The evolution of C++ is traced from C with Classes to the current ANSI and ISO standards work and the explosion of use, interest, commercial activity, compilers, tools, environments, and libraries.",
-		"container-title": "History of programming languages---II",
-		"event-place": "New York, NY, USA",
-		"ISBN": "978-0-201-89502-5",
-		"page": "699–769",
-		"publisher": "Association for Computing Machinery",
-		"publisher-place": "New York, NY, USA",
-		"source": "ACM Digital Library",
-		"title": "A history of C++: 1979--1991",
-		"title-short": "A history of C++",
-		"URL": "https://doi.org/10.1145/234286.1057836",
-		"author": [
-			{
-				"family": "Stroustrup",
-				"given": "Bjarne"
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					4,
-					15
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"1996",
-					1,
-					1
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/AUHC4CYV",
-		"type": "paper-conference",
-		"abstract": "In Self 4.0, people write programs by directly constructing webs of objects in a larger world of objects. But in order to save or share these programs, the objects must be moved to other worlds. However, a concrete, directly constructed program is incomplete, in particular missing five items of information: which module to use, whether to transport an actual value or a counterfactuaI initial value, whether to create a new object in the new world or to refer to an existing one, whether an object is immutable with respect to transportation, and whether an object should be created by a low-level, concrete expression or an abstract, type-specific expression. In Self 4.0, the programmer records this extra information in annotations and attributes. Any system that saves directly constructed programs will have to supply this missing information somehow.",
-		"collection-title": "OOPSLA '95",
-		"container-title": "Proceedings of the tenth annual conference on Object-oriented programming systems, languages, and applications",
-		"DOI": "10.1145/217838.217845",
-		"event-place": "New York, NY, USA",
-		"ISBN": "978-0-89791-703-0",
-		"page": "73–87",
-		"publisher": "Association for Computing Machinery",
-		"publisher-place": "New York, NY, USA",
-		"source": "ACM Digital Library",
-		"title": "Annotating objects for transport to other worlds",
-		"URL": "https://doi.org/10.1145/217838.217845",
-		"volume": "30",
-		"author": [
-			{
-				"family": "Ungar",
-				"given": "David"
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					4,
-					15
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"1995",
-					10,
-					17
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/CGKSNXDD",
-		"type": "article-journal",
-		"abstract": "This article describes a series of tests of the generality of a “radically tailorable” tool for cooperative work. Users of this system can create applications by combining and modifying four kinds of building blocks: objects, views, agents, and links. We found that user-level tailoring of these primitives can provide most of the functionality found in well-known cooperative work systems such as gIBIS, Coordinator, Lotus Notes, and Information Lens. These primitives, therefore, appear to provide an elementary “tailoring language” out of which a wide variety of integrated information management and collaboration applications can be constructed by end users.",
-		"container-title": "ACM Transactions on Information Systems",
-		"DOI": "10.1145/201040.201047",
-		"ISSN": "1046-8188",
-		"issue": "2",
-		"journalAbbreviation": "ACM Trans. Inf. Syst.",
-		"page": "177–205",
-		"source": "April 1995",
-		"title": "Experiments with Oval: a radically tailorable tool for cooperative work",
-		"title-short": "Experiments with Oval",
-		"URL": "https://doi.org/10.1145/201040.201047",
-		"volume": "13",
-		"author": [
-			{
-				"family": "Malone",
-				"given": "Thomas W."
-			},
-			{
-				"family": "Lai",
-				"given": "Kum-Yew"
-			},
-			{
-				"family": "Fry",
-				"given": "Christopher"
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					4,
-					15
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"1995",
-					4,
-					1
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/C3YV53L7",
-		"type": "article-journal",
-		"abstract": "The ability to undo operations is a standard feature in most single-user interactive applications. We propose a general framework for implementing undo in collaborative systems. The framework allows users to reverse their own changes individually, taking into account the possibility of conflicts between different users' operations that may prevent an undo. The proposed framework has been incorporated into DistEdit, a toolkit for building group text editors. Based on our experience with DistEdit's undo facilities, we discuss several issues that need to be taken into account in using the framework, in order to ensure that a reasonable undo behavior is provided to users. We show that the framework is also applicable to single-user systems, since the operations to undo can be selected not just on the basis of who performed them, but by any appropriate criterion, such as the document region in which the operations occurred or the time interval in which the operations were carried out.",
-		"container-title": "ACM Transactions on Computer-Human Interaction",
-		"DOI": "10.1145/198425.198427",
-		"ISSN": "1073-0516",
-		"issue": "4",
-		"journalAbbreviation": "ACM Trans. Comput.-Hum. Interact.",
-		"page": "295–382",
-		"source": "Dec. 1994",
-		"title": "A framework for undoing actions in collaborative systems",
-		"URL": "https://doi.org/10.1145/198425.198427",
-		"volume": "1",
-		"author": [
-			{
-				"family": "Prakash",
-				"given": "Atul"
-			},
-			{
-				"family": "Knister",
-				"given": "Michael J."
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					4,
-					15
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"1994",
-					12
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/N9JHN4PM",
-		"type": "article-journal",
-		"abstract": "It is important to provide a recovery operation for applications with a graphical user interface. A restricted linear undo mechanism can conveniently be implemented using object-oriented techniques. Although linear undo provides an arbitrarily long history, it is not possible to undo isolated commands from the history without undoing all following commands. Various undo models have been proposed to overcome this limitation, but they all ignore the problem that in graphical user interfaces a previous user action might not have a sensible interpretation in another state. Selective undo introduced here can undo isolated commands by copying them into the current state “if that is meaningful.” Furthermore, the semantics of selective undo are argued to be more natural for the user, because the mechanism only looks at the command to undo and the current state and does not depend on the history in between. The user interface for selective undo can also be implemented generically. Such a generic implementation is able to provide a consistent recovery mechanism in arbitrary applications.",
-		"container-title": "ACM Transactions on Computer-Human Interaction",
-		"DOI": "10.1145/196699.196721",
-		"ISSN": "1073-0516",
-		"issue": "3",
-		"journalAbbreviation": "ACM Trans. Comput.-Hum. Interact.",
-		"page": "269–294",
-		"source": "Sept. 1994",
-		"title": "A selective undo mechanism for graphical user interfaces based on command objects",
-		"URL": "https://doi.org/10.1145/196699.196721",
-		"volume": "1",
-		"author": [
-			{
-				"family": "Berlage",
-				"given": "Thomas"
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					4,
-					15
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"1994",
-					9,
-					1
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/YG4BIRXS",
-		"type": "article-journal",
-		"container-title": "Interactions",
-		"DOI": "10.1145/174800.174807",
-		"ISSN": "1072-5520",
-		"issue": "1",
-		"journalAbbreviation": "interactions",
-		"page": "55–65",
-		"source": "Jan. 1994",
-		"title": "A discipline of software architecture",
-		"URL": "https://doi.org/10.1145/174800.174807",
-		"volume": "1",
-		"author": [
-			{
-				"family": "Denning",
-				"given": "Peter J."
-			},
-			{
-				"family": "Dargan",
-				"given": "Pamela A."
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					4,
-					15
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"1994",
-					1,
-					2
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/J6WNHTXX",
-		"type": "paper-conference",
-		"abstract": "An approach to flexible hyperbase (hypertext database) support predicated on the notion of ex-tensibility is presented. The extensible hypertext platform (Hyperform) implements basic hyperbase services that can be tailored to provide specialised hyperbase support. Hypeeform is based on an inter-nal computational engine that provides an object-oriented extension language which allows new data model objects and operations to be added at run-time. Hyperform has a number of built-in classes to pro-vide basic hyperbase features such as concurrency control, notification control (events), access control, version control and search and query. Each of these classes can be specialised using multiple inheritance to form virtually any type of hyperbase support needed in next-generation hypertext systems. This approach greatly reduces the effort required to provide high-quality customized hyperbase support for distributed hypertext applications. Hyper-form is implemented and operational in Unix environments. This paper describes the Hyperform approach, discusses its advantages and disadvantages, and gives examples of simulating the 11AM and the Danish Hyperlime in Hyperform. Hyper-form is compared with related work from the HAM generation of hyperbase systems and the current status of the project is reviewed.",
-		"collection-title": "ECHT '92",
-		"container-title": "Proceedings of the ACM conference on Hypertext",
-		"DOI": "10.1145/168466.171510",
-		"event-place": "New York, NY, USA",
-		"ISBN": "978-0-89791-547-X",
-		"page": "251–261",
-		"publisher": "Association for Computing Machinery",
-		"publisher-place": "New York, NY, USA",
-		"source": "ACM Digital Library",
-		"title": "Hyperform: using extensibility to develop dynamic, open, and distributed hypertext systems",
-		"title-short": "Hyperform",
-		"URL": "https://doi.org/10.1145/168466.171510",
-		"author": [
-			{
-				"family": "Wiil",
-				"given": "Uffe K."
-			},
-			{
-				"family": "Leggett",
-				"given": "John J."
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					4,
-					15
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"1993",
-					12,
-					1
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/DBX3AGEQ",
-		"type": "paper-conference",
-		"collection-title": "SIGDOC '93",
-		"container-title": "Proceedings of the 11th annual international conference on Systems documentation",
-		"DOI": "10.1145/166025.166055",
-		"event-place": "New York, NY, USA",
-		"ISBN": "978-0-89791-630-1",
-		"page": "149–162",
-		"publisher": "Association for Computing Machinery",
-		"publisher-place": "New York, NY, USA",
-		"source": "ACM Digital Library",
-		"title": "Information organization in multimedia resources",
-		"URL": "https://doi.org/10.1145/166025.166055",
-		"author": [
-			{
-				"family": "Kazman",
-				"given": "Rick"
-			},
-			{
-				"family": "Kominek",
-				"given": "John"
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					4,
-					15
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"1993",
-					11,
-					1
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/YHCT5BNA",
-		"type": "paper-conference",
-		"abstract": "A Software Development Environment (SDE) is a set of tools that, at the very least, supports coding and possibly other software development activities. Related to SDEs are meta-SDEs, which are classes of SDEs that must be configured or populated by tools before they can be useful. We will use the generic term environment to refer to both SDEs and meta-SDEs.This paper presents a multi-dimensional taxonomy of environments. The primary dimensions of our taxonomy are scale and genericity. Scale distinguishes environments that are suitable for small-scale programming from those that are suitable for large-scale software development. Genericity differentiates monolithic environments from highly configurable and extendible ones. Secondary taxonomy dimensions include tool integration, which identifies the degree of interoperability and data sharing between tools, and the historical dimension, which gives insight into past and present research trends in these environments.",
-		"collection-title": "CASCON '93",
-		"container-title": "Proceedings of the 1993 conference of the Centre for Advanced Studies on Collaborative research: software engineering - Volume 1",
-		"event-place": "Toronto, Ontario, Canada",
-		"language": "English",
-		"page": "581–594",
-		"publisher": "IBM Press",
-		"publisher-place": "Toronto, Ontario, Canada",
-		"source": "ACM Digital Library",
-		"title": "A multi-dimensional taxonomy of software development environments",
-		"URL": "https://dl.acm.org/doi/10.5555/962289.962338",
-		"volume": "1",
-		"author": [
-			{
-				"family": "Mancoridis",
-				"given": "Spiros"
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					4,
-					15
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"1993",
-					10,
-					24
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/9AC4DWJS",
-		"type": "paper-conference",
-		"abstract": "The abihly to undo operations is a standard feature in most single-user interactive applications. However, most current collaborative applications that allow several users to work simultaneously on a shared document lack undo capabilities; those which provide undo generally provide only a globe undo, in which the last change made by anyone to a document is undone, rather than allowing users to individually reverse their own changes. In this paper, we propose a general framework for undoing actions in collaborative systems. The framework takes into account the possibility of conflicts between different users' actions that may prevent a normal undo. The framework also allows selection of actions to undo based on who performed them, where they occurred, or any other appropriate criterion.",
-		"collection-title": "CSCW '92",
-		"container-title": "Proceedings of the 1992 ACM conference on Computer-supported cooperative work",
-		"DOI": "10.1145/143457.143527",
-		"event-place": "New York, NY, USA",
-		"ISBN": "978-0-89791-542-7",
-		"page": "273–280",
-		"publisher": "Association for Computing Machinery",
-		"publisher-place": "New York, NY, USA",
-		"source": "ACM Digital Library",
-		"title": "Undoing actions in collaborative work",
-		"URL": "https://doi.org/10.1145/143457.143527",
-		"author": [
-			{
-				"family": "Prakash",
-				"given": "Atul"
-			},
-			{
-				"family": "Knister",
-				"given": "Michael J."
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					4,
-					15
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"1992",
-					12,
-					1
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/ITGBNCQX",
-		"type": "paper-conference",
-		"abstract": "The process of developing and evolving complex software systems is intrinsically exploratory in nature. Some prototyping activity is therefore inevitable in every stage of that process. Our program development and evolution methodology is predicated upon this observation. In this methodology, a prototype software system is developed as an approximation to an envisioned target system by compromising along one or more of the following dimensions: system performance, system functionality, or user interface. However, the prototype is not the end-product of the process. Instead, we support iterative evolution of the prototype towards the envisioned system by gradually dealing with the three general areas of compromise. This paper describes the methodology of using this alternative lifecycle; to wit, the programming language concepts and related implementation technology that support practice of the suggested methodology. We summarize the lessons we have learned in building and using this technology over the last several years.",
-		"collection-title": "ICSE '92",
-		"container-title": "Proceedings of the 14th international conference on Software engineering",
-		"DOI": "10.1145/143062.143109",
-		"event-place": "New York, NY, USA",
-		"ISBN": "978-0-89791-504-5",
-		"page": "158–172",
-		"publisher": "Association for Computing Machinery",
-		"publisher-place": "New York, NY, USA",
-		"source": "ACM Digital Library",
-		"title": "Software evolution through iterative prototyping",
-		"URL": "https://doi.org/10.1145/143062.143109",
-		"author": [
-			{
-				"family": "Goldman",
-				"given": "Neil"
-			},
-			{
-				"family": "Narayanaswamy",
-				"given": "K."
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					4,
-					15
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"1992",
-					6,
-					1
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/9SEIVVBA",
-		"type": "paper-conference",
-		"abstract": "We describe enhancements to graphical search and replace that allow users to extend the capabilities of a graphical editor. Interactive constraint-based search and replace can search for objects that obey user-specified sets of constraints and automatically apply other constraints to modify these objects. We show how an interactive tool that employs this technique makes it possible for users to define sets of constraints graphically that modify existing illustrations or control the creation of new illustrations. The interace uses the same visual language as the editor and allows users to understand and create powerful rules without conventional programming. Rules can be saved and retrieved for use alone or in combination. Examples, generated with a working implementation, demonstrate applications to drawing beautification and transformation.",
-		"collection-title": "CHI '92",
-		"container-title": "Proceedings of the SIGCHI Conference on Human Factors in Computing Systems",
-		"DOI": "10.1145/142750.143053",
-		"event-place": "New York, NY, USA",
-		"ISBN": "978-0-89791-513-5",
-		"page": "609–618",
-		"publisher": "Association for Computing Machinery",
-		"publisher-place": "New York, NY, USA",
-		"source": "ACM Digital Library",
-		"title": "Interactive constraint-based search and replace",
-		"URL": "https://doi.org/10.1145/142750.143053",
-		"author": [
-			{
-				"family": "Kurlander",
-				"given": "David"
-			},
-			{
-				"family": "Feiner",
-				"given": "Steven"
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					4,
-					15
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"1992",
-					6,
-					1
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/XK2RYFWN",
-		"type": "book",
-		"abstract": "A Xerox Star 8010 Emulator. Contribute to livingcomputermuseum/Darkstar development by creating an account on GitHub.",
-		"genre": "C#",
-		"note": "original-date: 2019-01-15T20:40:02Z",
-		"source": "GitHub",
-		"title": "livingcomputermuseum/Darkstar",
-		"URL": "https://github.com/livingcomputermuseum/Darkstar",
-		"author": [
-			{
-				"family": "Museum+Labs",
-				"given": "Living Computers:"
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					4,
-					15
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"2020",
-					12,
-					25
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/G796KZSG",
-		"type": "article-journal",
-		"abstract": "In an ideal list-processing system there would be enough core memory to contain all the data and programs. Described in this paper are a number of techniques that have been used to build a LISP system utilizing a drum for its principal storage medium, with a surprisingly low time penalty for use of this slow storage device. The techniques include careful segmentation of system programs, allocation of virtual memory to allow address arithmetic for type determination, and a special algorithm for building reasonably linearized lists. A scheme for binding variables is described which is good in this environment and allows for complete compatibility between compiled and interpreted programs with no special declarations.",
-		"container-title": "Communications of the ACM",
-		"DOI": "10.1145/363162.363185",
-		"ISSN": "0001-0782, 1557-7317",
-		"issue": "3",
-		"journalAbbreviation": "Commun. ACM",
-		"language": "en",
-		"page": "155-159",
-		"source": "DOI.org (Crossref)",
-		"title": "Structure of a LISP system using two-level storage: Communications of the ACM",
-		"URL": "https://dl.acm.org/doi/10.1145/363162.363185",
-		"volume": "10",
-		"author": [
-			{
-				"family": "Bobrow",
-				"given": "Daniel G."
-			},
-			{
-				"family": "Murphy",
-				"given": "Daniel L."
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					4,
-					15
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"1967",
-					3
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/EM6WJF9A",
-		"type": "article-journal",
-		"abstract": "Many control and access environment structures require that storage for a procedure activation exist at times when control is not nested within the procedure activated. This is straightforward to implement by dynamic storage allocation with linked blocks for each activation, but rather expensive in both time and space. This paper presents an implementation technique using a single stack to hold procedure activation storage which allows retention of that storage for durations not necessarily tied to control flow. The technique has the property that, in the simple case, it runs identically to the usual automatic stack allocation and deallocation procedure. Applications of this technique to multitasking, coroutines, backtracking, label-valued variables, and functional arguments are discussed. In the initial model, a single real processor is assumed, and the implementation assumes multiple-processes coordinate by passing control explicitly to one another. A multiprocessor implementation requires only a few changes to the basic technique, as described.",
-		"container-title": "Communications of the ACM",
-		"DOI": "10.1145/362375.362379",
-		"ISSN": "0001-0782, 1557-7317",
-		"issue": "10",
-		"journalAbbreviation": "Commun. ACM",
-		"language": "en",
-		"page": "591-603",
-		"source": "DOI.org (Crossref)",
-		"title": "A model and stack implementation of multiple environments",
-		"URL": "https://dl.acm.org/doi/10.1145/362375.362379",
-		"volume": "16",
-		"author": [
-			{
-				"family": "Bobrow",
-				"given": "Daniel G."
-			},
-			{
-				"family": "Wegbreit",
-				"given": "Ben"
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					4,
-					15
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"1973",
-					10
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/QFBSW8AZ",
-		"type": "article-journal",
-		"abstract": "In current machine designs, a machine address gives the user direct access to a single piece of information, namely the contents of that machine word. This note is based on the observation that it is often useful to associate additional information, with some (relatively few) address locations determined at run time, without the necessity of preallocating the storage at all possible such addresses. That is, it can be useful to have an effective extra bit, field, or address in some words without every word having to contain a bit (or bits) to mark this as a special case. The key idea is that this extra associated information can be found by a table search. Although it could be found by any search technique (e.g. linear, binary sorted, etc.), we suggest that an appropriate low overhead mechanism is to use hash search on a table in which the key is the address of the cell to be augmented.",
-		"container-title": "Communications of the ACM",
-		"DOI": "10.1145/360881.360920",
-		"ISSN": "0001-0782, 1557-7317",
-		"issue": "7",
-		"journalAbbreviation": "Commun. ACM",
-		"language": "en",
-		"page": "413-415",
-		"source": "DOI.org (Crossref)",
-		"title": "A note on hash linking",
-		"URL": "https://dl.acm.org/doi/10.1145/360881.360920",
-		"volume": "18",
-		"author": [
-			{
-				"family": "Bobrow",
-				"given": "Daniel G."
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					4,
-					15
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"1975",
-					7
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/G4F5FZND",
-		"type": "paper-conference",
-		"abstract": "This paper presents some of the issues involved in implementing Interlisp [19] on a VAX computer [24] with the goal of producing a version that runs under UNIX[17], specifically Berkeley VM/UNIX. This implementation has the following goals:\n• To be compatible with and functionally equivalent to Interlisp-10.\n\n• To serve as a basis for future Interlisp implementations on other mainframe computers. This goal requires that the implementation to be portable.\n\n• To support a large virtual address space.\n\n• To achieve a reasonable speed.\n\nThe implemention draws directly from three sources, Interlisp-10 [19], Interlisp-D [5], and Multilisp [12]. Interlisp-10, the progenitor of all Interlisps, runs on the PDP-10 under the TENEX [2] and TOPS-20 operating systems. Interlisp-D, developed at Xerox Palo Alto Research Center, runs on personal computers also developed at PARC. Multilisp, developed at the University of British Columbia, is a portable interpreter containing a kernel of Interlisp, written in Pascal [9] and running on the IBM Series/370 and the VAX. The Interlisp-VAX implementation relies heavily on these implementations. In turn, Interlisp-D and Multilisp were developed from The Interlisp Virtual Machine Specification [15] by J Moore (subsequently referred to as the VM specification), which discusses what is needed to implement an Interlisp by describing an Interlisp Virtual Machine from the implementors' point of view. Approximately six man-years of effort have been spent exclusively in developing Interlisp-VAX, plus the benefit of many years of development for the previous Interlisp implementations.",
-		"container-title": "Proceedings of the 1982 ACM symposium on LISP and functional programming  - LFP '82",
-		"DOI": "10.1145/800068.802138",
-		"event": "the 1982 ACM symposium",
-		"event-place": "Pittsburgh, Pennsylvania, United States",
-		"ISBN": "978-0-89791-082-6",
-		"language": "en",
-		"page": "81-87",
-		"publisher": "ACM Press",
-		"publisher-place": "Pittsburgh, Pennsylvania, United States",
-		"source": "DOI.org (Crossref)",
-		"title": "Implementation of Interlisp on the VAX",
-		"URL": "http://portal.acm.org/citation.cfm?doid=800068.802138",
-		"author": [
-			{
-				"family": "Bates",
-				"given": "Raymond L."
-			},
-			{
-				"family": "Dyer",
-				"given": "David"
-			},
-			{
-				"family": "Koomen",
-				"given": "Johannes A. G. M."
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					4,
-					15
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"1982",
-					8
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/RAASKHRE",
-		"type": "article-journal",
-		"abstract": "This paper describes a new way of solving the storage reclamation problem for a system such as Lisp that allocates storage automatically from a heap, and does not require the programmer to give any indication that particular items are no longer useful or accessible. A reference count scheme for reclaiming non-self-referential structures, and a linearizing, compacting, copying scheme to reorganize all storage at the users discretion are proposed. The algorithms are designed to work well in systems which use multiple levels of storage, and large virtual address space. They depend on the fact that most cells are referenced exactly once, and that reference counts need only be accurate when storage is about to be reclaimed. A transaction file stores changes to reference counts, and a multiple reference table stores the count for items which are referenced more than once.",
-		"container-title": "Communications of the ACM",
-		"DOI": "10.1145/360336.360345",
-		"ISSN": "0001-0782, 1557-7317",
-		"issue": "9",
-		"journalAbbreviation": "Commun. ACM",
-		"language": "en",
-		"page": "522-526",
-		"source": "DOI.org (Crossref)",
-		"title": "An efficient, incremental, automatic garbage collector",
-		"URL": "https://dl.acm.org/doi/10.1145/360336.360345",
-		"volume": "19",
-		"author": [
-			{
-				"family": "Deutsch",
-				"given": "L. Peter"
-			},
-			{
-				"family": "Bobrow",
-				"given": "Daniel G."
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					4,
-					15
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"1976",
-					9
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/V3ECJHJ3",
-		"type": "report",
-		"abstract": "The INTERLISP Virtual Machine is the environment in which the INTERLISP System is implemented. It includes such abstract objects as \"Literal Atoms\", \"List Cells\", \"Integers\", etc., the basic LISP functions for manipulating them, the underlying program control and variable binding mechanisms, the input/output facilities, and interrupt processing facilities. In order to Implement the INTER LISP System (as described in The INTERLISP Reference Manual by W. Teitelman, et. al.) on some physical machine, it is only necessary to implement the INTERLISP Virtual Machine, since Virtual Machine compatible source code for the rest of the INTERLISP System can be obtained from publicly available files. This document specifies the behavior of the INTER LISP Virtual Machine from the implementor's point of view. That is, it is an attempt to make explicit those things which must be implemented to allow the INTERLISP System to run on some machine. KEY WORDS AND PHRASES programming language semantics, LISP, dynamic storage allocation, interpreters, spaghetti stacks, abstract data types, function objects, FUNARGs, applicative programming languages, control structures, interactive systems, DWIM, programmer's assistant, automatic error correction, eval, error handling, interrupt",
-		"publisher": "Xerox Palo Alto Research Center",
-		"source": "CiteSeer",
-		"title": "The Interlisp Virtual Machine Specification",
-		"URL": "http://www.bitsavers.org/pdf/xerox/parc/techReports/CSL-76-5_The_Interlisp_Virtual_Machine_Specification.pdf",
-		"author": [
-			{
-				"family": "Moore",
-				"given": "J. Strother"
-			}
-		],
-		"issued": {
-			"date-parts": [
-				[
-					"1976"
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/S82MS337",
-		"type": "report",
-		"abstract": "This report describes briefly a set of display primitives that we have developed at PARC toextend the capabilities of InterLisp[l]. These primitives are designed to operate araster-scanned displaYt and concentrate on facilities for placing text carefully on the displayand for moving chunks of an already-created display.",
-		"event-place": "Xerox Palo Alto Research Center3333 Coyote H iII RoadPalo Altot California 94304",
-		"language": "en-US",
-		"publisher-place": "Xerox Palo Alto Research Center3333 Coyote H iII RoadPalo Altot California 94304",
-		"source": "CiteSeer",
-		"title": "INTERLISP DISPLAY PRIMITIVES",
-		"URL": "http://scholar.googleusercontent.com/scholar?q=cache:fAjwtL8R9ogJ:scholar.google.com/+INTERLISP+DISPLAY+PRIl%5ClITIVES&hl=en&as_sdt=0,5",
-		"author": [
-			{
-				"family": "Sproull",
-				"given": "Robert F."
-			}
-		],
-		"issued": {
-			"date-parts": [
-				[
-					"1977",
-					7
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/S2ZC62QX",
-		"type": "webpage",
-		"abstract": "17 new photos added to shared album",
-		"container-title": "Google Photos",
-		"language": "en",
-		"title": "Interlisp-D at AAAI-82",
-		"URL": "https://photos.google.com/share/AF1QipORUrk2uwraYYJVOZ2R8mH51U4n5uv30V1KJk5zvu5Pd5XtEXuXp8jg1BfwdHBHkw?key=OGxZSU5LbXZPaTdmbnU3QmZiOTRlYnR6SDdMNUJ3",
-		"author": [
-			{
-				"family": "Masinter",
-				"given": "Larry"
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					4,
-					15
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"2017",
-					9,
-					30
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/IVA8R7A2",
-		"type": "report",
-		"abstract": "The LOOPS (Lisp Object-Oriented Language) project was started to support development of expert systems project at PARC. We wanted a language that had many of the\nfeatures of frame languages, such as objects, annotated values, inheritance, and attached procedures. We drew heavily on Smalltalk-80, which was being developed next door.",
-		"language": "en",
-		"publisher": "Xerox Parc",
-		"source": "Zotero",
-		"title": "Programming Languages -- The LOOPS Project (1982-1986)",
-		"URL": "https://larrymasinter.net/stefik-loops.pdf",
-		"author": [
-			{
-				"family": "Bobrow",
-				"given": "Daniel"
-			},
-			{
-				"family": "Mittal",
-				"given": "Sanjay"
-			},
-			{
-				"family": "Lanning",
-				"given": "Stanley"
-			},
-			{
-				"family": "Stefik",
-				"given": "Mark"
-			}
-		],
-		"issued": {
-			"date-parts": [
-				[
-					"2003"
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/HVTRFS6C",
-		"type": "article",
-		"title": "X3J13 Charter",
-		"title-short": "Purposes of X3J13 Committee",
-		"URL": "http://www.nhplace.com/kent/CL/x3j13-sd-05.html",
-		"author": [
-			{
-				"literal": "Kent Pitman"
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					4,
-					15
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"1999",
-					4,
-					18
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/CAYFCPIB",
-		"type": "book",
-		"ISBN": "978-0-932376-41-1",
-		"language": "eng",
-		"number-of-pages": "488",
-		"publisher": "Burlington, MA : Digital Press",
-		"source": "Internet Archive",
-		"title": "COMMON LISP : the language",
-		"title-short": "COMMON LISP",
-		"URL": "http://archive.org/details/commonlisplangua00stee",
-		"author": [
-			{
-				"family": "Steele",
-				"given": "Guy L."
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					4,
-					15
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"1984"
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/W8I3UZC8",
-		"type": "webpage",
-		"title": "Common Lisp Condition System",
-		"title-short": "Common-Lisp",
-		"URL": "http://www.nhplace.com/kent/CL/Revision-18.txt",
-		"author": [
-			{
-				"family": "Pitman",
-				"given": "Kent M."
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					4,
-					15
-				]
-			]
-		},
-		"issued": {
-			"literal": "12-Mar-88"
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/CI5AB787",
-		"type": "patent",
-		"abstract": "An information retrieval system and method are provided in which an operator inputs one or more query words which are used to determine a search key for searching through a corpus of documents, and which returns any matches between the search key and the corpus of documents as a phrase containing the word data matching the query word(s), a non-stop (content) word next adjacent to the matching word data, and all intervening stop-words between the matching word data and the next adjacent non-stop word. The operator, after reviewing one or more of the returned phrases can then use one or more of the next adjacent non-stop-words as new query words to reformulate the search key and perform a subsequent search through the document corpus. This process can be conducted iteratively, until the appropriate documents of interest are located. The additional non-stop-words from each phrase are preferably aligned with each other (e.g., by columnation) to ease viewing of the \"new\" content words.",
-		"call-number": "US07/745,794",
-		"number": "US5278980A",
-		"title": "Iterative technique for phrase query formation and an information retrieval...",
-		"URL": "https://patents.google.com/patent/US5278980A",
-		"author": [
-			{
-				"literal": "Jan O. Pedersen"
-			},
-			{
-				"literal": "Per-Kristian Halvorsen"
-			},
-			{
-				"literal": "Douglass R. Cutting"
-			},
-			{
-				"literal": "John W. Tukey"
-			},
-			{
-				"literal": "Eric A. Bier"
-			},
-			{
-				"literal": "Daniel G. Bobrow"
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					4,
-					16
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"1994",
-					1,
-					11
-				]
-			]
-		},
-		"submitted": {
-			"date-parts": [
-				[
-					"1991",
-					8,
-					16
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/ZJMGSD7H",
-		"type": "patent",
-		"abstract": "Apparatus in a computer system provides source code analysis. The apparatus includes an analysis member which extracts programming semantics information from an input source code. The analysis member operates according to the programming language of the source code as defined by a grammar mechanism. The analysis member employs a database interface which enables the extracted programming semantics information to be placed in a user desired database for subsequent recall by a desired query system. The database and query system may be pre-existing elements which are supported by a digital processor independently of the analysis member. A relational database with an SQL query system may be used.",
-		"call-number": "US07/269,135",
-		"number": "US4931928A",
-		"title": "Apparatus for analyzing source code",
-		"URL": "https://patents.google.com/patent/US4931928A",
-		"author": [
-			{
-				"family": "Greenfeld",
-				"given": "Norton R."
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					4,
-					16
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"1990",
-					6,
-					5
-				]
-			]
-		},
-		"submitted": {
-			"date-parts": [
-				[
-					"1988",
-					11,
-					9
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/2LJ5ITDD",
-		"type": "patent",
-		"abstract": "A software architecture is provided for allowing users to impart various types of button behavior to ordinary human interpretable elements of electronic documents by associating hidden persistent character string button attributes to such elements. This architecture permits such buttons to be edited and searched through the use of the edit and search routines that are ordinarily provided by standard document editors.",
-		"call-number": "US08/174,949",
-		"number": "US5862395A",
-		"title": "Customizable user interfaces for programmed computer systems",
-		"URL": "https://patents.google.com/patent/US5862395A",
-		"author": [
-			{
-				"family": "Bier",
-				"given": "Eric A."
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					4,
-					16
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"1999",
-					1,
-					19
-				]
-			]
-		},
-		"submitted": {
-			"date-parts": [
-				[
-					"1993",
-					12,
-					27
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/JBXLKYFM",
-		"type": "patent",
-		"abstract": "An expert system shell efficiently computes functions of variables in response to numeric or symbolic data values input by a user. The system comprises a Knowledge Base in the form of a network of functions, an Inference Engine for efficiently updating values in the knowledge base in response to changes in entered data, and a Forms System that manages interaction with the user. A knowledge engineer creates the network of functions, and defines the user screens and the connection between screen objects and variables in the function network. The system allows many different types of variables, including numeric and symbolic types. The system associates a probability distribution with every variable, and computes the probability distributions for the dependent variables from the probability distributions for the independent variables. A variable can store multiple values as tables of probability distributions keyed by one or more key variables. When a user action changes the probability distributions for any variable, the system automatically maintains the specified functional relationships among all the related variables.",
-		"call-number": "US07/084,252",
-		"language": "English",
-		"number": "US4866634A",
-		"title": "Data-driven, functional expert system shell",
-		"URL": "https://patents.google.com/patent/US4866634A",
-		"author": [
-			{
-				"family": "Reboh",
-				"given": "Rene"
-			},
-			{
-				"literal": "Tore J. M. Risch"
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					4,
-					16
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"1989",
-					9,
-					12
-				]
-			]
-		},
-		"submitted": {
-			"date-parts": [
-				[
-					"1987",
-					8,
-					10
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/WIVA4TM3",
-		"type": "patent",
-		"abstract": "A workstation that employs methods to construct computer programs through use of visual graphical representations. Computer programs are illustrated as visual road maps of the intended sequence of actions. Each operational entity in a program graph on the screen is represented as an elemental \"atomic\" unit, called a \"Softron\". The Softron is a multidimensional, graphical \"atom\" of programming information which has four modes of operation, termed \"layers\". The four layers are Normal, where the basic functionally of the application resides; Initialization/Reset, responsible both for the startup values of important variables and for their values at strategic checkpoints; Error, which handles conditions outside design limits; and Input/Output, which performs human input/output and other I/O tasks. Softrons reside in very general form in the workstation's library, and are optimized by the process of specialization. Softrons may be grouped to form new Softrons by a process called Logical Zoom (TM). Logically Zoomed Softrons may combine with other Softrons to form a computer program of arbitrary complexity.",
-		"call-number": "US07/011,500",
-		"number": "US4860204A",
-		"title": "Computer based workstation for development of graphic representation of &hellip;",
-		"URL": "https://patents.google.com/patent/US4860204A",
-		"author": [
-			{
-				"family": "Gendron",
-				"given": "Robert F."
-			},
-			{
-				"literal": "E. Webb Stacy"
-			},
-			{
-				"literal": "Jr.Tudor V. Ionescu"
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					4,
-					16
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"1989",
-					8,
-					22
-				]
-			]
-		},
-		"submitted": {
-			"date-parts": [
-				[
-					"1987",
-					2,
-					5
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/GTHVJ545",
-		"type": "patent",
-		"abstract": "A workspace data structure, such as a window hierarchy or network, includes functional data units that include data relating to workspace functionality. These functional data units are associated with data units corresponding to the workspaces such that a functional data unit can be replaced by a functional data unit compatible with a different set of functions without modifying the structure of other data units. Each workspace data unit may have a replaceably associated functional data unit called an input contract relating to its input functions and another called an output contract relating to its output functions. A parent workspace's data unit and the data units of its children may together have a replaceably associated functional data unit, called a windowing contract, relating to the windowing relationship between the parent and the children. The data structure may also include an auxiliary data unit associated between the data units of the parent and children windows, and the windowing contract may be associated with the auxiliary data unit. The contracts can be accessed and replaced by a processor in a system that includes the data structure. The contracts can be instances of classes in an object-oriented programming language, and can be replaceably associated by pointers associated with the system objects. Alternatively, a contract can be replaceably associated through dynamic multiple inheritance, with the superclasses of each workspace class including one or more contract classes such that changing the class of an instance of a workspace class serves to replace the contract.",
-		"call-number": "US07/614,957",
-		"number": "US5121478A",
-		"title": "Window system with independently replaceable window functionality",
-		"URL": "https://patents.google.com/patent/US5121478A",
-		"author": [
-			{
-				"family": "Rao",
-				"given": "Ramana B."
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					4,
-					16
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"1992",
-					6,
-					9
-				]
-			]
-		},
-		"submitted": {
-			"date-parts": [
-				[
-					"1990",
-					11,
-					15
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/PGGC8GAZ",
-		"type": "article",
-		"title": "Recent Improvements to 940 LISP Library",
-		"URL": "http://bitsavers.org/pdf/sds/9xx/940/ucbProjectGenie/940_LISP_Memo_2_Apr67.pdf",
-		"author": [
-			{
-				"family": "Teitelman",
-				"given": "Warren"
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					4,
-					21
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"1967",
-					4,
-					10
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/PMXCAM4Y",
-		"type": "article",
-		"language": "English",
-		"title": "1985 Harmony and Intermezzo releases Koto release (for Xerox 1186), some bits of Common Lisp",
-		"URL": "https://www.google.com/search?client=firefox-b-d&q=1985+Harmony+and+Intermezzo+releases+Koto+release+%28for+Xerox+1186%29%2C+some+bits+of+Common+Lisp",
-		"author": [
-			{
-				"literal": "XEROX"
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					4,
-					21
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"1985",
-					12
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/IKAJUF8S",
-		"type": "webpage",
-		"container-title": "VENUE",
-		"title": "Medley",
-		"URL": "https://web.archive.org/web/20100304002925/http://top2bottom.net:80/medley.html",
-		"author": [
-			{
-				"literal": "Jill Marci Sybalsky"
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					4,
-					21
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"2010",
-					3,
-					4
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/9B3ESHMP",
-		"type": "report",
-		"abstract": "This report consists of five papers on Interlisp-0, a refinement and implementation of the\nI[ tnterlisp virtual machine [Moore, 761 which supports the interlisp programming system\n[Teitelman et at., 781 on the Dolphin and Dorado personal computers",
-		"collection-title": "COGNITIVE AND INSTRUCTIONAL SCIENCES SERIES CIS.5 (SSL-80-4",
-		"page": "52",
-		"source": "Google Scholar",
-		"title": "Papers on interlisp-D",
-		"URL": "http://www.softwarepreservation.net/projects/LISP/interlisp-d/Papers_On_Interlisp-D.pdf",
-		"author": [
-			{
-				"family": "Burton",
-				"given": "Richard R."
-			},
-			{
-				"family": "Kaplan",
-				"given": "Ronald M."
-			},
-			{
-				"family": "Masinter",
-				"given": "B."
-			},
-			{
-				"family": "Sheil",
-				"given": "B. A."
-			},
-			{
-				"family": "Bell",
-				"given": "A."
-			},
-			{
-				"family": "Bobrow",
-				"given": "D. G."
-			},
-			{
-				"family": "Deutsch",
-				"given": "L. P."
-			},
-			{
-				"family": "Haugeland",
-				"given": "W. S."
-			}
-		],
-		"issued": {
-			"date-parts": [
-				[
-					"1980",
-					9
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/JELN3BBL",
-		"type": "entry-encyclopedia",
-		"abstract": "Interlisp (also seen with a variety of capitalizations) is a programming environment built around a version of the programming language Lisp. Interlisp development began in 1966 at Bolt, Beranek and Newman (renamed BBN Technologies) in Cambridge, Massachusetts with Lisp implemented for the Digital Equipment Corporation (DEC) PDP-1 computer by Danny Bobrow and D. L. Murphy. In 1970, Alice K. Hartley implemented BBN LISP, which ran on PDP-10 machines running the operating system TENEX (renamed TOPS-20). In 1973, when Danny Bobrow, Warren Teitelman and Ronald Kaplan moved from BBN to the Xerox Palo Alto Research Center (PARC), it was renamed Interlisp. Interlisp became a popular Lisp development tool for artificial intelligence (AI) researchers at Stanford University and elsewhere in the community of the Defense Advanced Research Projects Agency (DARPA). Interlisp was notable for integrating interactive development tools into an integrated development environment (IDE), such as a debugger, an automatic correction tool for simple errors (via do what I mean (DWIM) software design, and analysis tools.",
-		"container-title": "Wikipedia",
-		"language": "en",
-		"source": "Wikipedia",
-		"title": "Interlisp",
-		"URL": "https://en.wikipedia.org/w/index.php?title=Interlisp&oldid=1014034897",
-		"editor": [
-			{
-				"literal": "Jekkara"
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					4,
-					21
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"2021",
-					3,
-					24
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/IRKEPIAR",
-		"type": "post-weblog",
-		"abstract": "Via libingcomputers.org: Josh Dersch writes about research into the Xerox 8010 Information System (codenamed “Dandelion” during development) and commonly referred to as the Star. The Star was envisioned as center point of the office of the future, combining high-resolution graphics with the now-familiar mouse, Ethernet networking for sharing and collaborating, and Xerox’s Laser Printer technology for faithful “WYSIWYG” document reproduction. A revolutionary system when most everyone else was using text based systems.",
-		"container-title": "Adafruit Industries - Makers, hackers, artists, designers and engineers!",
-		"language": "en-US",
-		"title": "Introducing Darkstar: A Xerox Star Emulator",
-		"title-short": "Introducing Darkstar",
-		"URL": "https://blog.adafruit.com/2019/01/23/introducing-darkstar-a-xerox-star-emulator-vintagecomputing-xerox-emulation/",
-		"author": [
-			{
-				"family": "Barela",
-				"given": "Anne"
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					4,
-					21
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"2019",
-					1,
-					23
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/LYDGRGW4",
-		"type": "paper-conference",
-		"abstract": "This paper describes some of the activities of the \"cleanup\" sub-committee of the ANSI X3J13 group. It\ndescribes some fundamental assumptions of our work in this sub-committee, the process we use to consider changes, and a sampler of some of the changes we are considering.",
-		"container-title": "Proceedings of the First International Workshop on LISP Evolution and Standardization",
-		"event-place": "Amsterdam",
-		"page": "6",
-		"publisher": "IOS",
-		"publisher-place": "Amsterdam",
-		"title": "Common Lisp Cleanup. — Software Preservation Group",
-		"URL": "http://www.softwarepreservation.org/projects/LISP/conference/iwoleas88/Masinter-CommonLispCleanup.pdf",
-		"author": [
-			{
-				"family": "Masinter",
-				"given": "Larry"
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					4,
-					17
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"1988",
-					1,
-					10
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/IWAVJBR2",
-		"type": "thesis",
-		"abstract": "This disscrttion dcscribes a programming tool. implemented in Lisp. callcd SCOPE. The basic\nidea behind ScoPE can be stated simply: SCOPE analyzes a user's programs. rcmembers what it\nsees. is able to answer questions based on the facts it remembers. and is able to incrcmentay\nupdate thc data basc when a picce of thc program changes. A varicty of program infonnation\nis available about cross rcfcrences. data flow and program organi7.aticil. Facts about programs\nare stored in a data bas: to answer a question. SCOPE rctrieves and makes inferences basd on\ninfonnation in the data base. SCOPE is interactive because it keeps track of which par of the\nprograms have changed during the course of an editing and debugging sesion. and is able to\nautomatically and incrementally update its data bas. Because SCOPE perfonns whatever re\nanalysis is necesry to answer the question when the question is asked. SCOPE maintans the\nilusion that the data bas is always up to date-ther than the additional wait tie. it is as if\nSCOPE knew the answer al along.\nSCOPE'S foundation is a representauon system in which propertes of pieces of progras ca be\nexpred. The objects of SCOPE'S language are pieces of progrs, and in par.\ndefinitions of symbols-.g.. the definition of a proedure or a data strcture. SCOPE doe not\nmodel propertes of individua statements or expreions in the program: SCOPE knows only\nindividual facts about procedures varables data strctures and other pieces of a progr\nwhich ca be asigned as the definiuon of symbols. The facts are relauons between the name\nof a definiuon and other symbols. For example. one of the relauons that SCOPE keeps trk of\nis Call: Call(FNl'FNil holds if the definiùon whose nae is FNi contans a ca to a\nprocedure named FNi\"\nSCOPE has two interfaces: one to the user and one to other progras. The user interface is an\nEnglish-like command language which allows for a unifonn command strcture and convenient\ndefaults: the most frequently used commands are the easiest to type. All of the power avaiable\nwith the command language is accesible Jirough the progra interface as well. The\ncompiler and varouš other uulities use the progra interf~\"",
-		"event-place": "3333 Coyote Hil Road I Palo Alto I Caliornia 94304",
-		"genre": "Doctor of Philosophy",
-		"language": "en-US",
-		"number-of-pages": "114",
-		"publisher": "PALO ALTO RESEARCH CENTER",
-		"publisher-place": "3333 Coyote Hil Road I Palo Alto I Caliornia 94304",
-		"title": "Global Program Analysis in an Interactive Envi ronment by Larry Melvin Masinter SSL.80-1 JANUARY 1980",
-		"URL": "https://larrymasinter.net/thesis.pdf",
-		"author": [
-			{
-				"family": "Masinter",
-				"given": "Larry Melvin"
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					4,
-					17
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"1980"
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/LQAA78HI",
-		"type": "report",
-		"abstract": "This report describes the LISP system implemented at BBN on the \nSDS 940 Computer. This LISP is an upward compatible extension of \nLISP 1.5 for the IBM 7090, with a number of new features which \nmake it work well as an on-line language. These new features \ninclude tracing, and conditional breakpoints in functions for \ndebugging and a sophisticated LISP oriented editor. The BBN 940 \nLISP SYSTEM has a large memory store (approximately 50,000 free \nwords) utilizing special paging techniques for a drum to provide \nreasonable computation times. The system includes both an \ninterpreter, a fully compatible compiler, and an assembly language \nfacility for inserting machine code subroutines.",
-		"language": "English",
-		"number": "9",
-		"page": "138",
-		"title": "The BBN-LISP System",
-		"URL": "http://www.softwarepreservation.org/projects/LISP/bbnlisp/BBN940Lisp_Jul67.pdf/view",
-		"author": [
-			{
-				"literal": "Daniel G. Bobrow"
-			},
-			{
-				"literal": "D. Lucille Darley"
-			},
-			{
-				"literal": "L. Peter Deutsch"
-			},
-			{
-				"literal": "Daniel L. Murphy"
-			},
-			{
-				"literal": "Warren Teitelman"
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					4,
-					23
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"1967",
-					7,
-					15
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/F9XE85C9",
-		"type": "article",
-		"language": "en",
-		"publisher": "Xerox Corporation",
-		"title": "Artificial intelligence Systems Xerox LOOPS, A Friendly Primer",
-		"title-short": "Interlisp-D_A-Friendly-Primer",
-		"URL": "http://www.bitsavers.org/pdf/xerox/interlisp-d/198510_Koto/3102242_Xerox_LOOPS_A_Friendly_Primer_Mar87.pdf",
-		"author": [
-			{
-				"family": "Mears",
-				"given": "Lyn Ann"
-			},
-			{
-				"family": "Rees",
-				"given": "Ted"
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					4,
-					23
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"1987",
-					3
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/VLUQ9H8A",
-		"type": "article-journal",
-		"abstract": "A summary of G. GÖRZ \"Die Verwendung von LISP an wissenschaft-lichen Rechenzentren in der BRD\", IAB Nr 63, Universität Erlangen-nürnberg, Rechenzentrum, Dez. 76.",
-		"container-title": "ACM Lisp Bulletin",
-		"DOI": "10.1145/1411798.1411804",
-		"ISSN": "2372-8760",
-		"issue": "2",
-		"journalAbbreviation": "Lisp Bull.",
-		"language": "en",
-		"page": "10-13",
-		"source": "DOI.org (Crossref)",
-		"title": "The use of LISP at computer centers in Western Germany",
-		"URL": "https://dl.acm.org/doi/10.1145/1411798.1411804",
-		"author": [
-			{
-				"family": "Chailloux",
-				"given": "Jerome"
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					4,
-					23
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"1978",
-					7
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/NSDC3KIX",
-		"type": "article-journal",
-		"abstract": "For the SIGPLAN conference on history of programming languages held in Los Angeles in this June, J. McCarthy had to write a paper about LISP-history (1). He was very able to do this because he has given a talk on LISP history in summer 1974 at M.I.T. (2) and has contributed since then a lot of remarks and comments to my work on compiling a complete history of our language. His paper corresponds to the state of our knowledge in May of this year (1978) before D. Park found the original LISP 1 manual (3).",
-		"container-title": "ACM Lisp Bulletin",
-		"DOI": "10.1145/1411829.1411837",
-		"issue": "3",
-		"journalAbbreviation": "Lisp Bull.",
-		"language": "en",
-		"page": "42-53",
-		"source": "DOI.org (Crossref)",
-		"title": "LISP history",
-		"URL": "https://dl.acm.org/doi/10.1145/1411829.1411837",
-		"author": [
-			{
-				"family": "Stoyan",
-				"given": "Herbert"
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					4,
-					23
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"1979",
-					12
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/LT8JP57T",
-		"type": "paper-conference",
-		"abstract": "An implementation of the Portable Standard Lisp (PSL) on the BBN Butterfly is described. Butterfly PSL is identical, syntactically and semantically, to implementations of PSL currently available on the VAX, Gould, and many 68000-based machines, except for the differences discussed in this paper. The differences include the addition of the future and touch constructs for explicit parallelism and an extension of the fluid binding mechanism to support the multiple environments required by concurrent tasks. As with all other PSL implementations, full compilation to machine code of the basic system and application source code is the normal mode, in contrast to the previous byte-code interpreter efforts. Also discussed are other required changes to the PSL system not visible in the syntax or semantics, e.g., compiler support for the future construct. Finally, the underlying hardware is described, and timings for basic operations and speedup results for two examples are given.",
-		"container-title": "Proceedings of the 1988 ACM conference on LISP and functional programming  - LFP '88",
-		"DOI": "10.1145/62678.62694",
-		"event": "the 1988 ACM conference",
-		"event-place": "Snowbird, Utah, United States",
-		"ISBN": "978-0-89791-273-X",
-		"language": "en",
-		"page": "132-142",
-		"publisher": "ACM Press",
-		"publisher-place": "Snowbird, Utah, United States",
-		"source": "DOI.org (Crossref)",
-		"title": "An implementation of portable standard LISP on the BBN butterfly",
-		"URL": "http://portal.acm.org/citation.cfm?doid=62678.62694",
-		"author": [
-			{
-				"family": "Swanson",
-				"given": "Mark"
-			},
-			{
-				"family": "Kessler",
-				"given": "Robert"
-			},
-			{
-				"family": "Lindstrom",
-				"given": "Gary"
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					4,
-					23
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"1988"
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/8AB9NPK7",
-		"type": "book",
-		"edition": "First",
-		"event-place": "300 N. Halstead St. Pasadena CA 91107 USA",
-		"language": "English",
-		"number-of-pages": "57",
-		"publisher": "Xerox Corporation",
-		"publisher-place": "300 N. Halstead St. Pasadena CA 91107 USA",
-		"title": "Interlisp-VAX Users Manual",
-		"URL": "http://www.softwarepreservation.org/projects/LISP/interlisp/Interlisp-VAX-Users_Manual.pdf/view",
-		"author": [
-			{
-				"family": "Bates",
-				"given": "Raymond"
-			},
-			{
-				"family": "David",
-				"given": "Dayer"
-			},
-			{
-				"family": "Koomen",
-				"given": "Johannes"
-			},
-			{
-				"family": "Saunders",
-				"given": "Steven"
-			},
-			{
-				"family": "Voreck",
-				"given": "Donald"
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					4,
-					23
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"1982",
-					12,
-					5
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/6BCFJ639",
-		"type": "report",
-		"event-place": "Stailford University Stanford, CA 94305",
-		"number": "SUN-CS-81-879",
-		"page": "13",
-		"publisher": "Department of Computer Science, Stanford University",
-		"publisher-place": "Stailford University Stanford, CA 94305",
-		"title": "Interlisp-VAX: A Report",
-		"URL": "http://www.softwarepreservation.org/projects/LISP/interlisp/Interlisp-VAX_A_Report.pdf/view",
-		"author": [
-			{
-				"family": "Masintcr",
-				"given": "Larry M."
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					4,
-					23
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"1981",
-					8,
-					1
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/398X5WQZ",
-		"type": "webpage",
-		"container-title": "Software Preservation Group",
-		"title": "new-lisp-messages.txt.1.",
-		"URL": "http://www.softwarepreservation.org/projects/LISP/interlisp/tenex/sumex-aim/new-lisp-messages.txt.1/view",
-		"author": [
-			{
-				"family": "Teitelman",
-				"given": "Warren"
-			},
-			{
-				"family": "Kaplan",
-				"given": "Ron"
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					4,
-					23
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"1979"
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/P43BUE35",
-		"type": "webpage",
-		"container-title": "Software Preservation Group",
-		"title": "PARCMESSAGE.TXT.1.",
-		"URL": "http://www.softwarepreservation.org/projects/LISP/interlisp/tenex/twenex.org/PARCMESSAGE.TXT.1/view",
-		"author": [
-			{
-				"family": "Masinter",
-				"given": "Larry"
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					4,
-					23
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"1976",
-					1
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/PB5L9AVM",
-		"type": "article-journal",
-		"abstract": "LISP appears to be the language of choice among the developers of knowledge-based expert systems. Analysis of structures in INTERLISP environment is discussed in this paper. An interactive INTERLISP program is presented for analysis of frames which can be used as part of an expert system for computer-aided design of structures. Some of the concepts and characteristics of INTERLISP language are explained by referring to the INTERLISP program.",
-		"container-title": "Computers & structures",
-		"DOI": "https://doi.org/10.1016/0045-7949(86)90231-2",
-		"issue": "3",
-		"page": "393-407",
-		"source": "Google Scholar",
-		"title": "Computer-aided analysis of structures in INTERLISP environment",
-		"URL": "https://www.sciencedirect.com/science/article/abs/pii/0045794986902312",
-		"volume": "23",
-		"author": [
-			{
-				"family": "Adeli",
-				"given": "H."
-			},
-			{
-				"family": "Paek",
-				"given": "Y. J."
-			}
-		],
-		"issued": {
-			"date-parts": [
-				[
-					"1986"
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/9VQ4QK5H",
-		"type": "article-journal",
-		"container-title": "Communications of the ACM",
-		"DOI": "10.1145/114669.114679",
-		"ISSN": "0001-0782",
-		"issue": "9",
-		"journalAbbreviation": "Commun. ACM",
-		"page": "64-69",
-		"source": "Sept. 1991",
-		"title": "Real-time programming in Common Lisp",
-		"URL": "https://doi.org/10.1145/114669.114679",
-		"volume": "34",
-		"author": [
-			{
-				"family": "Allard",
-				"given": "James R."
-			},
-			{
-				"family": "Hawkinson",
-				"given": "Lowell B."
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					4,
-					25
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"1991",
-					9,
-					1
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/HFRDQ97U",
-		"type": "article-journal",
-		"abstract": "In theory, abstraction is important, but in practice, so is performance. Thus, there is a struggle between an abstract description of an algorithm and its efficient implementation. This struggle can be mediated by using an interpreter or a compiler. An interpreter takes a program that is a high level abstract description of an algorithm and applies it to some data. Don't think of an interpreter as slow. An interpreter is important enough to software that it is often implemented in hardware. A compiler takes the program and produces another program, perhaps in another language. The resulting program is applied to some data by another interpreter.",
-		"container-title": "ACM SIGPLAN Lisp Pointers",
-		"DOI": "10.1145/224133.224136",
-		"ISSN": "1045-3563",
-		"issue": "2",
-		"journalAbbreviation": "SIGPLAN Lisp Pointers",
-		"language": "en",
-		"page": "25-36",
-		"source": "DOI.org (Crossref)",
-		"title": "Freeing the essence of a computation",
-		"URL": "https://dl.acm.org/doi/10.1145/224133.224136",
-		"volume": "VIII",
-		"author": [
-			{
-				"family": "Anderson",
-				"given": "Kenneth R."
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					4,
-					25
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"1995",
-					5,
-					5
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/E5NDSA26",
-		"type": "report",
-		"number": "ISG 83-28",
-		"publisher": "University of Illinois Urbana-Champaign",
-		"source": "Google Scholar",
-		"title": "AQINTERLISP: An INTERLISP Program for Inductive Generalization of VL1 Event Sets",
-		"title-short": "AQINTERLISP",
-		"URL": "https://www.mli.gmu.edu/papers/81-85/83-28.pdf",
-		"author": [
-			{
-				"family": "Becker",
-				"given": "Jeffrey M."
-			}
-		],
-		"issued": {
-			"date-parts": [
-				[
-					"1983",
-					9
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/M6869X84",
-		"type": "book",
-		"ISBN": "0-262-59004-2",
-		"publisher": "The M.I.T. Press",
-		"source": "Google Scholar",
-		"title": "The programming language LISP: Its operation and applications",
-		"title-short": "The programming language LISP",
-		"URL": "http://www.softwarepreservation.org/projects/LISP/book/III_LispBook_Apr66.pdf",
-		"author": [
-			{
-				"family": "Berkeley",
-				"given": "Edmund Callis"
-			},
-			{
-				"family": "Bobrow",
-				"given": "Daniel Gureasko"
-			}
-		],
-		"issued": {
-			"date-parts": [
-				[
-					"1966"
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/I2U8XT9Z",
-		"type": "article-journal",
-		"abstract": "This first (long delayed) LISP Bulletin contains samples of most of those types of items which the editor feels are relevant to this publication. These include announcements of new (i.e. not previously announced here) implementations of LISP (or closely related) systems; quick tricks in LISP; abstracts of LISP related papers; short writeups and listings of useful programs; and longer articles on problems of general interest to the entire LISP community. Printing of these last articles in the Bulletin does not interfere with later publications in formal journals or books. Short write-ups of new features added to LISP are of interest, preferably upward compatible with LISP 1.5, especially if they are illustrated by programming examples.",
-		"container-title": "ACM SIGPLAN Notices",
-		"DOI": "10.1145/1132291.1132032",
-		"ISSN": "0362-1340",
-		"issue": "9",
-		"journalAbbreviation": "SIGPLAN Not.",
-		"page": "17-57",
-		"source": "September 1969",
-		"title": "LISP bulletin",
-		"URL": "https://doi.org/10.1145/1132291.1132032",
-		"volume": "4",
-		"author": [
-			{
-				"family": "Bobrow",
-				"given": "D. G."
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					4,
-					25
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"1969",
-					9,
-					1
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/B2PF228B",
-		"type": "report",
-		"abstract": "This report describes measurements performed for the purpose of determining areas of potential improvement to the efficiency of INTERLISP running under TENEX.",
-		"language": "English",
-		"number": "DTIC_ADA1045834",
-		"page": "61",
-		"publisher": "BOLT BERANEK AND NEWMAN INC CAMBRIDGE MA",
-		"source": "Google Scholar",
-		"title": "Interlisp performance measurements",
-		"URL": "https://archive.org/details/DTIC_ADA1045834",
-		"author": [
-			{
-				"family": "Bobrow",
-				"given": "Robert"
-			},
-			{
-				"family": "Grignetti",
-				"given": "Mario"
-			}
-		],
-		"issued": {
-			"date-parts": [
-				[
-					"1976",
-					6,
-					1
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/L6DXES8K",
-		"type": "article-journal",
-		"abstract": "In the fall of 1978 we decided to produce a special issue of the SIGART Newsletter devoted to a survey of current knowledge representation research. We felt that there were twe useful functions such an issue could serve. First, we hoped to elicit a clear picture of how people working in this subdiscipline understand knowledge representation research, to illuminate the issues on which current research is focused, and to catalogue what approaches and techniques are currently being developed. Second -- and this is why we envisaged the issue as a survey of many different groups and projects -- we wanted to provide a document that would enable the reader to acquire at least an approximate sense of how each of the many different research endesvours around the world fit into the field as a whole.It would of course be impossible to produce a final or definitive document accomplishing these goals: rather, we hoped that this survey could initiate a continuing dialogue on issues in representation, a project for which this newsletter seems the ideal forum. It has been many months since our original decision was made, but we are finally able to present the results of that survey. Perhaps more than anything else, it has emerged as a testament to an astounding range and variety of opinions held by many different people in many different places.The following few pages are intended as an introduction to the survey as a whole, and to this issue of the newsletter. We will briefly summarize the form that the survey took, discuss the strategies we followed in analyzing and tabulating responses, briefly review the overall sense we received from the answers that were submitted, and discuss various criticisms which were submitted along with the responses. The remainder of the volume has been designed to be roughly self-explanatory at each point, so that one may dip into it at different places at will. Certain conventions, however, particularly regarding indexing and tabulating, will also be explained in the remainder of this introduction.As editors, we are enormously grateful to the many people who devoted substantial effort to responding to our survey. It is our hope that the material presented here will be interesting and helpful to our readers, and that fruitful discussion of these and other issues will continue energetically and enthusiastically into the future.",
-		"container-title": "ACM SIGART Bulletin",
-		"DOI": "10.1145/1056751.1056752",
-		"ISSN": "0163-5719",
-		"issue": "70",
-		"journalAbbreviation": "SIGART Bull.",
-		"page": "1-138",
-		"source": "February 1980",
-		"title": "Special issue on knowledge representation",
-		"URL": "https://doi.org/10.1145/1056751.1056752",
-		"author": [
-			{
-				"family": "Brachman",
-				"given": "Ronald J."
-			},
-			{
-				"family": "Smith",
-				"given": "Brian C."
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					4,
-					25
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"1980",
-					2,
-					1
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/H8CQWPGG",
-		"type": "article-journal",
-		"abstract": "VCMC1 is a virtual machine designed to observe \"in vitro\" the behaviour of VLISP interpreters. VCMC1 is actually entirely simulated in VLISP 10. We present a short description of the VCMC1 machine followed by the complete listing of the code of a VLISP interpreter, This interpreter incorporates the special feature for tail-recursion function calls.",
-		"container-title": "ACM Lisp Bulletin",
-		"DOI": "10.1145/1411798.1411807",
-		"issue": "2",
-		"journalAbbreviation": "Lisp Bull.",
-		"page": "19-26",
-		"source": "July 1978",
-		"title": "Technical notes: a VLISP interpreter on the VCMC1 machine",
-		"title-short": "Technical notes",
-		"URL": "https://doi.org/10.1145/1411798.1411807",
-		"author": [
-			{
-				"family": "Chailloux",
-				"given": "Jerome"
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					4,
-					25
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"1978",
-					7,
-					1
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/C86QBBMZ",
-		"type": "article-journal",
-		"abstract": "This study presents the realization of three systems VLISP (a dialect of LISP) developped at the University of Paris 8 - Vincennes, on the following machines: - a 8 bit words micro-processor (Intel8080/Zilog80) - a 16 bit words PDP-11 - a 36 bit words PDP-10 From these realizations is extracted an implementation model. Our study proposes a solution to the problems of construction and evaluation of such a system. These problems are : 1) The exhaustive description of the implementation. We propose a description based on the virtual, referential and prototype machine VCMC2. 2) The adequate representations of the VLISP objects and functions. We have associated some natural properties and we have established a functionnal typology. 3) The efficiency of the interpreter (in words of core, execution time and power). Our iterpreter does, for his own need, a optimal core allocation (in term of CONS module calls). The direct acces (which needs only one memory access) to the values of objects variable and function, and a type classification of functions allow a direct invocation of all typed functions. 4) The power of control structures. Our implementation's KIT generalizes the VLISP control structures SELF an ESCAPE, extends them with the new constructions EXIT, WHERE and LETF and unifies completly their description and implementation. An incarnation of our model is given by the realization of a complete VLISP system in the referential machine VCMC2. The full code is given in appendix.",
-		"container-title": "ACM Lisp Bulletin",
-		"DOI": "10.1145/1411829.1411832",
-		"issue": "3",
-		"journalAbbreviation": "Lisp Bull.",
-		"page": "5",
-		"source": "December 1979",
-		"title": "The VLISP KIT: description implementation and evaluation",
-		"title-short": "The VLISP KIT",
-		"URL": "https://doi.org/10.1145/1411829.1411832",
-		"author": [
-			{
-				"family": "Chailloux",
-				"given": "Jérôme"
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					4,
-					25
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"1979",
-					12,
-					1
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/V8UFH8IQ",
-		"type": "paper-conference",
-		"abstract": "The LISP-MN protocol is an extension of the Locator/ID Separation Protocol (LISP) that support end-host IP mobility and that, to operate, requires updating the software of the mobile terminal. However in several scenarios this is a major roadblock to effectively deploy mobility. On the one hand the operator must support the implementation over a wide range of devices and on the other hand, end-host mobility does not provide sufficient control to the operator itself. In this paper we present LISP-ROAM, a LISP extension to support network-based end-host mobility. With LISP-ROAM, end-hosts remain completely unmodified while the network provides the mobility support by assigning the same IP address regardless of their network attachment point. The paper describes the protocol and presents an experimental evaluation of the performance of LISP-ROAM implemented on top of LISPmob, an open-source LISP implementation.",
-		"collection-title": "MobiArch '14",
-		"container-title": "Proceedings of the 9th ACM workshop on Mobility in the evolving internet architecture",
-		"DOI": "10.1145/2645892.2645898",
-		"event-place": "New York, NY, USA",
-		"ISBN": "978-1-4503-3074-9",
-		"page": "19-24",
-		"publisher": "Association for Computing Machinery",
-		"publisher-place": "New York, NY, USA",
-		"source": "ACM Digital Library",
-		"title": "LISP-ROAM: network-based host mobility with LISP",
-		"title-short": "LISP-ROAM",
-		"URL": "https://doi.org/10.1145/2645892.2645898",
-		"author": [
-			{
-				"family": "Galvani",
-				"given": "Andrea"
-			},
-			{
-				"family": "Rodriguez-Natal",
-				"given": "Alberto"
-			},
-			{
-				"family": "Cabellos-Aparicio",
-				"given": "Albert"
-			},
-			{
-				"family": "Risso",
-				"given": "Fulvio"
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					4,
-					25
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"2014",
-					9,
-					11
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/YT8PC2CA",
-		"type": "article-journal",
-		"abstract": "The design of a LISP interpreter that allows tail-recursive procedures to be interpreted iteratively is presented at the machine-language level. Iterative interpretation means that, without any program transformations, no environments and continuations will be stacked unless necessary. We apply a specific modification within a traditional stack-oriented version of LISP interpreter, without any non-recursive control structure. The design is compatible with value-cells as well as a-lists LISP processors. We present a complete modified interpreter written itself in LISP and an informal proof that it meets its requirements.",
-		"container-title": "ACM Lisp Bulletin",
-		"DOI": "10.1145/1411798.1411809",
-		"issue": "2",
-		"journalAbbreviation": "Lisp Bull.",
-		"page": "35-46",
-		"source": "July 1978",
-		"title": "Iterative interpretation of tail-recursive LISP procedures",
-		"URL": "https://doi.org/10.1145/1411798.1411809",
-		"author": [
-			{
-				"family": "Greussay",
-				"given": "Patrick"
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					4,
-					25
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"1978",
-					7,
-					1
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/CVQ8EFWQ",
-		"type": "paper-conference",
-		"abstract": "This paper discusses garbage collection techniques used in a high-performance Lisp implementation with a large virtual memory, the Symbolics 3600. Particular attention is paid to practical issues and experience. In a large system problems of scale appear and the most straightforward garbage-collection techniques do not work well. Many of these problems involve the interaction of the garbage collector with demand-paged virtual memory. Some of the solutions adopted in the 3600 are presented, including incremental copying garbage collection, approximately depth-first copying, ephemeral objects, tagged architecture, and hardware assists. We discuss techniques for improving the efficiency of garbage collection by recognizing that objects in the Lisp world have a variety of lifetimes. The importance of designing the architecture and the hardware to facilitate garbage collection is stressed.",
-		"collection-title": "LFP '84",
-		"container-title": "Proceedings of the 1984 ACM Symposium on LISP and functional programming",
-		"DOI": "10.1145/800055.802040",
-		"event-place": "New York, NY, USA",
-		"ISBN": "978-0-89791-142-3",
-		"page": "235-246",
-		"publisher": "Association for Computing Machinery",
-		"publisher-place": "New York, NY, USA",
-		"source": "ACM Digital Library",
-		"title": "Garbage collection in a large LISP system",
-		"URL": "https://doi.org/10.1145/800055.802040",
-		"author": [
-			{
-				"family": "Moon",
-				"given": "David A."
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					4,
-					25
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"1984",
-					8,
-					6
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/THYZ7UPH",
-		"type": "report",
-		"abstract": "The TXDT package is a collection of INTERLISP programs designed for those who wish to build text editors in INTERLISP. TXDT provides a new INTERLISP data type, called a buffer, and programs for efficiently inserting, deleting, searching and manipulating text in buffers. Modifications may be made undoable. A unique feature of TXDT is that an address may be \"stuck\" to a character occurrence so as to follow that character wherever it Is subsequently moved. TXDT also has provisions for fonts.",
-		"event-place": "California",
-		"page": "34",
-		"publisher": "Xerox. Palo Alto Research Center",
-		"publisher-place": "California",
-		"source": "Google Scholar",
-		"title": "The TXDT Package-Interlisp Text Editing Primitives",
-		"URL": "http://129.69.211.95/pdf/xerox/parc/techReports/CSL-81-2_The_TXDT_Package.pdf",
-		"author": [
-			{
-				"family": "Moore",
-				"given": "J. Strother"
-			}
-		],
-		"issued": {
-			"date-parts": [
-				[
-					"1981"
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/FHBWRWVS",
-		"type": "paper-conference",
-		"abstract": "This paper reports work-in-progress within the LISP community on efforts to bring the LISP language to national and international standardisation. The paper discusses the objective criteria that have been established, how it is planned that these will be satisfied, when it is expected these will be fulfilled and what it still open. The Common LISP definition has made a very valuable contribution to the standardisation of LISP and the current authors have learned much from that experience. The result is a rationale for how LISP could be standardised along with identification of key features in the language and its environment, which together lead to a layered definition. This is followed by detail of the proposal for LISP standardisation based on the strategies that will have been outlined.",
-		"collection-title": "LFP '86",
-		"container-title": "Proceedings of the 1986 ACM conference on LISP and functional programming",
-		"DOI": "10.1145/319838.319850",
-		"event-place": "New York, NY, USA",
-		"ISBN": "978-0-89791-200-4",
-		"page": "54-66",
-		"publisher": "Association for Computing Machinery",
-		"publisher-place": "New York, NY, USA",
-		"source": "ACM Digital Library",
-		"title": "Desiderata for the standardization of LISP",
-		"URL": "https://doi.org/10.1145/319838.319850",
-		"author": [
-			{
-				"family": "Padget",
-				"given": "Julian"
-			},
-			{
-				"family": "Chailloux",
-				"given": "Jérôme"
-			},
-			{
-				"family": "Christaller",
-				"given": "Thomas"
-			},
-			{
-				"family": "DeMantaras",
-				"given": "Ramon"
-			},
-			{
-				"family": "Dalton",
-				"given": "Jeff"
-			},
-			{
-				"family": "Devin",
-				"given": "Matthieu"
-			},
-			{
-				"family": "Fitch",
-				"given": "John"
-			},
-			{
-				"family": "Krumnack",
-				"given": "Timm"
-			},
-			{
-				"family": "Neidl",
-				"given": "Eugen"
-			},
-			{
-				"family": "Papon",
-				"given": "Eric"
-			},
-			{
-				"family": "Pope",
-				"given": "Stephen"
-			},
-			{
-				"family": "Queinnec",
-				"given": "Christian"
-			},
-			{
-				"family": "Steels",
-				"given": "Luc"
-			},
-			{
-				"family": "Stoyan",
-				"given": "Herbert"
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					4,
-					25
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"1986",
-					8,
-					8
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/6L976844",
-		"type": "article-journal",
-		"abstract": "Much has been written about Lazy Evaluation in Lisp---less about the other end of the spectrum---Ambitious Evaluation. Ambition is a very subjective concept, though, and if you have some preconceived idea of what you think an Ambitious Evaluator might be about, you might want to set it aside for a few minutes because this probably isn't going to be what you expect.",
-		"container-title": "ACM SIGPLAN Lisp Pointers",
-		"DOI": "10.1145/224133.224137",
-		"ISSN": "1045-3563",
-		"issue": "2",
-		"journalAbbreviation": "SIGPLAN Lisp Pointers",
-		"language": "en",
-		"page": "1-44",
-		"source": "DOI.org (Crossref)",
-		"title": "Ambitious evaluation: a new reading of an old issue",
-		"title-short": "Ambitious evaluation",
-		"URL": "https://dl.acm.org/doi/10.1145/224133.224137",
-		"volume": "VIII",
-		"author": [
-			{
-				"family": "Pitman",
-				"given": "Kent M."
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					4,
-					25
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"1995",
-					5,
-					5
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/622G2WG9",
-		"type": "book",
-		"abstract": "To the complexity of\nbuilding a single interface\nbetween people, machines,\nand problems, which has\nmade this brief so long",
-		"number-of-pages": "35",
-		"source": "Google Scholar",
-		"title": "LISP-an Amicus Curiae Brief",
-		"URL": "http://www.softwarepreservation.net/projects/LISP/MIT/Pratt-LISP_Amicus_Curiae_Brief-1977.pdf",
-		"author": [
-			{
-				"family": "Pratt",
-				"given": "V. R."
-			}
-		],
-		"issued": {
-			"date-parts": [
-				[
-					"1977",
-					1,
-					10
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/EV5ZT2WL",
-		"type": "article-journal",
-		"abstract": "No abstract available",
-		"container-title": "ACM SIGPLAN Lisp Pointers",
-		"DOI": "10.1145/121999.122004",
-		"ISSN": "1045-3563",
-		"issue": "1",
-		"journalAbbreviation": "SIGPLAN Lisp Pointers",
-		"language": "en",
-		"page": "7-61",
-		"source": "DOI.org (Crossref)",
-		"title": "A subjective view of Lisp",
-		"URL": "https://dl.acm.org/doi/10.1145/121999.122004",
-		"volume": "III",
-		"author": [
-			{
-				"family": "Queinnec",
-				"given": "Christian"
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					4,
-					25
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"1989",
-					7
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/KAGGGPEG",
-		"type": "paper-conference",
-		"abstract": "We describe our use of Lisp to generate teaching aids for an Algorithms and Data Structures course taught as part of the undergraduate Computer Science curriculum. Specifically, we have made use of the ease of construction of domain-specific languages in Lisp to build an restricted language with programs capable of being pretty-printed as pseudocode, interpreted as abstract instructions, and treated as data in order to produce modified distractor versions. We examine student performance, report on student and educator reflection, and discuss practical aspects of delivering using this teaching tool.",
-		"collection-title": "ELS2018",
-		"container-title": "Proceedings of the 11th European Lisp Symposium on European Lisp Symposium",
-		"event-place": "Marbella, Spain",
-		"ISBN": "978-2-9557474-2-1",
-		"page": "68-75",
-		"publisher": "European Lisp Scientific Activities Association",
-		"publisher-place": "Marbella, Spain",
-		"source": "ACM Digital Library",
-		"title": "Using Lisp-based pseudocode to probe student understanding",
-		"URL": "https://dl.acm.org/doi/10.5555/3323215.3323225",
-		"author": [
-			{
-				"family": "Rhodes",
-				"given": "Christophe"
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					4,
-					25
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"2018",
-					4,
-					16
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/HNE2HXZ8",
-		"type": "article-journal",
-		"abstract": "Expert Database Systems (EDS) has emerged in the recent years as a powerful combination of disciplines like Artificial Intelligence, Database Management, Logic Programming, and Fuzzy System Theory. This new field incorporates the benefits of both data-based and knowledge-based systems and has generated a great interest among the research, industrial and government communities. An International Workshop on EDS was held in South Carolina in October, 1984, which became the initiative for starting a series of International Conferences on EDS. The first conference on EDS was held in April, 1986 in South Carolina. The second conference, EDS'88, was held in Virginia on April 25--27, 1988. This conference was attended by 350 participants from Australia, Belgium, Brazil, Canada, Denmark, Egypt, England, Federal Republic of Germany, France, Ireland, Italy, Japan, Mexico, Netherlands, Singapore, the Soviet Union, Switzerland, and USA.",
-		"container-title": "ACM SIGART Bulletin",
-		"DOI": "10.1145/84234.1056291",
-		"ISSN": "0163-5719",
-		"issue": "2",
-		"journalAbbreviation": "SIGART Bull.",
-		"page": "21",
-		"source": "Jul. 1990",
-		"title": "Book Review: EXPERT DATABASE SYSTEMS Proceedings from the 2nd Intl. Conference. April 25-27, 1988 Vienna, VA. Edited by Larry Kerschberg (Benjamin/Cummings Publishing Company, 1988)",
-		"title-short": "Book Review",
-		"URL": "https://doi.org/10.1145/84234.1056291",
-		"volume": "1",
-		"author": [
-			{
-				"family": "Saeed",
-				"given": "Faisel"
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					4,
-					25
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"1990",
-					6,
-					1
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/7CSMGPUT",
-		"type": "paper-conference",
-		"abstract": "CANDO is a compiled programming language designed for rapid prototyping and design of macromolecules and nanometer-scale materials. CANDO provides functionality to write programs that assemble atoms and residues into new molecules and construct three-dimensional coordinates for them. CANDO also provides functionality for searching molecules for substructures, automatically assigning atom types, identifying rings, carrying out conformational searching, and automatically determining stereochemistry, among other things. CANDO extends the Clasp implementation of the dynamic language Common Lisp. CANDO provides classes for representing atoms, residues, molecules and aggregates (collections of molecules) as primitive objects that are implemented in C++ and subject to automatic memory management, like every other object within the language. CANDO inherits all of the capabilities of Clasp, including the easy incorporation of C++ libraries using a C++ template programming library. This automatically builds wrap- per code to expose the C++ functionality to the CANDO Common Lisp environment and the use of the LLVM library[1] to generate fast native code. A version of CANDO can be built that incorporates the Open Message Passing Interface C++ library[2], which allows CANDO to be run on supercomputers, in order to automatically setup, start, and analyze molecular mechanics simulations on large parallel computers. CANDO is currently available under the LGPL 2.0 license.",
-		"collection-title": "ELS2016",
-		"container-title": "Proceedings of the 9th European Lisp Symposium on European Lisp Symposium",
-		"event-place": "Kraków, Poland",
-		"ISBN": "978-2-9557474-0-7",
-		"page": "75-82",
-		"publisher": "European Lisp Scientific Activities Association",
-		"publisher-place": "Kraków, Poland",
-		"source": "ACM Digital Library",
-		"title": "CANDO: A Compiled Programming Language for Computer-Aided Nanomaterial Design and Optimization Based on Clasp Common Lisp",
-		"title-short": "CANDO",
-		"URL": "https://dl.acm.org/doi/abs/10.5555/3005729.3005738",
-		"author": [
-			{
-				"family": "Schafmeister",
-				"given": "Christian E."
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					4,
-					25
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"2016",
-					5,
-					9
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/78YMFD8R",
-		"type": "paper-conference",
-		"abstract": "Common Lisp is a towering language that supports a plethora of functionality useful for both scientific and mathematical programming. However---except for a few notable systems such as Axiom, Macsyma/Maxima, and ACL2---Lisp has not taken center stage for such kinds of programming tasks. We will analyze exiting systems, including computer algebra systems, technical computing systems, and other programming languages, and their utility in scientific and mathematical programming. Such a discussion will form a foundation for comparative study. Following that, we will expound on some features of Lisp that augment the expressiveness, simplicity, and utility of programs written in the language. In particular, we do so by way of three carefully selected pragmatic examples arising in fields ranging from the theory of special functions to numerical simulation.",
-		"collection-title": "ILC '14",
-		"container-title": "Proceedings of ILC 2014 on 8th International Lisp Conference",
-		"DOI": "10.1145/2635648.2639484",
-		"event-place": "New York, NY, USA",
-		"ISBN": "978-1-4503-2931-6",
-		"page": "10",
-		"publisher": "Association for Computing Machinery",
-		"publisher-place": "New York, NY, USA",
-		"source": "ACM Digital Library",
-		"title": "Common Lisp's Predilection for Mathematical Programming",
-		"URL": "https://doi.org/10.1145/2635648.2639484",
-		"author": [
-			{
-				"family": "Smith",
-				"given": "Robert"
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					4,
-					25
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"2014",
-					8,
-					14
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/QHTE5I6X",
-		"type": "article-journal",
-		"abstract": "Maybe not as hot a topic in computer architecture as it used to be, but still of considerable interest, is parallelism. How do you make a faster computer? Just strap 20 or 200 or 2000 processors together? As we have learned, the architectural and hardware difficulties are immense (How do you connect them? A shared bus? A network? Is there a single system clock or many clocks?), and after these have been solved there remains the matter of programming.",
-		"container-title": "ACM SIGPLAN Lisp Pointers",
-		"DOI": "10.1145/224133.224134",
-		"ISSN": "1045-3563",
-		"issue": "2",
-		"journalAbbreviation": "SIGPLAN Lisp Pointers",
-		"language": "en",
-		"page": "1-14",
-		"source": "DOI.org (Crossref)",
-		"title": "Parallelism in Lisp",
-		"URL": "https://dl.acm.org/doi/10.1145/224133.224134",
-		"volume": "VIII",
-		"author": [
-			{
-				"family": "Steele",
-				"given": "Guy L."
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					4,
-					25
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"1995",
-					5,
-					5
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/JQGY7E57",
-		"type": "paper-conference",
-		"abstract": "This presentation will cover several themes connected with Lisp. There will be some part about history, some part about semantical equivalences of code pieces in Lisp, etc.",
-		"collection-title": "ILC '07",
-		"container-title": "Proceedings of the 2007 International Lisp Conference",
-		"DOI": "10.1145/1622123.1622132",
-		"event-place": "New York, NY, USA",
-		"ISBN": "978-1-59593-618-9",
-		"page": "1",
-		"publisher": "Association for Computing Machinery",
-		"publisher-place": "New York, NY, USA",
-		"source": "ACM Digital Library",
-		"title": "Lisp: themes and history",
-		"title-short": "Lisp",
-		"URL": "https://doi.org/10.1145/1622123.1622132",
-		"author": [
-			{
-				"family": "Stoyan",
-				"given": "Herbert"
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					4,
-					25
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"2007",
-					4,
-					1
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/SZJRBQAF",
-		"type": "paper-conference",
-		"abstract": "Garbage collection algorithms are divided into three main categories, namely mark-and-sweep, mark-and-compact, and copying collectors. The collectors in the mark-and-compact category are frequently overlooked, perhaps because they have traditionally been associated with greater cost than collectors in the other categories. Among the compacting collectors, the sliding collector has some advantages in that it preserves the relative age of objects. The main problem with the traditional sliding collector by Haddon and Waite [4] is that building address-forwarding tables is costly. We suggest an improvement to the existing algorithm that reverses the order between building the forwarding table and moving the objects. Our method improves performance of building the table, making the sliding collector a better contestant for young generations of objects (nurseries).",
-		"collection-title": "ILC '14",
-		"container-title": "Proceedings of ILC 2014 on 8th International Lisp Conference",
-		"DOI": "10.1145/2635648.2635655",
-		"event-place": "New York, NY, USA",
-		"ISBN": "978-1-4503-2931-6",
-		"page": "97-102",
-		"publisher": "Association for Computing Machinery",
-		"publisher-place": "New York, NY, USA",
-		"source": "ACM Digital Library",
-		"title": "An Improvement to Sliding Garbage Collection",
-		"URL": "https://doi.org/10.1145/2635648.2635655",
-		"author": [
-			{
-				"family": "Strandh",
-				"given": "Robert"
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					4,
-					25
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"2014",
-					8,
-					14
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/PXHVFM62",
-		"type": "article-journal",
-		"abstract": "Lisp has been around for more than twenty-five years. But for most of Lisp's lifetime, there haven't been any good books that teach the language. Only a few books were available, ranging from mediocre to awful.",
-		"container-title": "ACM SIGPLAN Lisp Pointers",
-		"DOI": "10.1145/1862396.1862402",
-		"ISSN": "1045-3563",
-		"issue": "1",
-		"journalAbbreviation": "SIGPLAN Lisp Pointers",
-		"page": "5-55",
-		"source": "April-May 1987",
-		"title": "A programmer's guide to common Lisp",
-		"URL": "https://doi.org/10.1145/1862396.1862402",
-		"volume": "1",
-		"author": [
-			{
-				"family": "Tatar",
-				"given": "Deborah G."
-			},
-			{
-				"family": "Weinreb",
-				"given": "Daniel"
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					4,
-					25
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"1987",
-					4,
-					1
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/5WCSNA4L",
-		"type": "article-journal",
-		"abstract": "We consider the impact of introducing the future construct to the multiple value facility in Lisp (Common Lisp and Scheme). A natural way to accommodate this problem is by modifying the implementation of futures so that one future object returns (or resolves to) multiple values instead of one. We first show how a such straightforward modification fails to maintain the crucial characteristic of futures, namely that inserting futures in a functional program does not alter the the result of the computation. A straightforward modification may result in wrong number of values. We then present two methods which we call the mv-context method and the mv-p flag method to overcome this problem. Both of these methods have been tested in TOP-1 Common Lisp, an implementation of a parallel Common Lisp on the TOP-1 multiprocessor workstation. To our knowledge, this problem has never been analyzed nor solved in an implementation of parallel Lisp. We also present the technique of\nfuture chain elimination\nwhich avoids creation of unnecessary futures and processes at run-time, which was inspired by this solution.",
-		"container-title": "ACM SIGPLAN Lisp Pointers",
-		"DOI": "10.1145/224133.224135",
-		"ISSN": "1045-3563",
-		"issue": "2",
-		"journalAbbreviation": "SIGPLAN Lisp Pointers",
-		"language": "en",
-		"page": "15-24",
-		"source": "DOI.org (Crossref)",
-		"title": "Futures and multiple values in parallel Lisp",
-		"URL": "https://dl.acm.org/doi/10.1145/224133.224135",
-		"volume": "VIII",
-		"author": [
-			{
-				"family": "Tomoyuki",
-				"given": "Tanaka"
-			},
-			{
-				"family": "Shigeru",
-				"given": "Uzuhara"
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					4,
-					25
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"1995",
-					5,
-					5
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/NEZYJT4Y",
-		"type": "paper-conference",
-		"abstract": "Reference-counting garbage collection is known to have problems with the collection of cyclically connected data. There are two historically significant styles of cycle-aware algorithms: The style of Brownbridge that maintains a subset of marked edges and the invariant that every cycle contains at least one marked edge, and the style of Martinez-Lins-Wachenchauzer (MLW) that involves local mark-and-scan procedures to detect cycles. The former is known to be difficult to design and implement correctly, and the latter to have pathological efficiency for a number of very typical situations. We present a novel algorithm that combines both approaches to obtain reasonably efficient local mark-and-scan phases with a marking invariant that is rather cheap to maintain. We demonstrate that the assumptions of this algorithm about mutator activity patterns make it well-suited, but not limited, to a functional programming technique for cyclic data. We evaluate the approach in comparison with simple and more sophisticated MLW algorithms using a simple benchmark based on that functional paradigm.",
-		"collection-title": "ISMM '08",
-		"container-title": "Proceedings of the 7th international symposium on Memory management",
-		"DOI": "10.1145/1375634.1375645",
-		"event-place": "New York, NY, USA",
-		"ISBN": "978-1-60558-134-7",
-		"page": "71-80",
-		"publisher": "Association for Computing Machinery",
-		"publisher-place": "New York, NY, USA",
-		"source": "ACM Digital Library",
-		"title": "A reference-counting garbage collection algorithmfor cyclical functional programming",
-		"URL": "https://doi.org/10.1145/1375634.1375645",
-		"author": [
-			{
-				"family": "Trancón y Widemann",
-				"given": "Baltasar"
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					4,
-					25
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"2008",
-					6,
-					7
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/GPX7B6F7",
-		"type": "paper-conference",
-		"abstract": "Writing a program and writing its documentation are often considered two separate tasks, leading to several problems: the documentation may never be written; when it is, it may be an afterthought; and when the program is modified, the needed changes to the documentation may be overlooked. Literate programming (LP), introduced by Donald Knuth, views a program and its documentation as an integrated whole: they are written together to inform both the computer and human readers. LP tools then extract the code for the computer and the documentation for further document processing. Unfortunately, existing LP tools are much more suited for compiled languages, where there is already a step between coding and executing and debugging the code. Lisp programming typically involved incremental development and testing, often highly interleaving coding with running portions of the code. Thus LP tools inject an artificial impediment into this process. LP/Lisp is a new LP tool designed specifically for Lisp and the usual style of programming using Lisp. The literate programming file is the Lisp file; LP markup and text resides in Lisp comments, where it does not interfere with running the code. LP/Lisp provided the usual literate programming services, such as code typesetting, syntactic sugaring, and the ability to split the code for expository purposes (a \"chunk\" mechanism). LP/Lisp, itself written in Lisp, is run on the code to produce the documentation.",
-		"collection-title": "ILC '10",
-		"container-title": "Proceedings of the 2010 international conference on Lisp",
-		"DOI": "10.1145/1869643.1869647",
-		"event-place": "New York, NY, USA",
-		"ISBN": "978-1-4503-0470-2",
-		"page": "21-28",
-		"publisher": "Association for Computing Machinery",
-		"publisher-place": "New York, NY, USA",
-		"source": "ACM Digital Library",
-		"title": "LP/LISP: literate programming for Lisp",
-		"title-short": "LP/LISP",
-		"URL": "https://doi.org/10.1145/1869643.1869647",
-		"author": [
-			{
-				"family": "Turner",
-				"given": "Roy M."
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					4,
-					25
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"2010",
-					10,
-					19
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/E4ZM3L5Q",
-		"type": "article-journal",
-		"abstract": "This paper presents a systems (PHENARETE) which understands and improves incompletely defined LISP programs, such as those written by students beginning to program in LISP. This system takes, as input, the program without any additional information. In order to understand the program, the system meta-evaluates it, using a library of \"pragmatic rules\", describing the construction and correction of general program constructs, and a set of \"specialists\", describing the syntax and semantics of the standard LISP functions. The system can use its understanding of the program to detect errors in it, to debug them and, eventually, to justify its proposed modification. This paper gives a brief survey of the working of the system, emphasizing on some commented examples.",
-		"container-title": "ACM Lisp Bulletin",
-		"DOI": "10.1145/1411798.1411808",
-		"issue": "2",
-		"journalAbbreviation": "Lisp Bull.",
-		"page": "2-46",
-		"source": "July 1978",
-		"title": "A system to understand incorrect programs",
-		"URL": "https://doi.org/10.1145/1411798.1411808",
-		"author": [
-			{
-				"family": "Wertz",
-				"given": "Harald"
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					4,
-					25
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"1978",
-					7,
-					1
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/IX8UFN2M",
-		"type": "article-journal",
-		"container-title": "Linux Journal",
-		"ISSN": "1075-3583",
-		"issue": "31es",
-		"journalAbbreviation": "Linux J.",
-		"page": "6-es",
-		"source": "Nov. 1996",
-		"title": "LJ Interviews Larry Gritz",
-		"URL": "https://dl.acm.org/doi/abs/10.5555/326464.326470",
-		"volume": "1996",
-		"author": [
-			{
-				"family": "Wood",
-				"given": "Amy"
-			}
-		],
-		"issued": {
-			"date-parts": [
-				[
-					"1996",
-					11,
-					1
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/PTZNWRJX",
-		"type": "entry-encyclopedia",
-		"abstract": "X3J13 is the name of a technical committee which was part of the International Committee for Information Technology Standards (INCITS, then named X3).  The X3J13 committee was formed in 1986 to draw up an American National Standards Institute (ANSI) Common Lisp standard based on the first edition of the book Common Lisp the Language (also termed CLtL, or CLtL1), by Guy L. Steele Jr., which was formerly a de facto standard for the language.  The primary output of X3J13 was an American National Standard for programming language Common Lisp (X3.226/1994), approved December 8, 1994. X3J13 later worked with International Organization for Standardization (ISO) working group SC22/WG16 on an internationally standardised dialect of Lisp named ISLISP.",
-		"container-title": "Wikipedia",
-		"language": "en",
-		"source": "Wikipedia",
-		"title": "X3J13",
-		"URL": "https://en.wikipedia.org/w/index.php?title=X3J13&oldid=990841364",
-		"editor": [
-			{
-				"literal": "Monkbot"
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					4,
-					17
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"2020",
-					11,
-					26
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/IVLM3WCS",
-		"type": "webpage",
-		"title": "Format for proposals to the cleanup committee (Version 14)",
-		"URL": "https://larrymasinter.net/cl-cleanup-proposal.txt",
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					4,
-					17
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"1988",
-					10,
-					5
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/DNCVYGJC",
-		"type": "article-journal",
-		"abstract": "The problem of the use of two levels of storage for programs is explored in the context of a LISP system which uses core memory as a buffer for a large virtual memory stored on a drum. Details of timing are given for one particular problem.",
-		"container-title": "Communications of the ACM",
-		"DOI": "10.1145/363567.363581",
-		"ISSN": "0001-0782, 1557-7317",
-		"issue": "8",
-		"journalAbbreviation": "Commun. ACM",
-		"language": "en",
-		"page": "558",
-		"source": "DOI.org (Crossref)",
-		"title": "A note on the efficiency of a LISP computation in a paged machine",
-		"URL": "https://dl.acm.org/doi/10.1145/363567.363581",
-		"volume": "11",
-		"author": [
-			{
-				"family": "Bobrow",
-				"given": "Daniel G."
-			},
-			{
-				"family": "Murphy",
-				"given": "Daniel L."
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					4,
-					21
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"1968",
-					8
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/BSE5UV9A",
-		"type": "article-journal",
-		"abstract": "List structures provide a general mechanism for representing easily changed structured data, but can introduce inefficiencies in the use of space when fields of uniform size are used to contain pointers to data and to link the structure. Empirically determined regularity can be exploited to provide more space-efficient encodings without losing the flexibility inherent in list structures. The basic scheme is to provide compact pointer fields big enough to accommodate most values that occur in them and to provide “escape” mechanisms for exceptional cases. Several examples of encoding designs are presented and evaluated, including two designs currently used in Lisp machines. Alternative escape mechanisms are described, and various questions of cost and implementation are discussed. In order to extrapolate our results to larger systems than those measured, we propose a model for the generation of list pointers and we test the model against data from two programs. We show that according to our model, list structures with compact cdr fields will, as address space grows, continue to be compacted well with a fixed-width small field. Our conclusion is that with a microcodable processor, about a factor of two gain in space efficiency for list structure can be had for little or no cost in processing time.",
-		"container-title": "ACM Transactions on Programming Languages and Systems",
-		"DOI": "10.1145/357073.357081",
-		"ISSN": "0164-0925, 1558-4593",
-		"issue": "2",
-		"journalAbbreviation": "ACM Trans. Program. Lang. Syst.",
-		"language": "en",
-		"page": "266-286",
-		"source": "DOI.org (Crossref)",
-		"title": "Compact Encodings of List Structure",
-		"URL": "https://dl.acm.org/doi/10.1145/357073.357081",
-		"volume": "1",
-		"author": [
-			{
-				"family": "Bobrow",
-				"given": "Daniel G."
-			},
-			{
-				"family": "Clark",
-				"given": "Douglas W."
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					4,
-					21
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"1979",
-					10
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/MXG7MRIV",
-		"type": "paper-conference",
-		"abstract": "In 1992 when we completed our first draft of the History of Programming Languages II paper, The Evolution of Lisp [1], it included sections on a theory or model of how complex language families like Lisp grew and evolved, and in particular, how and when diversity would bloom and consolidation would prune. The historian who worked with all the HOPL II authors, Michael S. Mahoney, did not believe our theory was substantiated properly, so he recommended removing the material and sticking with the narrative of Lisp's evolution. We stopped working on those sections, but they remained in the original text sources but removed with conditionals.",
-		"collection-title": "LISP50",
-		"container-title": "Celebrating the 50th Anniversary of Lisp",
-		"DOI": "10.1145/1529966.1529967",
-		"event-place": "New York, NY, USA",
-		"ISBN": "978-1-60558-383-9",
-		"page": "1-10",
-		"publisher": "Association for Computing Machinery",
-		"publisher-place": "New York, NY, USA",
-		"source": "ACM Digital Library",
-		"title": "A pattern of language evolution",
-		"URL": "https://doi.org/10.1145/1529966.1529967",
-		"author": [
-			{
-				"family": "Gabriel",
-				"given": "Richard P."
-			},
-			{
-				"family": "Steele",
-				"given": "Guy L."
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					4,
-					23
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"2008",
-					10,
-					20
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/88GP5KT3",
-		"type": "webpage",
-		"title": "PDP-10 software archive",
-		"title-short": "Tape Images from Computer History",
-		"URL": "http://pdp-10.trailing-edge.com/",
-		"author": [
-			{
-				"family": "Kossow",
-				"given": "Al"
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					4,
-					25
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"2006"
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/CHD59QIJ",
-		"type": "article-journal",
-		"container-title": "ACM SIGCAS Computers and Society",
-		"DOI": "10.1145/236394.236396",
-		"ISSN": "0095-2737",
-		"issue": "2",
-		"journalAbbreviation": "SIGCAS Comput. Soc.",
-		"page": "22-29",
-		"source": "June 1996",
-		"title": "Cyberethics and the future of computing",
-		"URL": "https://doi.org/10.1145/236394.236396",
-		"volume": "26",
-		"author": [
-			{
-				"family": "Tavani",
-				"given": "Herman T."
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					4,
-					25
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"1996",
-					5,
-					1
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/NSSJE3JB",
-		"type": "article-journal",
-		"container-title": "ACM SIGCHI Bulletin",
-		"DOI": "10.1145/214132.570139",
-		"ISSN": "0736-6906",
-		"issue": "4",
-		"journalAbbreviation": "SIGCHI Bull.",
-		"page": "79-80",
-		"source": "Oct. 1995",
-		"title": "Book Review: Practical User Interface Design by Larry Wood",
-		"title-short": "Book Review",
-		"URL": "https://doi.org/10.1145/214132.570139",
-		"volume": "27",
-		"author": [
-			{
-				"family": "Wood",
-				"given": "Larry"
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					4,
-					25
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"1995",
-					10,
-					1
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/IGYFMP8H",
-		"type": "paper-conference",
-		"abstract": "This paper describes a real-time garbage collection algorithm for list processing systems. We identify two efficiency problems inherent to real-time garbage collectors, and give some evidence that the proposed algorithm tends to reduce these problems. In a virtual memory implementation, the algorithm restructures the cell storage area more compactly, thus reducing working sets. The algorithm also may provide a more garbage-free storage area at the end of the collection cycle, although this claim really must await empirical verification.",
-		"collection-title": "LFP '82",
-		"container-title": "Proceedings of the 1982 ACM symposium on LISP and functional programming",
-		"DOI": "10.1145/800068.802146",
-		"event-place": "New York, NY, USA",
-		"ISBN": "978-0-89791-082-6",
-		"page": "159-167",
-		"publisher": "Association for Computing Machinery",
-		"publisher-place": "New York, NY, USA",
-		"source": "ACM Digital Library",
-		"title": "Improved effectiveness from a real time LISP garbage collector",
-		"URL": "https://doi.org/10.1145/800068.802146",
-		"author": [
-			{
-				"family": "Dawson",
-				"given": "Jeffrey L."
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					4,
-					25
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"1982",
-					8,
-					15
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/J6VTRV7Q",
-		"type": "article-journal",
-		"container-title": "ACM Lisp Bulletin",
-		"DOI": "10.1145/1411829.1411833",
-		"issue": "3",
-		"journalAbbreviation": "Lisp Bull.",
-		"page": "6-8",
-		"source": "December 1979",
-		"title": "An interesting LISP function",
-		"URL": "https://doi.org/10.1145/1411829.1411833",
-		"author": [
-			{
-				"family": "McCarthy",
-				"given": "J."
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					4,
-					25
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"1979",
-					12,
-					1
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/UPJSYJUJ",
-		"type": "article-journal",
-		"source": "Google Scholar",
-		"title": "Die Arbeitsweise hypermedialer Lernsysteme am Beispiel der Systeme Lisp-Tutor und ELM-ART",
-		"URL": "http://informatikdidaktik.de/Lehre/HypermediaLernsysteme/Vortraege/BoehnkeEggerth.pdf",
-		"author": [
-			{
-				"family": "Böhnke",
-				"given": "Dorothea"
-			},
-			{
-				"family": "Eggerth",
-				"given": "Claudia"
-			}
-		],
-		"issued": {
-			"date-parts": [
-				[
-					"2001",
-					1,
-					29
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/5FXRXRFT",
-		"type": "chapter",
-		"container-title": "Prototypen benutzergerechter Computersysteme",
-		"ISBN": "978-3-11-086190-7",
-		"language": "de",
-		"page": "151-168",
-		"publisher": "De Gruyter",
-		"source": "Google Scholar",
-		"title": "IX. OPTIMIST. Ein System zur Beurteilung und Verbesserung von Lisp-Code",
-		"URL": "https://www.degruyter.com/document/doi/10.1515/9783110861907-010/html",
-		"author": [
-			{
-				"family": "Böcker",
-				"given": "Heinz-Dieter"
-			}
-		],
-		"issued": {
-			"date-parts": [
-				[
-					"2019",
-					7,
-					8
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/3UNHV59N",
-		"type": "webpage",
-		"container-title": "Table of contents for issues of Lisp and Symbolic Computation",
-		"title": "Lisp and Symbolic Computation",
-		"URL": "http://ftp.math.utah.edu/pub/tex/bib/toc/lispsymbcomput.html",
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					4,
-					25
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/UFJLXXCL",
-		"type": "article-journal",
-		"abstract": "A programming system called LISP (for Lisp Processor) has been developed for the IBM 704 computer by the Artificial Intelligence group at M.I.T. The system was designed to facilitate experiments with a proposed system called the Advice Taker, whereby a machine could be instructed to handle declarative as well as imperative sentences and could exhibit, \"common sense\"  in carrying out its instructions. The original proposal for the Advice Taker was made in November l958. The main requirement was a programming system for manipulating expressions representing formalized declarative and imperative sentences so that the Advice Taker system could make deductions.",
-		"container-title": "Communications of the ACM",
-		"DOI": "10.1145/367177.367199",
-		"ISSN": "0001-0782, 1557-7317",
-		"issue": "4",
-		"journalAbbreviation": "Commun. ACM",
-		"language": "en",
-		"page": "184-195",
-		"source": "DOI.org (Crossref)",
-		"title": "Recursive functions of symbolic expressions and their computation by machine, Part I",
-		"URL": "https://dl.acm.org/doi/10.1145/367177.367199",
-		"volume": "3",
-		"author": [
-			{
-				"family": "McCarthy",
-				"given": "John"
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					4,
-					25
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"1960",
-					4
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/EIATQTVR",
-		"type": "article-journal",
-		"abstract": "A large high-speed general-purpose digital computer (IBM 7090) was programmed to solve elementary symbolic integration problems at approximately the level of a good college freshman. The program is called SAINT, an acronym for \"Symbolic Automatic INTegrator.\" This paper discusses the SAINT program and its performance. SAINT performs indefinite integration. It also performs definite and multiple integration when these are trivial extensions of indefinite integration. It uses many of the methods and heuristics of students attacking the same prombles. SAINT took an average of two minutes each to solve 52 of the 54 attempted problems taken from the Massachusetts Institute of Technology freshman calculus final examinations. Based on this and other experiments with SAINT, some conclusions coneering computer solution of such problems are: (1) Pattern recognition is of fundamental importance. (2) Great benefit would have been derived from a large memory and more convenient symbol manipulating facilities. (3) The solution of a symbolic integration problem by a commercially available computer is far cheaper and faster than by man.",
-		"container-title": "Journal of the ACM",
-		"DOI": "10.1145/321186.321193",
-		"ISSN": "0004-5411, 1557-735X",
-		"issue": "4",
-		"journalAbbreviation": "J. ACM",
-		"language": "en",
-		"page": "413-581",
-		"source": "DOI.org (Crossref)",
-		"title": "A Heuristic Program that Solves Symbolic Integration Problems in Freshman Calculus",
-		"URL": "https://dl.acm.org/doi/10.1145/321186.321193",
-		"volume": "10",
-		"author": [
-			{
-				"family": "Slagle",
-				"given": "James R."
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					4,
-					25
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"1963",
-					10
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/IGCGZ4Z8",
-		"type": "article-journal",
-		"abstract": "This is a proposal to the X3 J13 committee for both extending and modifying\nthe Common LISP language definition to provide a standard basis for Common\nLISP support of the variety of characters used to represent the languages of the\ninternational community.\nThis proposal was created by the Character Subcommittee of X3 J13. We\nwould like to acknowledge discussions with T. Yuasa and other members of\nthe JIS Technical Working Group, comments from members of X3 J13, and\nthe proposals [Ida87], [Linden87], [Kerns87], and [Kurokawa88] for providing\nthe motivation and direction for these extensions. As all these documents and\ndiscussions were created expressly for LISP standardization usage, we have borrowed freely from their ideas as well as the texts themselves.",
-		"page": "24",
-		"source": "Google Scholar",
-		"title": "Extensions to Common LISP to Support International Character Sets",
-		"URL": "https://www.researchgate.net/profile/Larry-Masinter/publication/237527690_Extensions_to_Common_LISP_to_Support_International_Character_Sets/links/0c960535d33199f90d000000/Extensions-to-Common-LISP-to-Support-International-Character-Sets.pdf",
-		"author": [
-			{
-				"family": "Beckerle",
-				"given": "Michael"
-			},
-			{
-				"family": "Beiser",
-				"given": "Paul"
-			},
-			{
-				"family": "Duggan",
-				"given": "Jerry"
-			},
-			{
-				"family": "Kerns",
-				"given": "Robert"
-			},
-			{
-				"family": "Layer",
-				"given": "Kevin"
-			},
-			{
-				"family": "Linden",
-				"given": "Thom"
-			},
-			{
-				"family": "Masinter",
-				"given": "Larry"
-			},
-			{
-				"family": "Unietis",
-				"given": "David"
-			}
-		],
-		"issued": {
-			"date-parts": [
-				[
-					"1989"
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/QXTFTCCF",
-		"type": "article-journal",
-		"abstract": "The major limitations in building large software have always been (a) its brittleness when confronted by problems that were not foreseen by its builders, and (by the amount of manpower required. The recent history of expert systems, for example highlights how constricting the brittleness and knowledge acquisition bottlenecks are. Moreover, standard software methodology (e.g., working from a detailed \"spec\") has proven of little use in AI, a field which by definition tackles ill- structured problems. How can these bottlenecks be widened? Attractive, elegant answers have included machine learning, automatic programming, and natural language understanding. But decades of work on such systems have convinced us that each of these approaches has difficulty \"scaling up\" for want a substantial base of real world knowledge.",
-		"container-title": "AI magazine",
-		"DOI": "https://doi.org/10.1609/aimag.v6i4.510",
-		"issue": "4",
-		"page": "65-65",
-		"source": "Google Scholar",
-		"title": "CYC: Using common sense knowledge to overcome brittleness and knowledge acquisition bottlenecks",
-		"title-short": "CYC",
-		"URL": "https://ojs.aaai.org/index.php/aimagazine/article/view/510",
-		"volume": "6",
-		"author": [
-			{
-				"family": "Lenat",
-				"given": "Douglas B."
-			},
-			{
-				"family": "Prakash",
-				"given": "Mayank"
-			},
-			{
-				"family": "Shepherd",
-				"given": "Mary"
-			}
-		],
-		"issued": {
-			"date-parts": [
-				[
-					"1985",
-					3,
-					15
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/SYH6SCAR",
-		"type": "paper-conference",
-		"abstract": "We present the Computer Science Scholar's Workbench, a tool kit written in Pascal suitable for research and teaching. It has advantages over contemporary workbenches, UNIX and INTERLISP: a host to support the tool kit costs less than $3,000, the tools are free-available in source from publications, and the tools are written in Pascal which is widely used in academic environments. We discuss a) course requirements and problems unique to project oriented software engineering classes, b) the tools we've chosen for the workbench, and c) how they may be used to ameliorate or solve many of the problems. We report our experience using the workbench and evaluate it in terms of cost, performance, portability, extensibility, and effectiveness.",
-		"collection-title": "SIGCSE '84",
-		"container-title": "Proceedings of the fifteenth SIGCSE technical symposium on Computer science education",
-		"DOI": "10.1145/800039.808638",
-		"event-place": "New York, NY, USA",
-		"ISBN": "978-0-89791-126-1",
-		"page": "137-145",
-		"publisher": "Association for Computing Machinery",
-		"publisher-place": "New York, NY, USA",
-		"source": "ACM Digital Library",
-		"title": "A workbench for project oriented software engineering courses",
-		"URL": "https://doi.org/10.1145/800039.808638",
-		"author": [
-			{
-				"family": "Waguespack",
-				"given": "Leslie J."
-			},
-			{
-				"family": "Hass",
-				"given": "David F."
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					4,
-					25
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"1984",
-					1,
-					1
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/AFGJ2CTH",
-		"type": "article-journal",
-		"abstract": "In this issue we survey the Lisp programming environment provided on the family of Lisp machines built by Xerox. These machines, which once ran only Interlisp-D, are now said to run 'Xerox Lisp' which is a combination of Interlisp-D and Common Lisp.",
-		"container-title": "ACM SIGPLAN Lisp Pointers",
-		"DOI": "10.1145/1317193.1317199",
-		"ISSN": "1045-3563",
-		"issue": "2",
-		"journalAbbreviation": "SIGPLAN Lisp Pointers",
-		"page": "33-35",
-		"source": "June-July 1987",
-		"title": "Lisp environments",
-		"URL": "https://doi.org/10.1145/1317193.1317199",
-		"volume": "1",
-		"author": [
-			{
-				"family": "Foderaro",
-				"given": "John"
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					4,
-					25
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"1987",
-					6,
-					1
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/P767HNJ4",
-		"type": "paper-conference",
-		"abstract": "In INTERLISP we find a number of embedded languages such as the iterative statement and the pattern match facility in the CLISP package, the editor and makefile languages and so forth. We will in this paper concentrate on the problem of extending the LISP language and discuss a method to compile such extensions. We propose the language to be implemented through an interpreter (written in LISP) and that compilation of statements in such an embedded language is done through partial evaluation. The interpreter is partially evaluated with respect to the actual statements, and an object program in LISP is obtained. This LISP code can further be compiled to machine code by the standard LISP compiler. We have implemented the iterative statement and a CLISP-like pattern matcher and used a program manipulation system to generate object programs in LISP. Comparisons will be made with the corresponding INTERLISP implementations, which use special purpose compilers in order to generate the LISP code.",
-		"collection-title": "LFP '80",
-		"container-title": "Proceedings of the 1980 ACM conference on LISP and functional programming",
-		"DOI": "10.1145/800087.802808",
-		"event-place": "New York, NY, USA",
-		"ISBN": "978-1-4503-7396-8",
-		"page": "208-215",
-		"publisher": "Association for Computing Machinery",
-		"publisher-place": "New York, NY, USA",
-		"source": "ACM Digital Library",
-		"title": "On compiling embedded languages in LISP",
-		"URL": "https://doi.org/10.1145/800087.802808",
-		"author": [
-			{
-				"family": "Emanuelson",
-				"given": "Pär"
-			},
-			{
-				"family": "Haraldsson",
-				"given": "Anders"
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					4,
-					25
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"1980",
-					8,
-					25
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/YR58NY6F",
-		"type": "paper-conference",
-		"abstract": "CommonLoops blends object-oriented programming smoothly and tightly with the procedure-oriented design of Lisp. Functions and methods are combined in a more general abstraction. Message passing is invoked via normal Lisp function call. Methods are viewed as partial descriptions of procedures. Lisp data types are integrated with object classes. With these integrations, it is easy to incrementally move a program between the procedure and object-oriented styles. One of the most important properties of CommonLoops is its extensive use of meta-objects. We discuss three kinds of meta-objects: objects for classes, objects for methods, and objects for discriminators. We argue that these meta-objects make practical both efficient implementation and experimentation with new ideas for object-oriented programming. CommonLoops' small kernel is powerful enough to implement the major object-oriented systems in use today.",
-		"collection-title": "OOPSLA '86",
-		"container-title": "Conference proceedings on Object-oriented programming systems, languages and applications",
-		"DOI": "10.1145/28697.28700",
-		"event-place": "New York, NY, USA",
-		"ISBN": "978-0-89791-204-7",
-		"page": "17-29",
-		"publisher": "Association for Computing Machinery",
-		"publisher-place": "New York, NY, USA",
-		"source": "ACM Digital Library",
-		"title": "CommonLoops: merging Lisp and object-oriented programming",
-		"title-short": "CommonLoops",
-		"URL": "https://doi.org/10.1145/28697.28700",
-		"author": [
-			{
-				"family": "Bobrow",
-				"given": "Daniel G."
-			},
-			{
-				"family": "Kahn",
-				"given": "Kenneth"
-			},
-			{
-				"family": "Kiczales",
-				"given": "Gregor"
-			},
-			{
-				"family": "Masinter",
-				"given": "Larry"
-			},
-			{
-				"family": "Stefik",
-				"given": "Mark"
-			},
-			{
-				"family": "Zdybel",
-				"given": "Frank"
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					4,
-					25
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"1986",
-					6,
-					1
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/WPDGQV37",
-		"type": "paper-conference",
-		"abstract": "DoradoLisp is an implementation of the Interlisp programming system on a large personal computer. It has evolved from AltoLisp, an implementation on a less powerful machine. The major goal of the Dorado implementation was to eliminate the performance deficiencies of the previous system. This paper describes the current status of the system and discusses some of the issues that arose during its implementation. Among the techniques that helped us meet our performance goal were transferring much of the kernel software into Lisp, intensive use of performance measurement tools to determine the areas of worst performance, and use of the Interlisp programming environment to allow rapid and widespread improvements to the system code. The paper lists some areas in which performance was critical and offers some observations on how our experience might be useful to other implementations of Interlisp.",
-		"collection-title": "LFP '80",
-		"container-title": "Proceedings of the 1980 ACM conference on LISP and functional programming",
-		"DOI": "10.1145/800087.802812",
-		"event-place": "New York, NY, USA",
-		"ISBN": "978-1-4503-7396-8",
-		"page": "243-247",
-		"publisher": "Association for Computing Machinery",
-		"publisher-place": "New York, NY, USA",
-		"source": "ACM Digital Library",
-		"title": "Overview and status of DoradoLisp",
-		"URL": "https://doi.org/10.1145/800087.802812",
-		"author": [
-			{
-				"family": "Burton",
-				"given": "Richard R."
-			},
-			{
-				"family": "Masinter",
-				"given": "L. M."
-			},
-			{
-				"family": "Bobrow",
-				"given": "Daniel G."
-			},
-			{
-				"family": "Haugeland",
-				"given": "Willie Sue"
-			},
-			{
-				"family": "Kaplan",
-				"given": "Ronald M."
-			},
-			{
-				"family": "Sheil",
-				"given": "B. A."
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					4,
-					25
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"1980",
-					8,
-					25
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/A52363YK",
-		"type": "article-journal",
-		"abstract": "Effective information access involves rich interactions between users and information residing in diverse locations. Users seek and retrieve information from the sources—for example, file serves, databases, and digital libraries—and use various tools to browse, manipulate, reuse, and generally process the information. We have developed a number of techniques that support various aspects of the process of user/information interaction. These techniques can be considered attempts to increase the bandwidth and quality of the interactions between users and information in an information workspace—an environment designed to support information work (see Figure 1).",
-		"container-title": "Communications of the ACM",
-		"DOI": "10.1145/205323.205326",
-		"ISSN": "0001-0782",
-		"issue": "4",
-		"journalAbbreviation": "Commun. ACM",
-		"page": "29-39",
-		"source": "April 1995",
-		"title": "Rich interaction in the digital library",
-		"URL": "https://doi.org/10.1145/205323.205326",
-		"volume": "38",
-		"author": [
-			{
-				"family": "Rao",
-				"given": "Ramana"
-			},
-			{
-				"family": "Pedersen",
-				"given": "Jan O."
-			},
-			{
-				"family": "Hearst",
-				"given": "Marti A."
-			},
-			{
-				"family": "Mackinlay",
-				"given": "Jock D."
-			},
-			{
-				"family": "Card",
-				"given": "Stuart K."
-			},
-			{
-				"family": "Masinter",
-				"given": "Larry"
-			},
-			{
-				"family": "Halvorsen",
-				"given": "Per-Kristian"
-			},
-			{
-				"family": "Robertson",
-				"given": "George C."
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					4,
-					25
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"1995",
-					4,
-					1
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/RYF24FVN",
-		"type": "paper-conference",
-		"abstract": "We will demonstrate how to build Common Lisp programs using Bazel, Google's hermetic and reproducible build system. Unlike the state of the art so far for building Lisp programs, Bazel ensures that incremental builds are always both fast and correct. With Bazel, one can statically link C libraries into the SBCL runtime, making the executable file self-contained.",
-		"collection-title": "ELS2016",
-		"container-title": "Proceedings of the 9th European Lisp Symposium on European Lisp Symposium",
-		"event-place": "Kraków, Poland",
-		"ISBN": "978-2-9557474-0-7",
-		"page": "95-96",
-		"publisher": "European Lisp Scientific Activities Association",
-		"publisher-place": "Kraków, Poland",
-		"source": "ACM Digital Library",
-		"title": "Building Common Lisp programs using Bazel",
-		"URL": "https://dl.acm.org/doi/10.5555/3005729.3005741",
-		"author": [
-			{
-				"family": "Knight",
-				"given": "James Y."
-			},
-			{
-				"family": "Rideau",
-				"given": "François-René"
-			},
-			{
-				"family": "Walczak",
-				"given": "Andrzej"
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					4,
-					25
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"2016",
-					5,
-					9
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/4Y6C6GIS",
-		"type": "paper-conference",
-		"abstract": "We describe a technique for generic dispatch that is adapted to modern computers where accessing memory is potentially quite expensive. Instead of the traditional hashing scheme used by PCL [6], we assign a unique number to each class, and the dispatch consists of comparisons of the number assigned to an instance with a certain number of (usually small) constant integers. While our implementation (SICL) is not yet in a state where we are able to get exact performance figures, a conservative simulation suggests that our technique is significantly faster than the one used in SBCL, which uses PCL, and indeed faster than the technique used by most high-performance Common Lisp implementations. Furthermore, existing work [7] using a similar technique in the context of static languages suggests that perfomance can improve significantly compared to table-based techniques.",
-		"collection-title": "ILC '14",
-		"container-title": "Proceedings of ILC 2014 on 8th International Lisp Conference",
-		"DOI": "10.1145/2635648.2635654",
-		"event-place": "New York, NY, USA",
-		"ISBN": "978-1-4503-2931-6",
-		"page": "89-96",
-		"publisher": "Association for Computing Machinery",
-		"publisher-place": "New York, NY, USA",
-		"source": "ACM Digital Library",
-		"title": "Fast Generic Dispatch for Common Lisp",
-		"URL": "https://doi.org/10.1145/2635648.2635654",
-		"author": [
-			{
-				"family": "Strandh",
-				"given": "Robert"
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					4,
-					25
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"2014",
-					8,
-					14
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/SWFYUER9",
-		"type": "article-magazine",
-		"abstract": "Lisp has done quite well over the last ten years: becoming nearly standardized, forming the basis of a commercial sector, achieving excellent performance, having good environments, able to deliver applications. Yet the Lisp community has failed to do as well as it could have. In this paper I look at the successes, the failures, and what to do next.",
-		"container-title": "Dreamsongs",
-		"title": "Lisp: Good News, Bad News, How to Win Big",
-		"URL": "https://dreamsongs.com/WIB.html",
-		"author": [
-			{
-				"family": "Gabriel",
-				"given": "Richard P."
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					4,
-					25
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"1991"
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/48ESB5WE",
-		"type": "book",
-		"abstract": "LISP, as a language, has been around for about 25 years [mcca78]. It was originally developed to support artificial intelligence (AI) research. At first, it seemed\nto be little noticed except by a small band of academics who implemented some\nof the early LISP interpreters and wrote some of the early AI programs. In the\nearly 60’s, LISP began to diverge as various implementations were developed for\ndifferent machines. McCarthy [mcca78] gives a short history of its early days.",
-		"event-place": "Canada",
-		"language": "eng",
-		"number-of-pages": "1181",
-		"publisher": "A Wiley-lnterscience Publication JOHN WILEY & SONS",
-		"publisher-place": "Canada",
-		"source": "Internet Archive",
-		"title": "INTERLISP The Language And Its Usage",
-		"URL": "https://interlisp.org/docs/1986-Interlisp-language-book-1.pdf",
-		"author": [
-			{
-				"literal": "Stephen H. Kaisler"
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					4,
-					25
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"1986"
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/4IVLXUAF",
-		"type": "webpage",
-		"title": "International Lisp Conference 2014",
-		"URL": "http://ilc2014.iro.umontreal.ca/",
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					4,
-					26
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"2014",
-					8,
-					15
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/4EDHAKDB",
-		"type": "paper-conference",
-		"abstract": "We describe the local optimization phase of a compiler for translating the INTERLISP dialect of LISP into stack-architecture (0-address) instruction sets. We discuss the general organization of the compiler, and then describe the set of optimization techniques found most useful, based on empirical results gathered by compiling a large set of programs. The compiler and optimization phase are machine independent, in that they generate a stream of instructions for an abstract stack machine, which an assembler subsequently turns into the actual machine instructions. The compiler has been in successful use for several years, producing code for two different instruction sets.",
-		"collection-title": "LFP '80",
-		"container-title": "Proceedings of the 1980 ACM conference on LISP and functional programming",
-		"DOI": "10.1145/800087.802810",
-		"event-place": "New York, NY, USA",
-		"ISBN": "978-1-4503-7396-8",
-		"page": "223–230",
-		"publisher": "Association for Computing Machinery",
-		"publisher-place": "New York, NY, USA",
-		"source": "ACM Digital Library",
-		"title": "Local optimization in a compiler for stack-based Lisp machines",
-		"URL": "https://doi.org/10.1145/800087.802810",
-		"author": [
-			{
-				"family": "Masinter",
-				"given": "Larry M."
-			},
-			{
-				"family": "Deutsch",
-				"given": "L. Peter"
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					4,
-					26
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"1980",
-					8,
-					25
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/TEHSJNIS",
-		"type": "motion_picture",
-		"abstract": "This clip looks at two examples of larger tutorial--CAI systems that were developed by the Ontario Institute for Studies and Education, and Xerox's PARC.\n\nIt is from Episode 7 of the classic 1983 television series, Bits and Bytes, which starred Luba Goy and Billy Van.  It was produced by TVOntario, but is no longer available for purchase.",
-		"dimensions": "5:42",
-		"source": "YouTube",
-		"title": "Computer-Assisted Instruction (Bits and Bytes, Episode 7)",
-		"URL": "https://www.youtube.com/watch?v=eURtTV_qKw8&t=147s",
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					5,
-					2
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"2012",
-					5,
-					19
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/4CCTNX5G",
-		"type": "motion_picture",
-		"abstract": "Reuploaded from: \nhttp://people.csail.mit.edu/riastradh...​\n\nThanks to \"lispm\" on reddit for all the info: \nhttps://www.reddit.com/r/lisp/comment...​\n\nFrom what I understand SEdit was developed later than DEdit. SEdit is documented first in the 1987 Lyric release of Interlisp-D, see Appendix B:\nhttp://bitsavers.trailing-edge.com/pd...​\nSEdit is expanded in the virtual machine version of Interlisp-D, called Medley. See the Medley 1.0 release notes, appendix B:\nhttp://bitsavers.trailing-edge.com/pd...​\nSome hints for using SEdit\nhttp://bitsavers.trailing-edge.com/pd...​\nIf you want to try it out, maybe this contains the editors:\nhttp://www2.parc.com/isl/groups/nltt/...​",
-		"dimensions": "4:53",
-		"publisher": "thoughtupquick",
-		"source": "YouTube",
-		"title": "Lisp Editing in the 80s - Interlisp SEdit",
-		"URL": "https://www.youtube.com/watch?v=2qsmF8HHskg",
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					5,
-					2
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"2017",
-					6,
-					22
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/ZE7EVJYM",
-		"type": "motion_picture",
-		"abstract": "Guy DesVignes and R. Wayne Oldford, 1988 \n \nThis video (in 3 pieces) describes the use of graphical programming with an example, showing the encapsulation of several steps of an analysis into a single reusable tool.   An INTERLISP-D programming environment with the object oriented system LOOPS is used for software development. \nWork is on a Xerox Lisp Workstation  (Xerox 1186). \n \nFirst of 3 pieces of a single video. \n \nFirst piece: Graphical Programming (1988) - Part 0 \n       Contains: \n        \"Opening\"   \n            -  Introduction by a young Wayne Oldford   \n               (refers to earlier video called \"Data Analysis Networks \n                in DINDE\")  \n       \"Part 0 Statistical Analysis Maps\" \n            - review of the interactive data analysis network representation  \n              of a statistical analysis. \n \nSecond piece:  Graphical Programming (1988) - Parts 1 and 2 \n       Contains: \n        \"Part 1   Toolboxes\"   \n            -  Review of the elements of a statistical toolbox in DINDE  \n       \"Part 2 The Analysis Path\" \n            - Demonstrates exploration of a path in an existing \n              analysis map and its representation as a pattern, \n              It is shown how to capture this pattern in DINDE as a new \n             new program represented as an \"AnalysisPath\" object.. \n              This is what is meant by  \"graphical programming\". \n \n \nThird piece: \"Graphical Programming (1988) - Part 3\" \n       Contains: \n        \"Part 3   Graphical Programming \n                        Example: Added Variable Plots\"   \n            - Demonstrates graphical programming by constructing \n              an added variable plot.  This is done by constructing the \n              appropriate analysis path on some data, capturing the pattern \n              adding it to the toolbox and then applying it to new data. \n \n        \"Summary\" \n \n \nSound has been cleaned up a little. \nComplete video also available in whole at  \n        stat-graphics.org/movies/graphical-programming.html",
-		"dimensions": "6:28",
-		"publisher": "Xerox Lisp Workstation",
-		"source": "YouTube",
-		"title": "Graphical Programming (1988) - Part 0",
-		"URL": "https://www.youtube.com/watch?v=J4F6ioMKiqw&t=53s",
-		"author": [
-			{
-				"family": "Oldford",
-				"given": "Wayne"
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					5,
-					2
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"2012",
-					2,
-					16
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/VKU8MPEY",
-		"type": "motion_picture",
-		"abstract": "All the Widgets 2: Menus\nBrad Myers, Carnegie Mellon University\n\nCHI '90 Special Issue: All The Widgets\n\nWEB:: http://www.cs.umd.edu/hcil/chivideosl...​\n\nEditor: Brad Myers (Carnegie Mellon University)\nLocation: Austin, USA",
-		"dimensions": "28:04",
-		"source": "YouTube",
-		"title": "All the Widgets 2: Menus",
-		"title-short": "All the Widgets 2",
-		"URL": "https://www.youtube.com/watch?v=phr1UcEa_B8",
-		"author": [
-			{
-				"literal": "Brad Myers"
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					5,
-					2
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"2021",
-					2,
-					14
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/FJ2M3GNL",
-		"type": "motion_picture",
-		"abstract": "Guy DesVignes and R. Wayne Oldford, 1988 \n \nThis video (in 3 pieces) describes the use of graphical programming with an example, showing the encapsulation of several steps of an analysis into a single reusable tool.   An INTERLISP-D programming environment with the object oriented system LOOPS is used for software development. \nWork is on a Xerox Lisp Workstation  (Xerox 1186). \n \nSecond of 3 pieces of a single video. \n \nFirst piece: Graphical Programming (1988) - Part 0 \n       Contains: \n        \"Opening\"   \n            -  Introduction by Wayne Oldford   \n               (refers to earlier video called \"Data Analysis Networks \n                in DINDE\")  \n       \"Part 0 Statistical Analysis Maps\" \n            - review of the interactive data analysis network representation  \n              of a statistical analysis. \n \nSecond piece:  Graphical Programming (1988) - Parts 1 and 2 \n       Contains: \n        \"Part 1   Toolboxes\"   \n            -  Review of the elements of a statistical toolbox in DINDE  \n       \"Part 2 The Analysis Path\" \n            - Demonstrates exploration of a path in an existing \n              analysis map and its representation as a pattern, \n              It is shown how to capture this pattern in DINDE as a new \n             new program represented as an \"AnalysisPath\" object.. \n              This is what is meant by  \"graphical programming\". \n \n \nThird piece: \"Graphical Programming (1988) - Part 3\" \n       Contains: \n        \"Part 3   Graphical Programming \n                        Example: Added Variable Plots\"   \n            - Demonstrates graphical programming by constructing \n              an added variable plot.  This is done by constructing the \n              appropriate analysis path on some data, capturing the pattern \n              adding it to the toolbox and then applying it to new data. \n \n        \"Summary\" \n \n \nSound has been cleaned up a little. \nComplete video also available in whole at  \n        stat-graphics.org/movies/graphical-programming.html",
-		"dimensions": "11:18",
-		"publisher": "Xerox Lisp Workstation",
-		"source": "YouTube",
-		"title": "Graphical Programming (1988) - Parts 1 and 2",
-		"URL": "https://www.youtube.com/watch?v=wlN0hHLZL8c",
-		"author": [
-			{
-				"family": "Oldford",
-				"given": "Wayne"
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					5,
-					2
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"2012",
-					2,
-					17
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/GWFXGZW7",
-		"type": "motion_picture",
-		"abstract": "Scrollbars, in Interlisp-D, appear on a window only when they are needed.\n\nsrc: https://vimeo.com/61556918​",
-		"dimensions": "5:46",
-		"publisher": "worrydream",
-		"source": "YouTube",
-		"title": "scrollbars",
-		"URL": "https://www.youtube.com/watch?v=Hg4YFuz6HT8",
-		"author": [
-			{
-				"family": "Myers",
-				"given": "Brad"
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					5,
-					2
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"2014",
-					9,
-					26
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/ITWWEVAK",
-		"type": "motion_picture",
-		"abstract": "The Information Lens\nThomas Malone (MIT)\n\nCHI+GI '87 Technical Video Program\n\nAbstract\nAn intelligent system for information sharing and coordination (subtitle from the video)\n\nWEB:: http://www.cs.umd.edu/hcil/chivideosl...​\n\nPublished in two videotapes: issue 27, and issue 33-34 of ACM SIGGRAPH Video Review (issue 27 appeared in same tape as issue 26, i.e. the CHI '87 Electronic Theater).\nVideo Chair: Richard J. Beach (Xerox PARC)\nLocation: Toronto, Canada",
-		"dimensions": "15:24",
-		"event-place": "Toronto, Canada",
-		"publisher": "ACM SIGCHI",
-		"publisher-place": "Toronto, Canada",
-		"source": "YouTube",
-		"title": "The Information Lens",
-		"URL": "https://www.youtube.com/watch?v=o7P0cM5VqKc",
-		"author": [
-			{
-				"family": "Malone",
-				"given": "Thomas W."
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					5,
-					2
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"2021",
-					1,
-					13
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/E6IBZDIA",
-		"type": "motion_picture",
-		"abstract": "We as developers tend to separate our development tools by the stage of the development lifecycle: authoring, executing, building, or deployment. But this limits how much information each tool has at it’s disposal and therefore how much utility it can provide. For example, your IDE can show you the callers of a particular function but because it it’s not involved in running your code it can’t tell you how many times that function failed at runtime. Even worse, we end up with a lot of redundant implementations of the same functions – for example parsers – because it’s easier than sharing the work.\n\nAt Replit we’re growing a holistic development service from the ground up. At first our service just executed user code. Then it gained code intelligence capabilities like Lint. Then it understood the project structure and dependencies. Then it knew how to test code. And now it’s growing to understand deployment. All this within a single service. We envision this to become a long-lived always-on service that understands your code in all it’s stages and can be at your disposal anywhere you are regardless of the device, platform or the programming language you’re using.",
-		"dimensions": "21:40",
-		"source": "YouTube",
-		"title": "Building towards a holistic development service — Amjad Masad",
-		"URL": "https://www.youtube.com/watch?v=w8Pv29pkAvU",
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					5,
-					2
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"2017",
-					5,
-					26
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/7S3TZ2VS",
-		"type": "motion_picture",
-		"abstract": "Being the second oldest high-level language still in widespread use (after Fortran), Lisp is often considered solely as an academic language well-suited for artificial intelligence. It is sometimes accused of having a (very (strange syntax)), only using lists as data types, being difficult to learn, using lots of memory, being inefficient and slow, as well as being dead, an ex-language. This talk, focusing on Common Lisp, aims to show that it is actually an elegant, unique, expressive, fast, extensible language for symbolic computation that is not difficult to learn and may even change the way you think about programming. Lisp is primarily a functional paradigm language, but supports object-oriented, imperative, and other programming models natively. Rapid prototyping, iterative development, multiprocessor development, and creation of domain-specific languages are all facilitated by Lisp. There will be a discussion of the origins and history of Lisp, followed by a demonstration of the language, features that migrated to and from other languages, and concluding with a look to what may be in store for the future.\n\nHosted by Adam Tannir",
-		"dimensions": "50:12",
-		"publisher": "Channel2600",
-		"source": "YouTube",
-		"title": "The Next HOPE (2010): Lisp, The Oldest Language of the Future",
-		"title-short": "The Next HOPE (2010)",
-		"URL": "https://www.youtube.com/watch?v=YwDpjDZOxF0",
-		"author": [
-			{
-				"family": "Tannir",
-				"given": "Adam"
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					5,
-					2
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"2014",
-					1,
-					1
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/W96JCCYH",
-		"type": "paper-conference",
-		"abstract": "DED is a display-oriented editor that was designed to add the power and convenience of display terminals to INTERLISPs teletype-oriented structure editor. DED divides the display screen into a Prettypnnt Region and an Interaction Region. The Prettypnnt Region gives a prettyprinted view of the structure being edited; the Interaction Region contains the interaction between the user and INTERLISPs standard editor. DEDs prettyprinter allows ellision, and the user may zoom in or out to see the expression being edited with more or less detail. There are several arrow keys which allow the user to change quite easily the locus of attention in certain structural ways, as well as a menu-like facility for common command sequences. Together, these features provide a display-facility that considerably augments INTERLISPs otherwise quite sophisticated user interface.",
-		"collection-title": "IJCAI'81",
-		"container-title": "Proceedings of the 7th international joint conference on Artificial intelligence - Volume 2",
-		"event-place": "San Francisco, CA, USA",
-		"page": "927–929",
-		"publisher": "Morgan Kaufmann Publishers Inc.",
-		"publisher-place": "San Francisco, CA, USA",
-		"source": "ACM Digital Library",
-		"title": "Overview of a display-oriented editor for INTERLISP",
-		"URL": "https://dl.acm.org/doi/abs/10.5555/1623264.1623329",
-		"author": [
-			{
-				"family": "Barstow",
-				"given": "David R."
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					5,
-					4
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"1981",
-					8,
-					24
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/7T3AV4PM",
-		"type": "article-journal",
-		"abstract": "Integration, extensibility, and ease of modification made Interlisp unique and powerful. Its adaptations will enhance the power of the coming world of personal computing and advanced displays.",
-		"container-title": "Computer",
-		"DOI": "10.1109/C-M.1981.220410",
-		"ISSN": "0018-9162",
-		"issue": "04",
-		"language": "English",
-		"note": "publisher: IEEE Computer Society",
-		"page": "25-33",
-		"source": "www.computer.org",
-		"title": "The Interlisp Programming Environment",
-		"URL": "https://www.computer.org/csdl/magazine/co/1981/04/01667317/13rRUyv53Ic",
-		"volume": "14",
-		"author": [
-			{
-				"family": "Teitelman",
-				"given": "W."
-			},
-			{
-				"family": "Masinter",
-				"given": "L."
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					5,
-					5
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"1981",
-					4,
-					1
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/MJP8UYEV",
-		"type": "motion_picture",
-		"abstract": "In 1983 the Knowledge Systems Area at Xerox PARC taught experimental courses on knowledge programming. The Truckin' knowledge competition was the final exam at the end of a one week course. Students programmed their trucks to compete in Truckin' simulation world -- buying and selling goods, getting gas as needed, avoiding bandits, and so on. All of the trucks competed in the final. The winner was the truck with the most cash parked nearest Alice's Restaurant. See www.markstefik.com/?page_id=359",
-		"dimensions": "2:28",
-		"source": "YouTube",
-		"title": "Truckin Knowledge Competition (1983)",
-		"URL": "https://www.youtube.com/watch?v=Pt-Sv1ynGKc",
-		"author": [
-			{
-				"literal": "Mark Stefik"
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					5,
-					17
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"2011",
-					4,
-					10
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/PUPZYPIV",
-		"type": "motion_picture",
-		"abstract": "The Colab project at PARC was an experiment in creating an electronic meeting room. This project developed multi-user interfaces, telepointers, and other innovations at the time. This movie shows the Cognoter tool which was a multi-user brainstorming tool used for collaborative development of an outline for a paper. See /www.markstefik.com/?page_id=155\"",
-		"dimensions": "3:23",
-		"source": "YouTube",
-		"title": "The Colab Movie (1987)",
-		"title-short": "The Colab Movie",
-		"URL": "https://www.youtube.com/watch?v=iPZTOosKjAE",
-		"author": [
-			{
-				"literal": "Mark Stefik"
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					5,
-					17
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"2011",
-					4,
-					10
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/DY9YATE2",
-		"type": "chapter",
-		"abstract": "A variety of types of linkages from knowledge bases to databases have been proposed, and a few have been implemented [MW84]. In this research note, we summarize a technique which was employed in a specific context: knowledge extraction from a copy of an existing clinical database. The knowledge base is also used to drive the extracting process. RX builds causal models in its domain to generate input for statistical hypothesis verification. We distinguish two information types: knowledge and data, and recognize four types of knowledge: categorical, definitional, causal (represented in frames), and operational, represented by rules. Based on our experience, we speculate about the generalization of the approach.",
-		"collection-title": "Topics in Information Systems",
-		"container-title": "On Knowledge Base Management Systems: Integrating Artificial Intelligence and Database Technologies",
-		"event-place": "New York, NY",
-		"ISBN": "978-1-4612-4980-1",
-		"language": "en",
-		"note": "DOI: 10.1007/978-1-4612-4980-1_33",
-		"page": "431-444",
-		"publisher": "Springer",
-		"publisher-place": "New York, NY",
-		"source": "Springer Link",
-		"title": "An Integration of Knowledge and Data Representation",
-		"URL": "https://doi.org/10.1007/978-1-4612-4980-1_33",
-		"author": [
-			{
-				"family": "Wiederhold",
-				"given": "Gio"
-			},
-			{
-				"family": "Blum",
-				"given": "Robert L."
-			},
-			{
-				"family": "Walker",
-				"given": "Michael"
-			}
-		],
-		"editor": [
-			{
-				"family": "Brodie",
-				"given": "Micheal L."
-			},
-			{
-				"family": "Mylopoulos",
-				"given": "John"
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					5,
-					29
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"1986"
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/FW3Z9TSW",
-		"type": "report",
-		"abstract": "This report describes the file system for the experimental large file management support system currently being implemented at SRI. INTERLISP, an interactive, development-oriented computer programming system, has been augmented to support applications requiring large data bases maintained on secondary store.  The data base support programs are separated into two levels  an advanced file system and relational data base management procedures. The file system allows programmers to make full use of the capabilities of on-line random access devices using problem related symbolic primitives rather than page and word numbers.  It also performs several useful data storage functions such as data compression, sequencing, and generation of symbols which are unique for a file.",
-		"language": "en",
-		"note": "section: Technical Reports",
-		"publisher": "STANFORD RESEARCH INST MENLO PARK CALIF",
-		"source": "apps.dtic.mil",
-		"title": "An Interlisp Relational Data Base System.",
-		"URL": "https://apps.dtic.mil/sti/citations/ADA018962",
-		"author": [
-			{
-				"family": "Weyl",
-				"given": "Stephen"
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					5,
-					29
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"1975",
-					11,
-					1
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/NPV6XFQB",
-		"type": "report",
-		"abstract": "A preliminary version of QL1SP is described. QLISP permits free intermingling of QA4-like constructs with INTERLISP code. The preliminary version contains features similar to those of QA4 except for the backtracking of control environments. It provides several new features as well. This preliminary manual presumes a familiarity with both INTERL1SPand the basic concepts of QA4. It is intended to update rather than replace the existing documentation of QA4.",
-		"language": "en",
-		"note": "section: Technical Reports",
-		"page": "38",
-		"publisher": "Stanford Research Institute Menlo Park United States",
-		"source": "apps.dtic.mil",
-		"title": "A Preliminary QLISP Manual",
-		"URL": "https://apps.dtic.mil/sti/citations/AD1015722",
-		"author": [
-			{
-				"family": "Reboh",
-				"given": "Rene"
-			},
-			{
-				"family": "Sacerdoti",
-				"given": "Earl"
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					5,
-					29
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"1973",
-					8,
-					1
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/GI8MCHKF",
-		"type": "paper-conference",
-		"abstract": "This paper describes the development of LISP from McCarthy's first research in the topic of programming languages for AI until the stage when the LISP1 implementation had developed into a serious program (May 1959). We show the steps that led to LISP and the various proposals for LISP interpreters (between November 1958 and May 1959). The paper contains some correcting details to our book (32).",
-		"collection-title": "LFP '84",
-		"container-title": "Proceedings of the 1984 ACM Symposium on LISP and functional programming",
-		"DOI": "10.1145/800055.802047",
-		"event-place": "New York, NY, USA",
-		"ISBN": "978-0-89791-142-3",
-		"page": "299–310",
-		"publisher": "Association for Computing Machinery",
-		"publisher-place": "New York, NY, USA",
-		"source": "ACM Digital Library",
-		"title": "Early LISP history (1956 - 1959)",
-		"URL": "https://doi.org/10.1145/800055.802047",
-		"author": [
-			{
-				"family": "Stoyan",
-				"given": "Herbert"
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					5,
-					29
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"1984",
-					8,
-					6
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/QXZFUW4U",
-		"type": "article-journal",
-		"abstract": "This paper presents the design of an Interlisp system running on a microprogrammed minicomputer. We discuss the constraints imposed by compatibility requirements and by the hardware, the important design decisions, and the most prominent successes and failures of our design, and offer some suggestions for future designers of small Lisp systems. This extended abstract contains only qualitative results. Supporting measurement data will be presented at MICRO-11.",
-		"container-title": "ACM SIGMICRO Newsletter",
-		"DOI": "10.1145/1014198.804321",
-		"ISSN": "1050-916X",
-		"issue": "4",
-		"journalAbbreviation": "SIGMICRO Newsl.",
-		"page": "128–129",
-		"source": "Dec. 1978",
-		"title": "Experience with a microprogrammed Interlisp system",
-		"URL": "https://doi.org/10.1145/1014198.804321",
-		"volume": "9",
-		"author": [
-			{
-				"family": "Deutsch",
-				"given": "L. Peter"
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					5,
-					31
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"1978",
-					11,
-					19
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/8SMP58AA",
-		"type": "paper-conference",
-		"abstract": "This paper describes in detail the most interesting aspects of ByteLisp, a transportable Lisp system architecture which implements the Interlisp dialect of Lisp, and its first implementation, on a microprogrammed minicomputer called the Alto. Two forthcoming related papers will deal with general questions of Lisp machine and system architecture, and detailed measurements of the Alto ByteLisp system described here. A highly condensed summary of the series was published at MICRO-11 in November 197815.",
-		"collection-title": "LFP '80",
-		"container-title": "Proceedings of the 1980 ACM conference on LISP and functional programming",
-		"DOI": "10.1145/800087.802811",
-		"event-place": "New York, NY, USA",
-		"ISBN": "978-1-4503-7396-8",
-		"page": "231–242",
-		"publisher": "Association for Computing Machinery",
-		"publisher-place": "New York, NY, USA",
-		"source": "ACM Digital Library",
-		"title": "ByteLisp and its Alto implementation",
-		"URL": "https://doi.org/10.1145/800087.802811",
-		"author": [
-			{
-				"family": "Deutsch",
-				"given": "L. Peter"
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					5,
-					31
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"1980",
-					8,
-					25
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/MSBZ5IMI",
-		"type": "article",
-		"abstract": "Interlisp began with an implementation of the Lisp programming language for the PDP-1 at Bolt. Beranek and Newman in 1966. It was followed in 1967 by 940 Lisp, an upward compatible implementation for\nthe SDS-940 computer. 940 Lisp was the first Lisp system to demonstrate the feasibility of using software paging techniques and a large vinual memory in conjunction with a list-processing system [Bobrow & ( -----\\\n) Murphy, 1967]. 940 Lisp was patterned after the Lisp 1.5 ~plementation for CTSS at MIT, with several' ) 1ew facilities added to take advantage of its timeshared. on-line environment. DWIM, the Do-What+\nMean error correction facility, was introduced into this system in 1968 by Warren Teitelman [Teitelman. 1969].",
-		"language": "English",
-		"note": "OCLC: 802551877",
-		"publisher": "Xerox Corporation",
-		"source": "Open WorldCat",
-		"title": "Interlisp reference manual",
-		"title-short": "Interlisp reference manual",
-		"URL": "https://larrymasinter.net/86-interlisp-manual-opt.pdf",
-		"author": [
-			{
-				"literal": "Xerox"
-			}
-		],
-		"issued": {
-			"date-parts": [
-				[
-					"1983",
-					10
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/L378BFRQ",
-		"type": "book",
-		"event-place": "Palo Alto Research Center, Pasadena, Calif.",
-		"language": "English",
-		"note": "OCLC: 11098633",
-		"publisher": "Xerox Corp.",
-		"publisher-place": "Palo Alto Research Center, Pasadena, Calif.",
-		"source": "Open WorldCat",
-		"title": "Interlisp reference manual: Revised",
-		"author": [
-			{
-				"literal": "Michael Sannella"
-			},
-			{
-				"literal": "Xerox"
-			},
-			{
-				"literal": "Palo Alto Research Center"
-			}
-		],
-		"issued": {
-			"date-parts": [
-				[
-					"1983"
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/JP52RFKS",
-		"type": "report",
-		"event-place": "Palo Alto",
-		"language": "eng",
-		"page": "2",
-		"publisher": "PARC/CSL",
-		"publisher-place": "Palo Alto",
-		"source": "Internet Archive",
-		"title": "Status Report on Alto Lisp",
-		"title-short": "xerox",
-		"URL": "http://www.bitsavers.org/pdf/xerox/alto/memos_1975/Status_Report_on_Alto_Lisp_May75.pdf",
-		"author": [
-			{
-				"family": "Deutsch",
-				"given": "P."
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					5,
-					31
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"1975",
-					5,
-					14
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/NQXP9QH8",
-		"type": "paper-conference",
-		"abstract": "This paper presents a machine designed for compact representation and rapid execution of LISP programs. The machine language is a factor of 2 to 5 more compact than S-expressions or conventional compiled code, and the compiler is extremely simple. The encoding scheme is potentially applicable to data as well as program. The machine also provides for user-defined data structures.",
-		"collection-title": "IJCAI'73",
-		"container-title": "Proceedings of the 3rd international joint conference on Artificial intelligence",
-		"event-place": "San Francisco, CA, USA",
-		"page": "697–703",
-		"publisher": "Morgan Kaufmann Publishers Inc.",
-		"publisher-place": "San Francisco, CA, USA",
-		"source": "ACM Digital Library",
-		"title": "A LISP machine with very compact programs",
-		"URL": "https://dl.acm.org/doi/abs/10.5555/1624775.1624860",
-		"author": [
-			{
-				"family": "Deutsch",
-				"given": "L. Peter"
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					5,
-					31
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"1973",
-					8,
-					20
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/JEW9IHTC",
-		"type": "article",
-		"language": "English",
-		"publisher": "Xerox Palo Alto Research Center",
-		"title": "INSIDE INTERLISP: TWO IMPLEMENTATIONS",
-		"URL": "http://www.softwarepreservation.org/projects/LISP/interlisp/Deutsch-Inside_Interlisp-1978.pdf",
-		"author": [
-			{
-				"family": "Deutsch",
-				"given": "L. Peter"
-			}
-		],
-		"issued": {
-			"date-parts": [
-				[
-					"1978",
-					11,
-					26
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/25TEJPHA",
-		"type": "article",
-		"abstract": "The Xerox Common Lisp Implementation Notes cover several aspects of the Lyric release. In these notes you will find:\n• An explanation of how Xerox Common Lisp extends the Common Lisp standard. For example, in Xerox Common Lisp the Common Lisp array-constructing function make-array has additional keyword\narguments that enhance its functionality.\n• An explanation of how several ambiguities in Steele's Common Lisp: the Language were\nresolved.\n• A description of additional features that provide far more than extensions to Common Lisp.",
-		"language": "English",
-		"publisher": "XEROX",
-		"title": "XEROX COMMON LISP IMPLEMENTATION NOTES",
-		"title-short": "IMPLEMENTATION NOTES",
-		"URL": "http://www.bitsavers.org/pdf/xerox/interlisp-d/198706_Lyric/3102464_Lyric_Common_Lisp_Implementation_Notes_Jun87.pdf",
-		"author": [
-			{
-				"literal": "Anonymous"
-			}
-		],
-		"issued": {
-			"date-parts": [
-				[
-					"1987",
-					6
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/YEUXRBGZ",
-		"type": "article",
-		"language": "en",
-		"publisher": "Xerox Corporation",
-		"title": "Artificial Intelligence Systems, Interlisp-D: A Friendly Primer",
-		"URL": "http://www.bitsavers.org/pdf/xerox/interlisp-d/198510_Koto/3102300_Interlisp-D_A_Friendly_Primer_Nov86.pdf",
-		"author": [
-			{
-				"literal": "Xerox"
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					4,
-					23
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"1986",
-					11
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/YC65PT77",
-		"type": "article",
-		"abstract": "The Koto release of Interlisp-D provides a wide range of added functionality, increased performance and improved reliability Central among these is that Koto is the first release of Interlisp that supports the new Xerox 1185i1186 artificial i nteil igence work stations, including the new features of these work stations such as the expanded 19\" display and the PC emulation option. Of course, like previous releases of Interlisp, Koto also supports the other current members of the 1100 series of machines, specifically the 1132 and various models of the 1108.",
-		"language": "English",
-		"publisher": "Xerox Corporation",
-		"title": "INTERLISP-D RELEASE NOTES",
-		"URL": "http://www.bitsavers.org/pdf/xerox/interlisp-d/198706_Lyric/3102464_Lyric_Common_Lisp_Implementation_Notes_Jun87.pdf",
-		"author": [
-			{
-				"literal": "Anonymous"
-			}
-		],
-		"issued": {
-			"date-parts": [
-				[
-					"1985",
-					12
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/DXD65IKD",
-		"type": "book",
-		"event-place": "S.l.",
-		"language": "English",
-		"note": "OCLC: 802551877",
-		"number-of-pages": "296",
-		"publisher": "Xerox Corporation",
-		"publisher-place": "S.l.",
-		"source": "Open WorldCat",
-		"title": "Interlisp-D Reference Manual, Volume I: Language",
-		"title-short": "Volume I: Language",
-		"URL": "http://www.bitsavers.org/pdf/xerox/interlisp-d/198510_Koto/3101272_Interlisp-D_Vol_1_Language_Oct85.pdf",
-		"volume": "1",
-		"editor": [
-			{
-				"family": "Sannella",
-				"given": "Michael"
-			}
-		],
-		"issued": {
-			"date-parts": [
-				[
-					"1985",
-					10
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/PUQ8EKTK",
-		"type": "book",
-		"event-place": "S.l.",
-		"language": "English",
-		"note": "OCLC: 802551877",
-		"number-of-pages": "436",
-		"publisher": "Xerox Corporation",
-		"publisher-place": "S.l.",
-		"source": "Open WorldCat",
-		"title": "Interlisp-D Reference Manual, Volume II: Environment",
-		"title-short": "Volume II: Environment",
-		"URL": "http://www.bitsavers.org/pdf/xerox/interlisp-d/198510_Koto/3101273_Interlisp-D_Vol_2_Environment_Oct85.pdf",
-		"volume": "2",
-		"editor": [
-			{
-				"family": "Sannella",
-				"given": "Michael"
-			}
-		],
-		"issued": {
-			"date-parts": [
-				[
-					"1985",
-					10
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/6D2EJDZD",
-		"type": "book",
-		"event-place": "S.l.",
-		"language": "English",
-		"note": "OCLC: 802551877",
-		"number-of-pages": "388",
-		"publisher": "Xerox Corporation",
-		"publisher-place": "S.l.",
-		"source": "Open WorldCat",
-		"title": "Interlisp-D Reference Manual, Volume III: Input/Output",
-		"title-short": "Volume III: Input/Output",
-		"URL": "http://www.bitsavers.org/pdf/xerox/interlisp-d/198510_Koto/3101274_Interlisp-D_Vol_3_Input_Output_Oct85.pdf",
-		"volume": "3",
-		"editor": [
-			{
-				"family": "Sannella",
-				"given": "Michael"
-			}
-		],
-		"issued": {
-			"date-parts": [
-				[
-					"1985",
-					10
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/3H5F6TBA",
-		"type": "paper-conference",
-		"abstract": "This paper continues and extends previous work by the author in developing systems which provide the user with various forms of explicit and implicit assistance, and in general cooperate with the user in the development of his programs. The system described in this paper makes extensive use of a bit map display and pointing device (a mouse) to significantly enrich the user's interactions with the system, and to provide capabilities not possible with terminals that essentially emulate hard copy devices. For example, any text that is displayed on the screen can be pointed at and treated as input, exactly as though it were typed, i.e., the user can say use this expression or that value, and then simply point. The user views his programming environment through a collection of display windows, each of which corresponds to a different task or context. The user can manipulate the windows, or the contents of a particular window, by a combination of keyboard inputs or pointing operations. The technique of using different windows for different tasks makes it easy for the user to manage several simultaneous tasks and contexts, e.g., defining programs, testing programs, editing, asking the system for assistance, sending and receiving messages, etc and to switch back and forth between these tasks at his convenience.",
-		"collection-title": "IJCAI'77",
-		"container-title": "Proceedings of the 5th international joint conference on Artificial intelligence - Volume 2",
-		"event-place": "San Francisco, CA, USA",
-		"page": "905–915",
-		"publisher": "Morgan Kaufmann Publishers Inc.",
-		"publisher-place": "San Francisco, CA, USA",
-		"source": "ACM Digital Library",
-		"title": "A display oriented programmer's assistant",
-		"URL": "https://dl.acm.org/doi/10.5555/1622943.1623025",
-		"author": [
-			{
-				"family": "Teitelman",
-				"given": "Warren"
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					5,
-					31
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"1977",
-					8,
-					22
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/IZ6P44N3",
-		"type": "article-journal",
-		"abstract": "This paper continues and extends previous work by the author in developing systems which provide the user with various forms of explicit and implicit assistance, and in general co-operate with the user in the development of his programs. The system described in this paper makes extensive use of a bit map display and pointing device (a mouse) to significantly enrich the user's interactions with the system, and to provide capabilities not possible with terminals that essentially emulate hard copy devices. For example, any text that is displayed on the screen can be pointed at and treated as input, exactly as though it were typed, i.e. the user can say use this expression or that value, and then simply point. The user views his programming environment through a collection of display windows, each of which corresponds to a different task or context. The user can manipulate the windows, or the contents of a particular window, by a combination of keyboard inputs or pointing operations. The technique of using different windows for different tasks makes it easy for the user to manage several simultaneous tasks and contexts, e.g. defining programs, testing programs, editing, asking the system for assistance, sending and receiving messages, etc. and to switch back and forth between these tasks at his convenience.",
-		"container-title": "International Journal of Man-Machine Studies",
-		"DOI": "10.1016/S0020-7373(79)80015-2",
-		"ISSN": "0020-7373",
-		"issue": "2",
-		"journalAbbreviation": "International Journal of Man-Machine Studies",
-		"language": "en",
-		"page": "157-187",
-		"source": "ScienceDirect",
-		"title": "A display oriented programmer's assistant",
-		"URL": "https://www.sciencedirect.com/science/article/pii/S0020737379800152",
-		"volume": "11",
-		"author": [
-			{
-				"family": "Teitelman",
-				"given": "Warren"
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					5,
-					31
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"1979",
-					3,
-					1
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/VCQ8JN33",
-		"type": "article-journal",
-		"abstract": "This paper gives a tutorial introduction to INTERLISP/360-370, a subset of INTERLISP, which can be implemented on IBM/360 and\nsimilar systems. oe·scriptions of a large number of functions in INTERLISP with numerous examples, exercises and solutions are contained. The use of edit, break, advice, file handling and compiler are given and both interactive and batch use of the system is taken care of.",
-		"container-title": "Oatalogi1aboratoriet, Sturegatan 1. S-752 23 Uppsala, -Sweden",
-		"ISSN": "9150600346",
-		"language": "English",
-		"page": "217",
-		"title": "LISP-details INTERLlSP / 360 - 370",
-		"URL": "http://www.softwarepreservation.org/projects/LISP/uppsala/Haraldson-LISP_details.pdf",
-		"author": [
-			{
-				"literal": "Anders Haraidson"
-			}
-		],
-		"issued": {
-			"date-parts": [
-				[
-					"1975"
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/QBBQSH3V",
-		"type": "article-journal",
-		"abstract": "Clisp is an attempt to make Lisp programs easier to read and write by extending the syntax of Lisp to include infix operators, IF-THEN statements, FOR-DO-WHILE statements, and similar Algol-like constructs, without changing the structure or representation of the language. Clisp is implemented through Lisp's error handling machinery, rather than by modifying the interpreter. When an expression is encountered whose evaluation causes an error, the expression is scanned for possible Clisp constructs, which are then converted to the equivalent Lisp expressions. Thus, users can freely intermix Lisp and Clisp without ut having to distinguish which is which. Emphasis in the design and development of Clisp has been on the system aspects of such a facility, with the goal of producing a useful tool, not just another language. To this end, Clisp includes interactive error correction and many \"do-what-I-mean\" features.",
-		"container-title": "IEEE Transactions on Computers",
-		"DOI": "10.1109/TC.1976.1674617",
-		"ISSN": "0018-9340",
-		"issue": "4",
-		"note": "event: IEEE Transactions on Computers",
-		"page": "354-357",
-		"source": "IEEE Xplore",
-		"title": "Clisp: Conversational Lisp",
-		"title-short": "Clisp",
-		"URL": "http://www.softwarepreservation.org/projects/LISP/interlisp/Teitelman-3IJCAI.pdf/view",
-		"volume": "C-25",
-		"author": [
-			{
-				"family": "Teitelman",
-				"given": "Warren"
-			}
-		],
-		"issued": {
-			"date-parts": [
-				[
-					"1976",
-					4
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/QWKIX8DW",
-		"type": "paper-conference",
-		"abstract": "This paper describes a research effort and programming system designed to facilitate the production of programs. Unlike automated programming, which focuses on developing systems that write programs, automated programmering involves developing systems which automate (or at least greatly facilitate) those tasks that a programmer performs other than writing programs: e.g., repairing syntactical errors to get programs to run in the first place, generating test cases, making tentative changes, retesting, undoing changes, reconfiguring, massive edits, et al., plus repairing and recovering from mistakes made during the above. When the system in which the programmer is operating is cooperative and helpful with respect to these activities, the programmer can devote more time and energy to the task of programming itself, i.e., to conceptualizing, designing and implementing. Consequently, he can be more ambitious, and more productive.",
-		"collection-title": "AFIPS '72 (Fall, part II)",
-		"container-title": "Proceedings of the December 5-7, 1972, fall joint computer conference, part II",
-		"DOI": "10.1145/1480083.1480119",
-		"event-place": "New York, NY, USA",
-		"ISBN": "978-1-4503-7913-7",
-		"page": "917–921",
-		"publisher": "Association for Computing Machinery",
-		"publisher-place": "New York, NY, USA",
-		"source": "ACM Digital Library",
-		"title": "Automated programmering: the programmer's assistant",
-		"title-short": "Automated programmering",
-		"URL": "https://doi.org/10.1145/1480083.1480119",
-		"author": [
-			{
-				"family": "Teitelman",
-				"given": "Warren"
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					5,
-					31
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"1972",
-					12,
-					5
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/RQWU8ZW9",
-		"type": "article-journal",
-		"abstract": "PILOT is a programming system constructed  in LISP. It is designed to facilitate the  development of programs by easing the  familiar sequence: write some code, run the  program, make some changes, write some  more code, run the program again, etc. As a  program becomes more complex, making  these changes becomes harder and harder  because the implications of changes are  harder to anticipate. In the PILOT system, the  computer plays an active role in this  evolutionary process by providing the means  whereby changes can be effected  immediately, and in ways that seem natural to  the user. The user of PILOT feels that he is  giving advice, or making suggestions, to the  computer about the operation of his  programs, and that the system then performs  the work necessary. The PILOT system is  thus an interface between the user and his  program, monitoring both in the requests of  the user and operation of his program. The  user may easily modify the PILOT system  itself by giving it advice about its own  operation. This allows him to develop his own  language and to shift gradually onto PILOT the  burden of performing routine but increasingly  complicated tasks. In this way, he can  concentrate on the conceptual difficulties in  the original problem, rather than on the  niggling tasks of editing, rewriting, or adding  to his programs. Two detailed examples are  presented. PILOT is a first step toward  computer systems that will help man to  formulate problems in the same way they now  help him to solve them. Experience with it  supports the claim that such \"symbiotic  systems\" allow the programmer to attack and  solve more difficult problems.",
-		"language": "en_US",
-		"note": "Accepted: 2004-10-20T20:06:03Z",
-		"page": "199",
-		"source": "dspace.mit.edu",
-		"title": "PILOT: A Step Toward Man-Computer Symbiosis",
-		"title-short": "PILOT",
-		"URL": "https://dspace.mit.edu/handle/1721.1/6905",
-		"author": [
-			{
-				"family": "Teitelman",
-				"given": "Warren"
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					5,
-					31
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"1966",
-					9,
-					1
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/Y73ECKA4",
-		"type": "article-journal",
-		"container-title": "IEEE Intelligent Systems",
-		"DOI": "10.1109/MEX.1987.4307102",
-		"ISSN": "1541-1672",
-		"issue": "03",
-		"language": "English",
-		"note": "publisher: IEEE Computer Society",
-		"page": "94-94",
-		"source": "www.computer.org",
-		"title": "Review of Interlisp: The Language and Its Usage",
-		"title-short": "Interlisp",
-		"URL": "https://www.computer.org/csdl/magazine/ex/1987/03/04307102/1e7uj6wTMVG",
-		"volume": "2",
-		"author": [
-			{
-				"family": "Gladwin",
-				"given": "Lee A."
-			},
-			{
-				"family": "Gladwin",
-				"given": "Lee A."
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					5,
-					31
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"1987",
-					7,
-					1
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/59BVIIF8",
-		"type": "report",
-		"abstract": "The INTERLISP Virtual Machine is the environment in which the INTERLISP System is implemented. It includes such abstract objects as ~Literal Atom s~. List CelIs~, ‘Integers. etc.. the basic LISP functions for manipulating them, the underlying program control, and variable binding mechanisms. the input/output facilities, and interrupt processing facilities. In order to implement the INTERLISP System (as described in The INTERLISP Reference Manual by W. Teitelman. et. al.) on some physical machine, it is only necessary to implement the INTERLISP Virtual Machine. since Virtual Machine compatible source code for the rest of the INTERLISP System can be obtained from publicly available files. This document specifies the behavior of the INTERLISP Virtual Machine from the implementor s point of view. That is. it is an attempt to make explicit those things that must be implemented to allow the INTERLISP System to run on some machine.",
-		"page": "126",
-		"source": "CiteSeer",
-		"title": "The INTERLISP Virtual Machine Specification: Revised",
-		"URL": "http://www.cs.utexas.edu/~moore/publications/interlisp-vm.pdf",
-		"author": [
-			{
-				"family": "Moore",
-				"given": "J. Strother"
-			}
-		],
-		"issued": {
-			"date-parts": [
-				[
-					"1979",
-					3
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/K4LSMPDE",
-		"type": "article",
-		"abstract": "Several conflicting goal must be resolved in deciding on a set of display facilities for Lisp: ease of lisp, efficient access to hardware facilities, and device and system independence. Thiss memo suggests a set of facilities constructed in two layers: a lower layer that gives direct access to the Alto\nbitmap capability, while retaining Lisp's tradition of freeing the programmer\nfrom  storage allocation worries and an upper Iayer that uses the lower (on the Alto) or a character-stream protocol (for VTS t on MAXC) to provide for writing strings, scrolling, edting, etc. on the screen,",
-		"publisher": "Palo Alto Research Center, Xerox Corporation",
-		"title": "Display primitives in Lisp",
-		"URL": "http://www.bitsavers.org/pdf/xerox/alto/memos_1974/Display_Primitives_in_Lisp_Nov74.pdf",
-		"author": [
-			{
-				"family": "Deutsch",
-				"given": "P."
-			}
-		],
-		"issued": {
-			"date-parts": [
-				[
-					"1974",
-					11,
-					18
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/RTRAYUTG",
-		"type": "article",
-		"language": "English",
-		"title": "930 LISP Reference Manual",
-		"URL": "http://bitsavers.org/pdf/sds/9xx/940/ucbProjectGenie/30.50.40_930_LISP_Reference_Feb66.pdf",
-		"author": [
-			{
-				"family": "Deutsch",
-				"given": "L. Peter"
-			},
-			{
-				"family": "Lampson",
-				"given": "Butler W."
-			}
-		],
-		"issued": {
-			"date-parts": [
-				[
-					"1965",
-					6,
-					5
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/KVDN9PE5",
-		"type": "article-journal",
-		"abstract": "Eliza is a program operating within the MAC time-sharing systemm at MIT which makes certain kinds of natural language conversation between man and computer possible. Input sentences are analyzed on the basis of decomposition rules which are triggered by key words appearing in the input text. Responsesare generated by reassembly rules associated with selected decomposition rules. The fundamental technical problems with which ELIZA is concerned are: (1) the identification of key words, (2) the discovery of minimal context, (3) the choice of appropriate transformations, (4) generation of reponses in the abscence of key words, and (5) the provision of an editing capability for ELIZA \"scripts\". A discussion of some pyschological issues relevant to the ELIZA approach as well as of future developments concludes the paper.",
-		"container-title": "Communications of the ACM",
-		"DOI": "10.1145/365153.365168",
-		"ISSN": "0001-0782",
-		"issue": "1",
-		"journalAbbreviation": "Commun. ACM",
-		"page": "36–45",
-		"source": "Jan. 1966",
-		"title": "ELIZA, a computer program for the study of natural language communication between man and machine",
-		"URL": "https://doi.org/10.1145/365153.365168",
-		"volume": "9",
-		"author": [
-			{
-				"family": "Weizenbaum",
-				"given": "Joseph"
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					5,
-					31
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"1966",
-					1,
-					1
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/6M8ISEUL",
-		"type": "article",
-		"language": "English",
-		"title": "Preliminary Specification for BBN 940 LISP",
-		"URL": "http://www.softwarepreservation.org/projects/LISP/bbnlisp/BBN940LispPrelimSpec_Oct1966.pdf",
-		"author": [
-			{
-				"literal": "Daniel G. Bobrow"
-			},
-			{
-				"literal": "Daniel L. Murphy"
-			}
-		],
-		"issued": {
-			"date-parts": [
-				[
-					"1966",
-					10,
-					13
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/LQQWKMEZ",
-		"type": "paper-conference",
-		"abstract": "This article describes a notation and a programming language for expressing, from within a LISP system, string transformations such as those performed in COMIT or SNOBOL. A simple transformation (or transformation rule) is specified by providing a pattern which must match the structure to be transformed and a format which specifies how to construct a new structure according to the segmentation specified by the pattern. The patterns and formats are greatly generalized versions of the left-half and right-half rules of COMIT and SNOBOL. For example, elementary patterns and formats can be variable names, results of computations, disjunctive sets, or repeating subpatterns; predicates can be associated with elementary patterns which check relationships among separated elements of the match; it is no longer necessary to restrict the operations to linear strings since elementary patterns can themselves match structures. The FLIP language has been implemented in LISP 1.5, and has been successfully used in such disparate tasks as editing LISP functions and parsing Kleene regular expressions.",
-		"collection-title": "SYMSAC '66",
-		"container-title": "Proceedings of the first ACM symposium on Symbolic and algebraic manipulation",
-		"DOI": "10.1145/800005.807968",
-		"event-place": "New York, NY, USA",
-		"ISBN": "978-1-4503-7371-5",
-		"page": "0301–0329",
-		"publisher": "Association for Computing Machinery",
-		"publisher-place": "New York, NY, USA",
-		"source": "ACM Digital Library",
-		"title": "Format-directed list processing in LISP",
-		"URL": "https://doi.org/10.1145/800005.807968",
-		"author": [
-			{
-				"family": "Bobrow",
-				"given": "Daniel G."
-			},
-			{
-				"family": "Teitelman",
-				"given": "Warren"
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					5,
-					31
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"1966",
-					1,
-					1
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/Y8FT8NIV",
-		"type": "article",
-		"abstract": "A program has been written for the PDP-1 providing a subset of the features of the LISP interpreter for the IBM 709/7090. This program, which contains no known bugs, will run on any PDP-1 with automatic divide. On machines with more than 4K of memory, it must be run in memory field 0.\n\nIt is assumed that the reader is familiar with 709 LISP in general and with the LISP 1.5 Programmer's Manual in particular.",
-		"title": "PDP-1 Lisp",
-		"URL": "http://www.bitsavers.org/pdf/mit/rle_pdp1/memos/Deutsch_PDP-1_LISP.pdf",
-		"author": [
-			{
-				"family": "Deutsch",
-				"given": "L. Peter"
-			}
-		],
-		"issued": {
-			"date-parts": [
-				[
-					"1960"
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/ZK7MFMNE",
-		"type": "article",
-		"abstract": "The editor described here is implemented within the PDP-l and SDS 940 time-sharing LISP systems, but can be used with minor changes within any LISP system which includes the capabilities of LISP 1.5. It was begun by the author in 1965 and later extended by Bobrow and Teitelman at BBN.",
-		"title": "Preliminary Guide to the LISP Editor",
-		"URL": "http://www.softwarepreservation.org/projects/LISP/bbnlisp/W-21_LISP_Editor_Apr67.pdf/view",
-		"author": [
-			{
-				"family": "Deutsch",
-				"given": "P."
-			}
-		],
-		"issued": {
-			"date-parts": [
-				[
-					"1967",
-					4,
-					18
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/V8B837IJ",
-		"type": "paper-conference",
-		"abstract": "LISP has survived for 21 years because it is an approximate local optimum in the space of programming languages. However, it has accumulated some barnacles that should be scraped off, and some long-standing opportunities for improvement have been neglected. It would benefit from some co-operative maintenance especially in creating and maintaining program libraries. Computer checked proofs of program correctness are now possible for pure LISP and some extensions, but more theory and some smoothing of the language itself are required before we can take full advantage of LISP's mathematical basis.",
-		"collection-title": "LFP '80",
-		"container-title": "Proceedings of the 1980 ACM conference on LISP and functional programming",
-		"DOI": "10.1145/800087.802782",
-		"event-place": "New York, NY, USA",
-		"ISBN": "978-1-4503-7396-8",
-		"language": "en",
-		"page": ".5–viii",
-		"publisher": "Association for Computing Machinery",
-		"publisher-place": "New York, NY, USA",
-		"source": "ACM Digital Library",
-		"title": "LISP - notes on its past and future",
-		"URL": "https://doi.org/10.1145/800087.802782",
-		"author": [
-			{
-				"family": "McCarthy",
-				"given": "John"
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					6,
-					2
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"1980",
-					8,
-					25
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/RI94XGIV",
-		"type": "paper-conference",
-		"abstract": "I acknowledge the help of David Elsweiler to get this paper more readable.",
-		"collection-title": "LISP50",
-		"container-title": "Celebrating the 50th Anniversary of Lisp",
-		"DOI": "10.1145/1529966.1529969",
-		"event-place": "New York, NY, USA",
-		"ISBN": "978-1-60558-383-9",
-		"page": "1–2",
-		"publisher": "Association for Computing Machinery",
-		"publisher-place": "New York, NY, USA",
-		"source": "ACM Digital Library",
-		"title": "Lisp 50 years ago",
-		"URL": "https://doi.org/10.1145/1529966.1529969",
-		"author": [
-			{
-				"family": "Stoyan",
-				"given": "Herbert"
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					6,
-					2
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"2008",
-					10,
-					20
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/WJ7DBZTL",
-		"type": "paper-conference",
-		"abstract": "LISP (for LISt Processor) is a programming system for the IBM 704 being developed by the Artificial Intelligence Group at MIT. We are developing it in order to program the Advice Taker which is to be a system for instructing a machine in a combination of declarative and imperative sentences.",
-		"collection-title": "ACM '59",
-		"container-title": "Preprints of papers presented at the 14th national meeting of the Association for Computing Machinery",
-		"DOI": "10.1145/612201.612243",
-		"event-place": "New York, NY, USA",
-		"ISBN": "978-1-4503-7364-7",
-		"page": "1–4",
-		"publisher": "Association for Computing Machinery",
-		"publisher-place": "New York, NY, USA",
-		"source": "ACM Digital Library",
-		"title": "LISP: a programming system for symbolic manipulations",
-		"title-short": "LISP",
-		"URL": "https://doi.org/10.1145/612201.612243",
-		"author": [
-			{
-				"family": "McCarthy",
-				"given": "John"
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					6,
-					2
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"1959",
-					9,
-					1
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/YDK5V6XM",
-		"type": "article-journal",
-		"abstract": "Introduction The Common Lisp Object System is an object-oriented extension to Common Lisp as defined in Common Lisp: The Language, by Guy L. Steele Jr. It is based on generic functions, multiple inheritance, declarative method combination, and a meta-object protocol. The first two chapters of this specification present a description of the standard Programmer Interface for the Common Lisp Object System. The first chapter contains a description of the concepts of the Common Lisp Object System, and the second contains a description of the functions and macros in the Common Lisp Object System Programmer Interface. The chapter \"The Common Lisp Object System Meta-Object Protocol\" describes how the Common Lisp Object System can be customized. The fundamental objects of the Common Lisp Object System are classes, instances, generic functions, and methods. A class object determines the structure and behavior of a set of other objects, which are called its instances. Every Common Lisp object is an instance of a class. The class of an object determines the set of operations that can be performed on the object. A generic function is a function whose behavior depends on the classes or identities of the arguments supplied to it. A generic function object contains a set of methods, a lambda-list, a method combination type, and other information. The methods define the class-specific behavior and operations of the generic function; a method is said to specialize a generic function. When invoked, a generic function executes a subset of its methods based on the classes of its arguments. A generic function can be used in the same ways that an ordinary function can be used in Common Lisp; in particular, a generic function can be used as an argument to funcall and apply and can be given a global or a local name. A method is an object that contains a method function, a sequence of parameter speclalizers that specify when the given method is applicable, and a sequence of qualifiers that is used by the method combination facility to distinguish among methods. Each required formal parameter of each method has an associated parameter specializer, and the method will be invoked only on arguments that satisfy its parameter specializers. The method combination facility controls the selection of methods, the order in which they are run, and the values that are returned by the generic function. The Common Lisp Object System offers a default method combination type and provides a facility for declaring new types of method combination.",
-		"collection-title": "Common Lisp Object System Specification X3JI3 Document 88-002R",
-		"container-title": "ACM SIGPLAN Notices",
-		"DOI": "10.1145/885631.885632",
-		"ISSN": "0362-1340",
-		"issue": "SI",
-		"journalAbbreviation": "SIGPLAN Not.",
-		"page": "1–142",
-		"source": "September 1988",
-		"title": "Common Lisp Object System specification",
-		"URL": "https://doi.org/10.1145/885631.885632",
-		"volume": "23",
-		"author": [
-			{
-				"family": "Bobrow",
-				"given": "Daniel G."
-			},
-			{
-				"family": "DeMichiel",
-				"given": "Linda G."
-			},
-			{
-				"family": "Gabriel",
-				"given": "Richard P."
-			},
-			{
-				"family": "Keene",
-				"given": "Sonya E."
-			},
-			{
-				"family": "Kiczales",
-				"given": "Gregor"
-			},
-			{
-				"family": "Moon",
-				"given": "David A."
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					6,
-					2
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"1988",
-					9,
-					1
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/HP2N2EKF",
-		"type": "article-journal",
-		"abstract": "New directions in Artifical Intelligence research have led to the need for certain novel features to be embedded in programming languages. This paper gives an overview of the nature of these features, and their implementation in four principal families of AI languages: SAIL; PLANNER/CONNIVER;QLIPS/INTERLISP; and POPLER/POP-2. The programming feature described include: new data types and accessing mechanisms for stored expressions; matching to allow caomparison of data item with a template, and extraction of labeled subexpressions; and deductive mechanisms which allow the programming system to carry out certain activities including modifying the data base and deciding which subroutines to run next using only constraints and guidelines set up by the programmer.",
-		"container-title": "ACM Computing Surveys",
-		"DOI": "10.1145/356631.356632",
-		"ISSN": "0360-0300",
-		"issue": "3",
-		"journalAbbreviation": "ACM Comput. Surv.",
-		"page": "153–174",
-		"source": "Sept. 1974",
-		"title": "New Programming Languages for Artificial Intelligence Research",
-		"URL": "https://doi.org/10.1145/356631.356632",
-		"volume": "6",
-		"author": [
-			{
-				"family": "Bobrow",
-				"given": "Daniel G."
-			},
-			{
-				"family": "Raphael",
-				"given": "Bertram"
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					6,
-					2
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"1974",
-					9,
-					1
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/PVEEX4BT",
-		"type": "report",
-		"abstract": "Conversion of the LogLispLogic programming in Lisp Artificial Intelligence programming environment from its original RutgersUCI-Lisp RUCI-Lisp implementation to an InterLisp implementation is described. This report may be useful to researchers wishing to convert LogLisp to yet another Lisp dialect, or to those wishing to convert other RUCI-Lisp programs into InterLisp. It is also intended to help users of the InterLisp version of LogLisp to understand the implementation. The conversion process is described at a level aimed toward potential translators who might benefit from approaches taken and lessons learned. General issues of conversion of Lisp software between dialects are discussed, use of InterLisps dialect translation package is described, and specific issues of non-mechanizable conversion are addressed. The latter include dialect differences in function definitions, arrays, integer arithmetic, io, interrupts, and macros. Subsequent validation, compilation, and efficiency enhancement of the InterLisp version are then described. A brief users guide to the InterLisp version and points of contact for information on LogLisp software distribution are also provided. Author",
-		"language": "en",
-		"note": "section: Technical Reports",
-		"publisher": "ROME AIR DEVELOPMENT CENTER GRIFFISS AFB NY",
-		"source": "apps.dtic.mil",
-		"title": "Notes on the Conversion of LogLisp from Rutgers/UCI-Lisp to InterLisp,",
-		"URL": "https://apps.dtic.mil/sti/citations/ADA127718",
-		"author": [
-			{
-				"family": "Schrag",
-				"given": "Robert C."
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					6,
-					2
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"1983",
-					1,
-					1
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/GCAQS8MG",
-		"type": "report",
-		"abstract": "The contract covered by this annual report includes a variety of activities and services centering around the continued growth and well-being of INTERLISP, a large, interactive system widely used in the ARPA community for developing advanced and sophisticated computer-based systems.",
-		"language": "en",
-		"note": "section: Technical Reports",
-		"publisher": "XEROX CORP PALO ALTO RESEARCH CENTER CA",
-		"source": "apps.dtic.mil",
-		"title": "Proposal for Research on Interlisp and Network-Based Systems",
-		"URL": "https://apps.dtic.mil/sti/citations/ADA033633",
-		"author": [
-			{
-				"family": "Teitelman",
-				"given": "W."
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					6,
-					2
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"1976",
-					10,
-					26
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/H6NZGEIH",
-		"type": "paper-conference",
-		"abstract": "As the need for high-speed computers increases, the need for multi-processors will be become more apparent. One of the major stumbling blocks to the development of useful multi-processors has been the lack of a good multi-processing language—one which is both powerful and understandable to programmers. Among the most compute-intensive programs are artificial intelligence (AI) programs, and researchers hope that the potential degree of parallelism in AI programs is higher than in many other applications. In this paper we propose multi-processing extensions to Lisp. Unlike other proposed multi-processing Lisps, this one provides only a few very powerful and intuitive primitives rather than a number of parallel variants of familiar constructs.",
-		"collection-title": "LFP '84",
-		"container-title": "Proceedings of the 1984 ACM Symposium on LISP and functional programming",
-		"DOI": "10.1145/800055.802019",
-		"event-place": "New York, NY, USA",
-		"ISBN": "978-0-89791-142-3",
-		"page": "25–44",
-		"publisher": "Association for Computing Machinery",
-		"publisher-place": "New York, NY, USA",
-		"source": "ACM Digital Library",
-		"title": "Queue-based multi-processing LISP",
-		"URL": "https://doi.org/10.1145/800055.802019",
-		"author": [
-			{
-				"family": "Gabriel",
-				"given": "Richard P."
-			},
-			{
-				"family": "McCarthy",
-				"given": "John"
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					6,
-					2
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"1984",
-					8,
-					6
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/BNAYT94G",
-		"type": "paper-conference",
-		"abstract": "This paper reports on recent developments of the ISI- Interlisp implementation of Interlisp on a VAX computer. ISI-Interlisp currently runs under UNIX, specifically the Berkeley VM/UNIX and VMS operating systems. Particular attention is paid to the current status of the implementation and the growing pains experienced in the last few years. Included is a discussion of the conversion from UNIX to VAX/VMS, recent modifications and improvements, current limitations, and projected goals. Since much of the recent effort has concerned performance tuning, our observations on this activity are included. ISI-Interlisp, formerly known as Interlisp-VAX, was reported in 1982 ACM Symposium on LISP and Functional Programming, August 1982 [1]. Experiences and recommendations since the 1982 LISP conference are presented.",
-		"collection-title": "LFP '84",
-		"container-title": "Proceedings of the 1984 ACM Symposium on LISP and functional programming",
-		"DOI": "10.1145/800055.802029",
-		"event-place": "New York, NY, USA",
-		"ISBN": "978-0-89791-142-3",
-		"page": "129–139",
-		"publisher": "Association for Computing Machinery",
-		"publisher-place": "New York, NY, USA",
-		"source": "ACM Digital Library",
-		"title": "Recent developments in ISI-interlisp",
-		"URL": "https://doi.org/10.1145/800055.802029",
-		"author": [
-			{
-				"family": "Bates",
-				"given": "Raymond L."
-			},
-			{
-				"family": "Dyer",
-				"given": "David"
-			},
-			{
-				"family": "Feber",
-				"given": "Mark"
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					6,
-					2
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"1984",
-					8,
-					6
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/P5MUCJX3",
-		"type": "article-journal",
-		"abstract": "One of the major stumbling blocks to more effective used computers by naive users is the lack of natural means of communication between the user and the computer system. This report discusses a paradigm for constructing efficient and friendly man-machine interface systems involving subsets of natural language for limited domains of discourse. As such this work falls somewhere between highly constrained formal language query systems and unrestricted natural language under-standing systems. The primary purpose of this research is not to advance our theoretical under-standing of natural language but rather to put forth a set of techniques for embedding both semantic/conceptual and pragmatic information into a useful natural language interface module. Our intent has been to produce a front end system which enables the user to concentrate on his problem or task rather than making him worry about how to communicate his ideas or questions to the machine.",
-		"container-title": "ACM SIGART Bulletin",
-		"DOI": "10.1145/1045283.1045290",
-		"ISSN": "0163-5719",
-		"issue": "61",
-		"journalAbbreviation": "SIGART Bull.",
-		"language": "en",
-		"page": "26",
-		"source": "February 1977",
-		"title": "Semantic grammar: an engineering technique for constructing natural language understanding systems",
-		"title-short": "Semantic grammar",
-		"URL": "https://doi.org/10.1145/1045283.1045290",
-		"author": [
-			{
-				"family": "Burton",
-				"given": "Richard R."
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					6,
-					2
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"1977",
-					2,
-					1
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/CEQUK2WU",
-		"type": "chapter",
-		"abstract": "Shifting is the process of moving data in a storage device relative to the boundaries of the device (as opposed to moving it in and out of the device). The device in which the shift is performed is called a shift register. In order to discuss the various modes of the shift operation, we assume that the register in which the shift is to be performed is n bits wide, and number the bits from left to right, 1...n.",
-		"container-title": "Encyclopedia of Computer Science",
-		"event-place": "United Kingdom",
-		"ISBN": "0-470-86412-8",
-		"page": "1572–1573",
-		"publisher": "John Wiley and Sons Ltd.",
-		"publisher-place": "United Kingdom",
-		"source": "ACM Digital Library",
-		"title": "Shifting",
-		"URL": "https://dl.acm.org/doi/abs/10.5555/1074100.1074788",
-		"author": [
-			{
-				"family": "Frieder",
-				"given": "Gideon"
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					6,
-					2
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"2003",
-					1,
-					1
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/J67QXUEA",
-		"type": "paper-conference",
-		"abstract": "This paper describes the design and motivations behind the Desert environment. The Desert environment has been created to demonstrate that the facilities typically associated with expensive data integration can be provided inexpensively in an open framework. It uses three integration mechanisms: control integration, simple data integration based on fragments, and a common editor. It offers a variety of capabilities including hyperlinks and the ability to create virtual files containing only the portions of the software that are relevant to the task on hand. It does this in an open environment that is compatible with existing tools and programs. The environment currently consists of a set of support facilities including a context database, a fragment database, scanners, and a ToolTalk interface, as well as a preliminary set of programming tools including a context manager and extensions to FrameMaker to support program editing and insets for non-textual software artifacts.",
-		"collection-title": "ICSE '96",
-		"container-title": "Proceedings of the 18th international conference on Software engineering",
-		"event-place": "USA",
-		"ISBN": "9780818672463",
-		"page": "398–407",
-		"publisher": "IEEE Computer Society",
-		"publisher-place": "USA",
-		"source": "ACM Digital Library",
-		"title": "Simplifying data integration: the design of the desert software development environment",
-		"title-short": "Simplifying data integration",
-		"URL": "https://dl.acm.org/doi/10.5555/227726.227811",
-		"author": [
-			{
-				"family": "Reiss",
-				"given": "Steven P."
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					6,
-					2
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"1996",
-					5,
-					1
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/9IIYFLFK",
-		"type": "article-journal",
-		"abstract": "This paper describes an experience with Lisp as an extension language for a large electronics CAD environment and the role it plays in software design automation. This paper is not about extension languages in general, for an analysis of extension languages in CAD, see, [HNS90] and [Bar89]. Cadence is a full range supplier of software based Electronics CAD tools.",
-		"container-title": "ACM SIGPLAN Lisp Pointers",
-		"DOI": "10.1145/174169.174185",
-		"ISSN": "1045-3563",
-		"issue": "3",
-		"journalAbbreviation": "SIGPLAN Lisp Pointers",
-		"language": "en",
-		"page": "71–79",
-		"source": "July-Sept 1993",
-		"title": "SKILL: a Lisp based extension language",
-		"title-short": "SKILL",
-		"URL": "https://doi.org/10.1145/174169.174185",
-		"volume": "VI",
-		"author": [
-			{
-				"family": "Petrus",
-				"given": "Edwin S."
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					6,
-					2
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"1993",
-					7,
-					1
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/36TCME67",
-		"type": "report",
-		"abstract": "Storage allocation, maintenance, and reclamation are handled automatically in LISP systems.  Storage is allocated as needed, and a garbage collection process periodically reclaims storage no longer in use.  A number of different garbage collection algorithms are described.  A common property of most of these algorithms is that during garbage collection all other computation ceases.  This is an untenable situation for programs which must respond to real time interrupts.  The paper concludes with a proposal for an incremental garbage collection scheme which allows simultaneous computation and storage reclamation.  Author",
-		"event-place": "Cambridge, MA",
-		"language": "en",
-		"note": "section: Technical Reports",
-		"publisher": "BOLT BERANEK AND NEWMAN INC",
-		"publisher-place": "Cambridge, MA",
-		"source": "apps.dtic.mil",
-		"title": "Storage management in LISP",
-		"URL": "https://apps.dtic.mil/sti/citations/AD0636049",
-		"author": [
-			{
-				"family": "Bobrow",
-				"given": "Daniel G."
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					6,
-					2
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"1966",
-					6,
-					1
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/AA2LK9EE",
-		"type": "paper-conference",
-		"abstract": "The Common Lisp Object System is an object-oriented system that is based on the concepts of generic functions, multiple inheritance, and method combination. All objects in the Object System are instances of classes that form an extension to the Common Lisp type system. The Common Lisp Object System is based on a meta-object protocol that renders it possible to alter the fundamental structure of the Object System itself. The Common Lisp Object System has been proposed as a standard for ANSI Common Lisp and has been tentatively endorsed by X3J13.",
-		"collection-title": "Lecture Notes in Computer Science",
-		"container-title": "ECOOP’ 87 European Conference on Object-Oriented Programming",
-		"DOI": "10.1007/3-540-47891-4_15",
-		"event-place": "Berlin, Heidelberg",
-		"ISBN": "978-3-540-47891-1",
-		"language": "en",
-		"page": "151-170",
-		"publisher": "Springer",
-		"publisher-place": "Berlin, Heidelberg",
-		"source": "Springer Link",
-		"title": "The Common Lisp Object System: An Overview",
-		"title-short": "The Common Lisp Object System",
-		"author": [
-			{
-				"family": "DeMichiel",
-				"given": "Linda G."
-			},
-			{
-				"family": "Gabriel",
-				"given": "Richard P."
-			}
-		],
-		"editor": [
-			{
-				"family": "Bézivin",
-				"given": "Jean"
-			},
-			{
-				"family": "Hullot",
-				"given": "Jean-Marie"
-			},
-			{
-				"family": "Cointe",
-				"given": "Pierre"
-			},
-			{
-				"family": "Lieberman",
-				"given": "Henry"
-			}
-		],
-		"issued": {
-			"date-parts": [
-				[
-					"1987"
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/JSW29WAW",
-		"type": "article-journal",
-		"abstract": "Lisp is the world's greatest programming language—or so its proponents think. The structure of Lisp makes it easy to extend the language or even to implement entirely new dialects without starting from scratch. Overall, the evolution of Lisp has been guided more by institutional rivalry, one-upsmanship, and the glee born of technical cleverness that is characteristic of the “hacker culture” than by sober assessments of technical requirements. Nevertheless this process has eventually produced both an industrial-strength programming language, messy but powerful, and a technically pure dialect, small but powerful, that is suitable for use by programming-language theoreticians. We pick up where McCarthy's paper in the first HOPL conference left off. We trace the development chronologically from the era of the PDP-6, through the heyday of Interlisp and MacLisp, past the ascension and decline of special purpose Lisp machines, to the present era of standardization activities. We then examine the technical evolution of a few representative language features, including both some notable successes and some notable failures, that illuminate design issues that distinguish Lisp from other programming languages. We also discuss the use of Lisp as a laboratory for designing other programming languages. We conclude with some reflections on the forces that have driven the evolution of Lisp.",
-		"container-title": "ACM SIGPLAN Notices",
-		"DOI": "10.1145/155360.155373",
-		"ISSN": "0362-1340",
-		"issue": "3",
-		"journalAbbreviation": "SIGPLAN Not.",
-		"language": "English",
-		"page": "231–270",
-		"source": "March 1993",
-		"title": "The evolution of Lisp",
-		"URL": "https://doi.org/10.1145/155360.155373",
-		"volume": "28",
-		"author": [
-			{
-				"family": "Steele",
-				"given": "Guy L."
-			},
-			{
-				"family": "Gabriel",
-				"given": "Richard P."
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					6,
-					2
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"1993",
-					3,
-					1
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/JEBHSFXU",
-		"type": "chapter",
-		"container-title": "Artificial intelligence and mathematical theory of computation: papers in honor of John McCarthy",
-		"event-place": "USA",
-		"ISBN": "978-0-12-450010-5",
-		"page": "409–426",
-		"publisher": "Academic Press Professional, Inc.",
-		"publisher-place": "USA",
-		"source": "ACM Digital Library",
-		"title": "The influence of the designer on the design—J. McCarthy and LISP",
-		"URL": "https://dl.acm.org/doi/abs/10.5555/132218.132242",
-		"author": [
-			{
-				"family": "Stoyan",
-				"given": "Herbert"
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					6,
-					2
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"1991",
-					9,
-					1
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/RV6K2EVG",
-		"type": "thesis",
-		"abstract": "Abstract machine definitions have been recognized as convenient and powerful tools for enhancing software portability. One such machine, the Inter lisp Virtual Machine, is examined in this thesis. We present the Multilisp System as an implementation of the Virtual Machine and discuss some of the design criteria and difficulties encountered in mapping the Virtual Machine onto a particular environment. On the basis of our experience with Multilisp we indicate several weaknesses of the Virtual Machine which impair its adequacy as a basis for a portable Interlisp System.",
-		"language": "eng",
-		"note": "DOI: 10.14288/1.0051801",
-		"publisher": "University of British Columbia",
-		"source": "open.library.ubc.ca",
-		"title": "The interlisp virtual machine: study of its design and its implementation as multilisp",
-		"title-short": "The interlisp virtual machine",
-		"URL": "https://open.library.ubc.ca/cIRcle/collections/ubctheses/831/items/1.0051801",
-		"author": [
-			{
-				"family": "Koomen",
-				"given": "Johannes A. G. M."
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					6,
-					2
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"1980"
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/68LHCGJF",
-		"type": "book",
-		"abstract": "The final report of the Stanford Lisp Performance Study, Performance and Evaluation of Lisp Systems is the first book to present descriptions on Lisp implementation techniques actually in use. It provides performance information using the tools of benchmarking to measure the various Lisp systems, and provides an understanding of the technical tradeoffs made during the implementation of a Lisp system. The study is divided into three parts. The first provides the theoretical background, outlining the factors that go into evaluating the performance of a Lisp system. The second part presents the Lisp implementations: MacLisp, MIT CADR, LMI Lambda, S-I Lisp, Franz Lisp, MIL, Spice Lisp, Vax Common Lisp, Portable Standard Lisp, and Xerox D-Machine. A final part describes the benchmark suite that was used during the major portion of the study and the results themselves.",
-		"event-place": "USA",
-		"ISBN": "978-0-262-07093-5",
-		"number-of-pages": "285",
-		"publisher": "Massachusetts Institute of Technology",
-		"publisher-place": "USA",
-		"source": "ACM Digital Library",
-		"title": "Performance and evaluation of LISP systems",
-		"URL": "https://dreamsongs.com/Files/Timrep.pdf",
-		"author": [
-			{
-				"family": "Gabriel",
-				"given": "Richard P."
-			}
-		],
-		"issued": {
-			"date-parts": [
-				[
-					"1985",
-					1,
-					1
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/XYRSF7QU",
-		"type": "paper-conference",
-		"abstract": "This abstract describes the design and implementation of pL isp, a Lisp dialect and integrated development environment modeled on Smalltalk that targets beginners",
-		"collection-title": "ELS2018",
-		"container-title": "Proceedings of the 11th European Lisp Symposium on European Lisp Symposium",
-		"event-place": "Marbella, Spain",
-		"ISBN": "978-2-9557474-2-1",
-		"page": "66–67",
-		"publisher": "European Lisp Scientific Activities Association",
-		"publisher-place": "Marbella, Spain",
-		"source": "ACM Digital Library",
-		"title": "pLisp: A Friendly Lisp IDE for Beginners",
-		"title-short": "pLisp",
-		"URL": "https://dl.acm.org/doi/10.5555/3323215.3323224",
-		"author": [
-			{
-				"family": "Jayaprakash",
-				"given": "Rajesh"
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					6,
-					2
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"2018",
-					4,
-					16
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/3QK929A2",
-		"type": "chapter",
-		"abstract": "This chapter discusses the power tools for programmers. Essentially, all of the intelligent programming tools described in this volume are at most experimental prototypes. Given that these tools are still quite far from being commercial realities, it is worthwhile to note that there is a completely different way in which artificial intelligence research has to help programmers. Artificial intelligence researchers are themselves programmers. Creating such programs is more a problem of exploration than implementation and does not conform to conventional software lifecycle models. The artificial intelligence programming community has always been faced with this kind of exploratory programming and has, therefore, had a head start on developing appropriate language, environment, and hardware features. Redundancy protects the design from unintentional change, the conventional programming technology restrains the programmer, and the programming languages used in exploratory systems minimize and defer constraints on the programmer.",
-		"container-title": "Readings in Artificial Intelligence and Software Engineering",
-		"ISBN": "978-0-934613-12-5",
-		"language": "en",
-		"note": "DOI: 10.1016/B978-0-934613-12-5.50048-3",
-		"page": "573-580",
-		"publisher": "Morgan Kaufmann",
-		"source": "ScienceDirect",
-		"title": "POWER TOOLS FOR PROGRAMMERS",
-		"title-short": "DATAMATION®",
-		"URL": "https://www.sciencedirect.com/science/article/pii/B9780934613125500483",
-		"author": [
-			{
-				"family": "Sheil",
-				"given": "Beau"
-			}
-		],
-		"editor": [
-			{
-				"family": "Rich",
-				"given": "Charles"
-			},
-			{
-				"family": "Waters",
-				"given": "Richard C."
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					6,
-					2
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"1986",
-					1,
-					1
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/VCGVB4XT",
-		"type": "article-journal",
-		"abstract": "Many applications written in garbage collected languages have large dynamic working sets and poor data locality. We present a new system for continuously improving program data locality at run time with low overhead. Our system proactively reorganizes the heap by leveraging the garbage collector and uses profile information collected through a low-overhead mechanism to guide the reorganization at run time. The key contributions include making a case that garbage collection should be viewed as a proactive technique for improving data locality by triggering garbage collection for locality optimization independently of normal garbage collection for space, combining page and cache locality optimization in the same system, and demonstrating that sampling provides sufficiently detailed data access information to guide both page and cache locality optimization with low runtime overhead. We present experimental results obtained by modifying a commercial, state-of-the-art garbage collector to support our claims. Independently triggering garbage collection for locality optimization significantly improved optimizations benefits. Combining page and cache locality optimizations in the same system provided larger average execution time improvements (17%) than either alone (page 8%, cache 7%). Finally, using sampling limited profiling overhead to less than 3%, on average.",
-		"container-title": "ACM SIGPLAN Notices",
-		"DOI": "10.1145/1133255.1134021",
-		"ISSN": "0362-1340",
-		"issue": "6",
-		"journalAbbreviation": "SIGPLAN Not.",
-		"page": "332–340",
-		"source": "June 2006",
-		"title": "Profile-guided proactive garbage collection for locality optimization",
-		"URL": "https://doi.org/10.1145/1133255.1134021",
-		"volume": "41",
-		"author": [
-			{
-				"family": "Chen",
-				"given": "Wen-ke"
-			},
-			{
-				"family": "Bhansali",
-				"given": "Sanjay"
-			},
-			{
-				"family": "Chilimbi",
-				"given": "Trishul"
-			},
-			{
-				"family": "Gao",
-				"given": "Xiaofeng"
-			},
-			{
-				"family": "Chuang",
-				"given": "Weihaw"
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					6,
-					2
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"2006",
-					6,
-					11
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/42SVX3YY",
-		"type": "article-journal",
-		"abstract": "Lisp systems have been used for highly interactive programming for more than a decade. During that time, special properties of the Lisp language (such as program/ data equivalence) have enabled a certain style of interactive programming to develop. characterized by powerful interactive support for the programmer, nonstandard program structures, and nonstandard program development methods. The paper summa-rizes the Lisp style of interactive programming for readers outside the Lisp community, describes those properties of Lisp systems that were essential for the development of this style. and discusses some current and not yet resolved issues",
-		"container-title": "ACM Computing Surveys",
-		"DOI": "10.1145/356715.356719",
-		"ISSN": "0360-0300",
-		"issue": "1",
-		"journalAbbreviation": "ACM Comput. Surv.",
-		"page": "35–71",
-		"source": "March 1978",
-		"title": "Programming in an Interactive Environment: the \"Lisp\" Experience",
-		"title-short": "Programming in an Interactive Environment",
-		"URL": "https://doi.org/10.1145/356715.356719",
-		"volume": "10",
-		"author": [
-			{
-				"family": "Sandewall",
-				"given": "Erik"
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					6,
-					2
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"1978",
-					3,
-					1
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/SYHYTLHH",
-		"type": "patent",
-		"abstract": "A computer-based tool, in the form of a computer system and method, for designing, constructing and interacting with any system containing or comprising concurrent asychronous processes, such as a factory operation. In the system according to the invention a variety of development and execution tools are supported. The invention features a highly visual user presentation of a control system, including structure, specification, and operation, offering a user an interactive capability for rapid design, modification, and exploration of the operating characteristics of a control system comprising asynchronous processes. The invention captures a representation of the system (RS) that is equivalent to the actual system (AS)--rather than a simulation of the actual system. This allows the invention to perform tests and modification on RS instead of AS, yet get accurate results. RS and AS are equivalent because AS is generated directly from RS by an automated process. Effectively, pressing a button in the RS environment can \"create\" the AS version or any selected portion of it, by \"downloading\" a translation of the RS version that can be executed by a programmable processor in the AS environment. Information can flow both ways between AS and RS. That AS and RS can interact is important. This allows RS to \"take on\" the \"state\" of AS whenever desired, through an \"uploading\" procedure, thereby reflecting accurately the condition of AS at a specific point in time.",
-		"authority": "United States",
-		"call-number": "US07/261,953",
-		"number": "US4914567A",
-		"title": "Design system using visual language",
-		"URL": "https://patents.google.com/patent/US4914567A/en",
-		"author": [
-			{
-				"family": "Lipkis",
-				"given": "Thomas A."
-			},
-			{
-				"family": "Mark",
-				"given": "William S."
-			},
-			{
-				"family": "Pirtle",
-				"given": "Melvin W."
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					6,
-					1
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"1990",
-					4,
-					3
-				]
-			]
-		},
-		"submitted": {
-			"date-parts": [
-				[
-					"1988",
-					10,
-					24
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/KXVS2RBT",
-		"type": "patent",
-		"abstract": "Workspaces provided by an object-based user interface appear to share windows and other display objects. Each workspace's data structure includes, for each window in that workspace, a linking data structure called a placement which links to the display system object which provides that window, which may be a display system object in a preexisting window system. The placement also contains display characteristics of the window when displayed in that workspace, such as position and size. Therefore, a display system object can be linked to several workspaces by a placement in each of the workspaces' data structures, and the window it provides to each of those workspaces can have unique display characteristics, yet appear to the user to be the same window or versions of the same window. As a result, the workspaces appear to be sharing a window. Workspaces can also appear to share a window if each workspace's data structure includes data linking to another workspace with a placement to the shared window. The user can invoke a switch between workspaces by selecting a display object called a door, and a back door to the previous workspace is created automatically so that the user is not trapped in a workspace. A display system object providing a window to a workspace being left remains active so that when that workspace is reentered, the window will have the same contents as when it disappeared. Also, the placements of a workspace are updated so that when the workspace is reentered its windows are organized the same as when the user left that workspace. The user can enter an overview display which shows a representation of each workspace and the windows it contains so that the user can navigate to any workspace from the overview.",
-		"authority": "United States",
-		"call-number": "US07/030,766",
-		"number": "US5072412A",
-		"title": "User interface with multiple workspaces for sharing display system objects",
-		"URL": "https://patents.google.com/patent/US5072412A/en",
-		"author": [
-			{
-				"family": "Henderson",
-				"given": "D. Austin"
-			},
-			{
-				"family": "Card",
-				"given": "Stuart K."
-			},
-			{
-				"family": "Maxwell",
-				"given": "John T."
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					6,
-					1
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"1991",
-					12,
-					10
-				]
-			]
-		},
-		"submitted": {
-			"date-parts": [
-				[
-					"1987",
-					3,
-					25
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/ELBQRBKS",
-		"type": "patent",
-		"abstract": "A text-compression technique utilizes a plurality of word-number mappers (\"WNMs\") in a frequency-ordered hierarchical structure. The particular structure of the set of WNMs depends on the specific encoding regime, but can be summarized as follows. Each WNM in the set is characterized by an ordinal WNM number and a WNM size (maximum number of tokens) that is in general a non-decreasing function of the WNM number. A given token is assigned a number pair, the first being one of the WNM numbers, and the second being the token's position or number in that WNM. Typically, the most frequently occurring tokens are mapped with a smaller-numbered WNM. The set of WNMs is generated on a first pass through the database to be compressed. The database is parsed into tokens, and a rank-order list based on the frequency of occurrence is generated. This list is partitioned in a manner to define the set of WNMs. Actual compression of the data base occurs on a second pass, using the set of WNMs generated on the first pass. The database is parsed into tokens, and for each token, the set of WNMs is searched to find the token. Once the token is found, it is assigned the appropriate number pair and is encoded. This proceeds until the entire database has been compressed.",
-		"authority": "United States",
-		"call-number": "US07/942,665",
-		"number": "US5325091A",
-		"title": "Text-compression technique using frequency-ordered array of word-number mappers",
-		"URL": "https://patents.google.com/patent/US5325091A/en",
-		"author": [
-			{
-				"family": "Kaplan",
-				"given": "Ronald M."
-			},
-			{
-				"family": "Maxwell",
-				"given": "John T. III"
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					6,
-					1
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"1994",
-					6,
-					28
-				]
-			]
-		},
-		"submitted": {
-			"date-parts": [
-				[
-					"1992",
-					9,
-					9
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/PX3PWI8C",
-		"type": "patent",
-		"abstract": "A declarative object-oriented approach to menu construction provides a mechanism for specifying the behavior, appearance and function of menus as part of an interactive user interface. Menus are constructed from interchangeable object building blocks to obtain the characteristics wanted without the need to write new code or code and maintaining a coherent interface standard. The approach is implemented by dissecting interface menu behavior into modularized objects specifying orthogonal components of desirable menu behaviors. Once primary characteristics for orthogonal dimensions of menu behavior are identified, individual objects are constructed to provide specific alternatives for the behavior within the definitions of each dimension. Finally, specific objects from each dimension are combined to construct a menu having the desired selections of menu behaviors.",
-		"authority": "United States",
-		"call-number": "US07/754,366",
-		"number": "US5119475A",
-		"title": "Object-oriented framework for menu definition",
-		"URL": "https://patents.google.com/patent/US5119475A/en",
-		"author": [
-			{
-				"family": "Smith",
-				"given": "Reid G."
-			},
-			{
-				"family": "Schoen",
-				"given": "Eric J."
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					6,
-					1
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"1992",
-					6,
-					2
-				]
-			]
-		},
-		"submitted": {
-			"date-parts": [
-				[
-					"1991",
-					8,
-					29
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/C4NIHH58",
-		"type": "patent",
-		"abstract": "A computer user interface includes a mechanism of graphically representing and displaying user-definable objects of multiple types. The object types that can be represented include data records, not limited to a particular kind of data, and agents. An agent processes information automatically on behalf of the user. Another mechanism allows a user to define objects, for example by using a template. These two mechanisms act together to allow each object to be displayed to the user and acted upon by the user in a uniform way regardless of type. For example, templates for defining objects allow a specification to be input by a user defining processing that can be performed by an agent.",
-		"authority": "United States",
-		"call-number": "US08/484,415",
-		"number": "US5790116A",
-		"title": "Object-oriented computer user interface",
-		"URL": "https://patents.google.com/patent/US5790116A/en",
-		"author": [
-			{
-				"family": "Malone",
-				"given": "Thomas W."
-			},
-			{
-				"family": "Lai",
-				"given": "Kum-Yew"
-			},
-			{
-				"family": "Yu",
-				"given": "Keh-Chiang"
-			},
-			{
-				"family": "Berenson",
-				"given": "Richard W."
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					6,
-					1
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"1998",
-					8,
-					4
-				]
-			]
-		},
-		"submitted": {
-			"date-parts": [
-				[
-					"1995",
-					6,
-					7
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/J62GHLSJ",
-		"type": "patent",
-		"abstract": "An apparatus and a method are disclosed for composing an imposition in terms of an arrangement of printing plates on selected of the image positions on selected units of a printing press to print a given edition, by first assigning each section of this edition to one of the press areas. Thereafter, each printing unit is examined to determine an utilization value thereof in terms of the placement of the printing plates on the image positions and the relative number of image positions to which printing plates are assigned with respect to the total number of image positions. Thereafter, a list of the image positions for each of the sections and its area, is constructed by examining one printing unit at a time in an order according to the placement of that printing unit in the array and examining its utilization value to determine whether or not to include a particular image position of that printing unit in the list. As a result, a list of the image positions is constructed in a sequence corresponding to numerical order of the pages in the section under consideration. Finally, that list of the image positions and the corresponding section and page numbers is displayed in a suitable fashion to inform a user of how to place the printing plates in the desired arrangement onto the printing units of the press to print this given edition.",
-		"authority": "United States",
-		"call-number": "US07/105,159",
-		"number": "US4984773A",
-		"title": "Method of and apparatus for composing a press imposition",
-		"URL": "https://patents.google.com/patent/US4984773A/en",
-		"author": [
-			{
-				"family": "Balban",
-				"given": "Morton S."
-			},
-			{
-				"family": "Lan",
-				"given": "Ming-Shong"
-			},
-			{
-				"family": "Panos",
-				"given": "Rodney M."
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					6,
-					1
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"1991",
-					1,
-					15
-				]
-			]
-		},
-		"submitted": {
-			"date-parts": [
-				[
-					"1987",
-					10,
-					6
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/7MK4IUTY",
-		"type": "patent",
-		"authority": "European Union",
-		"call-number": "EP89312093A",
-		"language": "en",
-		"number": "EP0370778B1",
-		"title": "Method for manipulating digital text data",
-		"URL": "https://patents.google.com/patent/EP0370778B1/en",
-		"author": [
-			{
-				"family": "Nunberg",
-				"given": "Geoffrey D."
-			},
-			{
-				"family": "Stansbury",
-				"given": "Tayloe H."
-			},
-			{
-				"family": "Abbott",
-				"given": "Curtis"
-			},
-			{
-				"family": "Smith",
-				"given": "Brian C."
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					6,
-					1
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"1998",
-					6,
-					3
-				]
-			]
-		},
-		"submitted": {
-			"date-parts": [
-				[
-					"1989",
-					11,
-					21
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/78B7IS7F",
-		"type": "patent",
-		"abstract": "A method and apparatus are shown for improving bit-image quality in video display terminals and xerographic processors. In one embodiment, each scan line of a source image is ANDed with the scan line above to remove half-bits and thin halftones. In other embodiments, entire blocks of data are processed by bit-block transfer operations, such as ANDing a copy of the source image with a copy of itself shifted by one bit. Also, a source image can be compared to a shifted copy of itself to locate diagonal lines in order to place gray pixels bordering these lines.",
-		"authority": "United States",
-		"call-number": "US07/636,395",
-		"number": "US5250934A",
-		"title": "Method and apparatus for thinning printed images",
-		"URL": "https://patents.google.com/patent/US5250934A/en",
-		"author": [
-			{
-				"family": "Denber",
-				"given": "Michel J."
-			},
-			{
-				"family": "Jankowski",
-				"given": "Henry P."
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					6,
-					1
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"1993",
-					10,
-					5
-				]
-			]
-		},
-		"submitted": {
-			"date-parts": [
-				[
-					"1990",
-					12,
-					31
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/HZ2DEN8T",
-		"type": "patent",
-		"abstract": "A method and apparatus are described for a programming language with fully undoable, timed reactive instructions. More specifically, the present invention relates to providing a multi-modal user interface for controlling the execution of fully undoable programs. An embodiment of the present invention includes a method for providing a multi-modal user interface that is enabled to control the order of execution of a program having fully undoable instructions using checkpoints associated with discrete locations within the program.",
-		"authority": "United States",
-		"call-number": "US10/465,884",
-		"number": "US7734958B1",
-		"title": "Method and apparatus for a programming language having fully undoable, timed reactive instructions",
-		"URL": "https://patents.google.com/patent/US7734958B1/en",
-		"author": [
-			{
-				"family": "Fabbrizio",
-				"given": "Giuseppe Di"
-			},
-			{
-				"family": "Klarlund",
-				"given": "Nils"
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					6,
-					1
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"2010",
-					6,
-					8
-				]
-			]
-		},
-		"submitted": {
-			"date-parts": [
-				[
-					"2003",
-					6,
-					20
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/5QACWN9U",
-		"type": "patent",
-		"abstract": "A system and method for interactive design of user manipulable graphic elements. A computer has display and stored tasks wherein the appearance of graphic elements and methods for their manipulation are defined. Each graphic element is defined by at least one figure specification, one mask specification and one map specification. An interactive display editor program defines specifications of said graphic elements. An interactive program editor program defines programming data and methods associated with said graphic elements. A display program uses the figure, map and mask specifications for assembling graphic elements upon the display and enabling user manipulation of said graphic elements.",
-		"authority": "United States",
-		"call-number": "US07/261,770",
-		"number": "US5041992A",
-		"title": "Interactive method of developing software interfaces",
-		"URL": "https://patents.google.com/patent/US5041992A/en",
-		"author": [
-			{
-				"family": "Cunningham",
-				"given": "Robert E."
-			},
-			{
-				"family": "Bonar",
-				"given": "Jeffery G."
-			},
-			{
-				"family": "Corbett",
-				"given": "John D."
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					6,
-					1
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"1991",
-					8,
-					20
-				]
-			]
-		},
-		"submitted": {
-			"date-parts": [
-				[
-					"1988",
-					10,
-					24
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/MV2TXBJZ",
-		"type": "patent",
-		"authority": "European Union",
-		"call-number": "EP19910307114",
-		"language": "en",
-		"number": "EP0471484B1",
-		"title": "Image display systems",
-		"URL": "https://patents.google.com/patent/EP0471484B1/en",
-		"author": [
-			{
-				"family": "Mackinlay",
-				"given": "Jock D."
-			},
-			{
-				"family": "Card",
-				"given": "Stuart K."
-			},
-			{
-				"family": "Robertson",
-				"given": "George G."
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					6,
-					1
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"1998",
-					9,
-					16
-				]
-			]
-		},
-		"submitted": {
-			"date-parts": [
-				[
-					"1991",
-					8,
-					2
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/LP7U9CZK",
-		"type": "patent",
-		"abstract": "In a graphic display system, display control software is modified to impart motion to a pop-up menu to attract the attention of the user. The menu becomes animated when a control and comparison circuit confirms that a mouse driven cursor on the screen is moving away from the pop-up menu indicating that the operator is unaware of the menu's presence. The menu moves or \"tags-along\" after the cursor until the user takes notice and makes the appropriate selection.",
-		"authority": "European Union",
-		"call-number": "EP91110869A",
-		"language": "en",
-		"number": "EP0464742A2",
-		"title": "Graphics display system with improved dynamic menu selection",
-		"URL": "https://patents.google.com/patent/EP0464742A2/en",
-		"author": [
-			{
-				"family": "Denber",
-				"given": "Michel J."
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					6,
-					1
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"1992",
-					1,
-					8
-				]
-			]
-		},
-		"submitted": {
-			"date-parts": [
-				[
-					"1991",
-					7,
-					1
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/HXGPKBTB",
-		"type": "patent",
-		"abstract": "An FSM data structure is encoded by generating a transition unit of data corresponding to each transition which leads ultimately to a final state of the FSM. Information about the states is included in the transition units, so that the encoded data structure can be written without state units of data. The incoming transition units to a final state each contain an indication of finality. The incoming transition units to a state which has no outgoing transition units each contain a branch ending indication. The outgoing transition units of each state are ordered into a comparison sequence for comparison with a received element, and all but the last outgoing transition unit contain an alternative indication of a subsequent alternative outgoing transition. The indications are incorporated with the label of each transition unit into a single byte, and the remaining byte values are allocated among a number of pointer data units, some of which begin full length pointers and some of which begin pointer indexes to tables where pointers are entered. The pointers may be used where a state has a large number of incoming transitions or where the block of transition units depending from a state is broken down to speed access. The first outgoing transition unit of a state is positioned immediately after one of the incoming transitions so that it may be found without a pointer. Each alternative outgoing transition unit is stored immediately after the block beginning with the previous outgoing transition unit so that it may be found by proceeding through the transition units until the number of alternative bits and the number of branch ending bits balance.",
-		"authority": "United States",
-		"call-number": "US07/855,129",
-		"number": "US5450598A",
-		"title": "Finite state machine data storage where data transition is accomplished without the use of pointers",
-		"URL": "https://patents.google.com/patent/US5450598A/en",
-		"author": [
-			{
-				"family": "Kaplan",
-				"given": "Ronald M."
-			},
-			{
-				"family": "Kay",
-				"given": "Martin"
-			},
-			{
-				"family": "Maxwell",
-				"given": "John"
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					6,
-					1
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"1995",
-					9,
-					12
-				]
-			]
-		},
-		"submitted": {
-			"date-parts": [
-				[
-					"1992",
-					3,
-					18
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/IZP9D9PC",
-		"type": "article-journal",
-		"abstract": "An introduction to LISP is given on an elementary level. Topics covered include the programming system, 240 exercises with solutions, debugging of LISP programs, and styles of programming. More advanced discussions are contained in the following articles: Techniques using LISP for automatically discovering interesting relations in data; Automation, using LISP, of inductive inference on sequences; Application of LISP to machine checking of mathematical proofs; METEOR: A LISP interpreter for string transformations; Notes on implementing LISP for the M-460 computer; LISP as the language for an incremental computer; The LISP system for the Q-2 computer; An auxiliary language for more natural expression -- the A-language. Some applications of the utilization of the LISP programming language are given in the appendices.",
-		"container-title": "Mathematics of Computation",
-		"DOI": "10.2307/2003282",
-		"ISSN": "0025-5718",
-		"issue": "99",
-		"note": "publisher: American Mathematical Society",
-		"page": "518-519",
-		"source": "JSTOR",
-		"title": "Review of The Programming Language LISP: Its Operation and Applications",
-		"title-short": "Review of The Programming Language LISP",
-		"URL": "https://www.jstor.org/stable/2003282",
-		"volume": "21",
-		"author": [
-			{
-				"family": "Harrison",
-				"given": "Malcolm"
-			}
-		],
-		"reviewed-author": [
-			{
-				"family": "Berkeley",
-				"given": "Edmund C."
-			},
-			{
-				"family": "Bobrow",
-				"given": "Daniel G."
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					6,
-					1
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"1967"
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/RNAZ2XUW",
-		"type": "paper-conference",
-		"abstract": "We describe an effort to translate the Interlisp KL-ONE system into Franzlisp to enable it to be run on a VAX . This effort has involved Tim Finin, Richard Duncan and Hassan Ait-Kaci from the University of Pennsylvania, Judy Weiner from Temple University, Jane Barnett from Computer Corporation of America and Jim Schmolze from Bolt Beranek and Newman. The primary motivation for this project was to make a version of KL-ONE available on a PDP 1 1/780 VAX . A VAX Interlisp is not yet available, although one is being written and will soon be available . Currently, the only substantial Lisp for a Vax is the Berkeley FranzLisp system. As a secondary motivation, we are interested in making KL-ONE more available in general - on a variety of Lisp dialects and machines.",
-		"container-title": "Proceedings of the Second KL-One Workshop",
-		"language": "en",
-		"page": "106-114",
-		"publisher": "Bolt Beranek and Newman",
-		"source": "ebiquity.umbc.edu",
-		"title": "Translating KL-One from interlisp to Franzlisp",
-		"URL": "https://ebiquity.umbc.edu/paper/html/id/738/Translating-KL-One-from-interlisp-to-Franzlisp",
-		"author": [
-			{
-				"family": "Finin",
-				"given": "Tim"
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					6,
-					1
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"1982",
-					6,
-					1
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/6RAE6DBF",
-		"type": "report",
-		"abstract": "In an ideal list-processing system there would be enough core memory to contain all the data and programs. The paper describes a number of techniques used to build a LISP system which utilizes a drum for its principal storage medium, with a surprisingly low time-penalty for use of this slow storage device. The techniques include careful segmentation of system programs, allocation of virtual memory to allow address arithmetic for type determination, and a special algorithm for building reasonably linearized lists. A scheme is described for binding variables which is good in this environment and allows for complete compatibility between compiled and interpreted programs with no special declarations.",
-		"event-place": "Cambridge, MA",
-		"language": "en",
-		"note": "section: Technical Reports",
-		"publisher": "BOLT BERANEK AND NEWMAN INC",
-		"publisher-place": "Cambridge, MA",
-		"source": "apps.dtic.mil",
-		"title": "THE STRUCTURE OF A LISP SYSTEM USING TWO-LEVEL STORAGE, SCIENTIFIC REPROT",
-		"URL": "https://apps.dtic.mil/sti/citations/AD0647601",
-		"author": [
-			{
-				"family": "Bobrow",
-				"given": "Daniel G."
-			},
-			{
-				"family": "Murphy",
-				"given": "Daniel L."
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					6,
-					1
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"1966",
-					11,
-					4
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/KQM2N5FW",
-		"type": "report",
-		"abstract": "Program verification refers to the idea that the intent or effect of a program can be stated in a precise way that is not a simple \"rewording \" of the program itself, and that one can prove (in the mathematical sense) that a program actually conforms to a given statement of intent. This thesis describes a software system which can verify (prove) some non-trivial programs automatically. The system described here is organized in a novel manner compared to most other theorem-proving systems. IL has a great deal of specific knowledge about integers and arrays of integers, yet it is not \"special-purpose\", since this knowledge is represented in procedures which are separate from the underlying structure of the system. It also incorporates some knowledge, gained by the author from both experiment and introspection, about how programs are often constructed, and uses this knowledge to guide the proof process. It uses its knowledge, plus contextual information from the program being verified, to simplify the theorems dramatically as they are being constructed, rather than relying on a super-powerful proof procedure. The system also provides for interactive editing of programs and assertions, and for detailed human control of the proof process when the system cannot produce a proof (or counter-example) on its own.",
-		"event-place": "California",
-		"publisher-place": "California",
-		"source": "CiteSeer",
-		"title": "PIVOT source listing",
-		"URL": "http://www.softwarepreservation.org/projects/verification/pivot/Deutsch-Pivot.pdf",
-		"author": [
-			{
-				"family": "Deutsch",
-				"given": "L. Peter"
-			}
-		],
-		"issued": {
-			"date-parts": [
-				[
-					"1975",
-					3,
-					19
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/I5AH4B95",
-		"type": "report",
-		"abstract": "Program verification refers to the idea that the intent or effect of a program can be stated in a precise way that is not a simple \"rewording \" of the program itself, and that one can prove (in the mathematical sense) that a program actually conforms to a given statement of intent. This thesis describes a software system which can verify (prove) some non-trivial programs automatically. The system described here is organized in a novel manner compared to most other theorem-proving systems. IL has a great deal of specific knowledge about integers and arrays of integers, yet it is not \"special-purpose\", since this knowledge is represented in procedures which are separate from the underlying structure of the system. It also incorporates some knowledge, gained by the author from both experiment and introspection, about how programs are often constructed, and uses this knowledge to guide the proof process. It uses its knowledge, plus contextual information from the program being verified, to simplify the theorems dramatically as they are being constructed, rather than relying on a super-powerful proof procedure. The system also provides for interactive editing of programs and assertions, and for detailed human control of the proof process when the system cannot produce a proof (or counter-example) on its own.",
-		"event-place": "California",
-		"publisher-place": "California",
-		"source": "CiteSeer",
-		"title": "An interactive program verifier",
-		"URL": "http://citeseerx.ist.psu.edu/viewdoc/summary?doi=10.1.1.696.5498",
-		"author": [
-			{
-				"family": "Deutsch",
-				"given": "L. Peter"
-			}
-		],
-		"issued": {
-			"date-parts": [
-				[
-					"1973",
-					5
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/23ZCTJ9Z",
-		"type": "article-journal",
-		"abstract": "In the late 1960s, a small group of developers at Bolt, Beranek, and Newman (BBN) in Cambridge, Massachusetts, began work on a new computer operating system, including a kernel, system call API, and user command interface (shell). While such an undertaking, particularly with a small group, became rare in subsequent decades, it was not uncommon in the 1960s. During development, this OS was given the name TENEX. A few years later, TENEX was adopted by Digital Equipment Corporation (DEC) for its new line of large machines to be known as the DECSYSTEM-20, and the operating system was renamed to TOPS-20. The author followed TENEX (or vice versa) on this journey, and these are some reflections and observations from that journey. He touches on some of the technical aspects that made TENEX notable in its day and an influence on operating systems that followed as well as on some of the people and other facets involved in the various steps along the way.",
-		"container-title": "Annals of the History of Computing, IEEE",
-		"DOI": "10.1109/MAHC.2015.15",
-		"journalAbbreviation": "Annals of the History of Computing",
-		"note": "publisher: IEEE",
-		"page": "75-82",
-		"source": "ResearchGate",
-		"title": "TENEX and TOPS-20",
-		"URL": "https://www.researchgate.net/publication/273523084_TENEX_and_TOPS-20",
-		"volume": "37",
-		"author": [
-			{
-				"family": "Murphy",
-				"given": "Dan"
-			}
-		],
-		"issued": {
-			"date-parts": [
-				[
-					"2015",
-					1,
-					1
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/KP33M4DP",
-		"type": "article",
-		"publisher": "Bolt, Beranek and Newman, Inc. (BBN)",
-		"title": "BBN - LISP, TENEX Reference Manual, Revised",
-		"URL": "http://www.bitsavers.org/pdf/bbn/tenex/TenexLispRef_Aug72.pdf",
-		"author": [
-			{
-				"family": "Teitelman",
-				"given": "W."
-			},
-			{
-				"family": "Bobrow",
-				"given": "D. G."
-			},
-			{
-				"family": "Hartley",
-				"given": "A. K."
-			},
-			{
-				"family": "Murphy",
-				"given": "D. L."
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					6,
-					1
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"1972",
-					8
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/XSVG2PVI",
-		"type": "report",
-		"abstract": "The report describes the LISP system implemented at BBN on the SDS 940 Computer. This LISP is an upward compatible extension of LISP 1.5 for the IBM 7090, with a number of new features which make it work well as an on-line language. These new features include tracing, and conditional breakpoints in functions for debugging and a sophisticated LISP oriented editor. The BBN 940 LISP SYSTEM has a large memory store approximately 50,000 free words utilizing special paging techniques for a drum to provide reasonable computation times. The system includes both an interpreter, a fully compatible compiler, and an assembly language facility for inserting machine code subroutines.",
-		"language": "en",
-		"note": "section: Technical Reports",
-		"publisher": "BOLT BERANEK AND NEWMAN INC CAMBRIDGE MA",
-		"source": "apps.dtic.mil",
-		"title": "THE BBN 940 LISP SYSTEM",
-		"URL": "https://apps.dtic.mil/sti/citations/AD0656771",
-		"author": [
-			{
-				"family": "Bobrow",
-				"given": "Daniel G."
-			},
-			{
-				"family": "Darley",
-				"given": "D. Lucille"
-			},
-			{
-				"family": "Deutsch",
-				"given": "L. Peter"
-			},
-			{
-				"family": "Murphy",
-				"given": "Daniel L."
-			},
-			{
-				"family": "Teitelman",
-				"given": "Warren"
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					6,
-					1
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"1967",
-					7,
-					15
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/6KKLXERD",
-		"type": "report",
-		"abstract": "The paper discusses some of the considerations involved in designing and implementing a pattern matching or COMIT feature inside of LISP. The programming language FLIP is presented here as a paradigm for such a feature. The design and implementation of FLIP discussed below emphasizes compact notation and efficiency of operation. In addition, FLIP is a modular language and can be readily extended and generalized to include features found in other pattern driven languages such as CONVERT and SNOBOL. This makes it extremely versatile. The development of this paper proceeds from abstract considerations to specific details. The syntax and semantics of FLIP are presented first, followed by a discussion of the implementation with especial attention devoted to techniques used for reducing the number of conses required as well as improving search strategy. Finally FLIP is treated as a working system and viewed from the users standpoint. Here we present some of the additions and extensions to FLIP that have evolved out of almost two years of experimentation. These transform it from a notational system into a practical and useful programming system.",
-		"language": "en",
-		"note": "section: Technical Reports",
-		"publisher": "BOLT BERANEK AND NEWMAN INC CAMBRIDGE MA",
-		"source": "apps.dtic.mil",
-		"title": "DESIGN AND IMPLEMENTATION OF FLIP, A LISP FORMAT DIRECTED LIST PROCESSOR",
-		"URL": "https://apps.dtic.mil/sti/citations/AD0660548",
-		"author": [
-			{
-				"family": "Teitelman",
-				"given": "Warren"
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					6,
-					1
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"1967",
-					7,
-					15
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/9SDF3BWD",
-		"type": "book",
-		"abstract": "This document describes the BEN-LISP system currently implemented on the SDS 940. It is a dialect of LISP 1.5 and the differences between IBM 7090 version and this system are described in Appendix\n1 and 2. Principally, this system has been expanded from the LISP 1.5 on the 7090 in a number of different ways. BBN-LISP is\ndesigned to utilize a drum for storage and to provide the user a large virtual memory, with a relatively small penalty in speed (using special paging techniques described in Bobrow and Murphy 1967).",
-		"call-number": "Z699.5.L28 B62 1969",
-		"event-place": "Cambridge",
-		"number-of-pages": "368",
-		"publisher": "Bolt, Beranek and Newman Inc",
-		"publisher-place": "Cambridge",
-		"source": "Library Catalog (Blacklight)",
-		"title": "The BBN-LISP system: Reference Manual",
-		"title-short": "The BBN-LISP system",
-		"URL": "http://www.bitsavers.org/pdf/bbn/The_BBN-LISP_System_Apr69.pdf",
-		"editor": [
-			{
-				"family": "Bobrow",
-				"given": "Daniel G."
-			},
-			{
-				"family": "Murphy",
-				"given": "D. L."
-			},
-			{
-				"family": "Teitelman",
-				"given": "Warren"
-			}
-		],
-		"issued": {
-			"date-parts": [
-				[
-					"1969",
-					4
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/JCVVQUVD",
-		"type": "article",
-		"publisher": "Bolt, Beranek and Newman, Inc. (BBN)",
-		"title": "BBN - LISP, TENEX Reference Manual",
-		"URL": "http://www.softwarepreservation.org/projects/LISP/bbnlisp/TenexLispRef_Jul71.pdf",
-		"author": [
-			{
-				"family": "Teitelman",
-				"given": "W."
-			},
-			{
-				"family": "Bobrow",
-				"given": "D. G."
-			},
-			{
-				"family": "Hartley",
-				"given": "A. K."
-			},
-			{
-				"family": "Murphy",
-				"given": "D. L."
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					6,
-					1
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"1971",
-					7
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/SI447SFB",
-		"type": "article",
-		"abstract": "This is a preliminary memo describing the BBN LISP 1.69 system for the 50S 940 computer. It is a description of how the system is working now, except for those places clearly noted in the text below. Any difference between the descriptions given and actual operation found should be reported, in writing, to the authors. At the end of this memo there is a copy of the index to function descriptions in the document, \"The BBN LISP SYSTEM (revised October 1966).",
-		"title": "General Structure of LISP 1.69",
-		"URL": "http://www.bitsavers.org/pdf/sds/9xx/940/ucbProjectGenie/940_LISP_Memo_1_Mar67.pdf",
-		"author": [
-			{
-				"family": "Bobrow",
-				"given": "D. G."
-			},
-			{
-				"family": "Deutsch",
-				"given": "L. P."
-			},
-			{
-				"family": "Murphy",
-				"given": "D. L."
-			}
-		],
-		"issued": {
-			"date-parts": [
-				[
-					"1967",
-					3,
-					23
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/XR77BB2T",
-		"type": "paper-conference",
-		"abstract": "ROSS [7] is an object-oriented language developed for building knowledge-based simulations [4]. SWIRL [5, 6] is a program written in ROSS that embeds knowledge about defensive and offensive air battle strategies. Given an initial configuration of military forces, SWIRL simulates the resulting air battle. We have implemented ROSS and SWIRL in several different Lisp environments. We report upon this experience by comparing the various environments in terms of cpu usage, real-time usage, and various user aids.",
-		"collection-title": "IJCAI'83",
-		"container-title": "Proceedings of the Eighth international joint conference on Artificial intelligence - Volume 2",
-		"event-place": "San Francisco",
-		"page": "859–861",
-		"publisher": "Morgan Kaufmann Publishers Inc.",
-		"publisher-place": "San Francisco",
-		"source": "ACM Digital Library",
-		"title": "Large-scale system development in several lisp environments",
-		"URL": "https://dl.acm.org/doi/10.5555/1623516.1623579",
-		"author": [
-			{
-				"family": "Naraln",
-				"given": "Sanjai"
-			},
-			{
-				"family": "McArthur",
-				"given": "David"
-			},
-			{
-				"family": "Klahr",
-				"given": "Philip"
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					6,
-					3
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"1983",
-					8,
-					8
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/6L8UHVSY",
-		"type": "article-journal",
-		"abstract": "This paper describes two related tools developed to support the isolation and analysts of optimization errors in the vpo optimizer. Both tools rely on vpo identifying sequences of changes, referred to as transformations. that result in semantically equivalent (and usually improved) code. One tool determines the first transfer. motion that causes incorrect output of the execution of the compiled program. This tool not only automatically isolates the illegal transformation, but also identifies the location and instant the transformation is performed in vpo. To assist in the analysis of an optimization error, a graphical optimization viewer was also implemented that can display the state of the generated instructions before and after each transformation performed by vpo. Unique features of the optimization viewer include reverse viewing (or undoing) of transformations and the ability to stop at breakpoints associated with the generated instructions. Both tools are useful independently. Together these tools form a powerful environment for facilitating the retargeting of vpo to a new machine and supporting experimentation with new optimizations. In addition, the optimization viewercan be used as a teaching aid in compiler classes.",
-		"container-title": "ACM SIGPLAN Notices",
-		"DOI": "10.1145/173262.155093",
-		"ISSN": "0362-1340",
-		"issue": "6",
-		"journalAbbreviation": "SIGPLAN Not.",
-		"page": "26–35",
-		"source": "June 1993",
-		"title": "Isolation and analysis of optimization errors",
-		"URL": "https://doi.org/10.1145/173262.155093",
-		"volume": "28",
-		"author": [
-			{
-				"family": "Boyd",
-				"given": "Mickey R."
-			},
-			{
-				"family": "Whalley",
-				"given": "David B."
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					6,
-					3
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"1993",
-					6,
-					1
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/YK6MRM4K",
-		"type": "chapter",
-		"abstract": "Major dialect of LISP <34>, designed for high-resolution, bit-mapped display, distinguished by (a) use of in-core editor for structures, and thus code, (b) programming environment of tools for automatic error-correction, syntax (sic) extension and structure declaration/access, (c) implementation of almost-compatible dialects (Interlisp <X>) on several machines, (d) extensive usage of display orientated tools and facilities. Emphasis: Personal Lisp workstation, user interface tools.",
-		"collection-title": "Symbolic Computation",
-		"container-title": "Catalogue of Artificial Intelligence Tools",
-		"event-place": "Berlin, Heidelberg",
-		"ISBN": "978-3-642-96868-6",
-		"language": "en",
-		"note": "DOI: 10.1007/978-3-642-96868-6_103",
-		"page": "52-52",
-		"publisher": "Springer",
-		"publisher-place": "Berlin, Heidelberg",
-		"source": "Springer Link",
-		"title": "Interlisp-D",
-		"URL": "https://doi.org/10.1007/978-3-642-96868-6_103",
-		"author": [
-			{
-				"family": "Bundy",
-				"given": "Alan"
-			},
-			{
-				"family": "Wallen",
-				"given": "Lincoln"
-			}
-		],
-		"editor": [
-			{
-				"family": "Bundy",
-				"given": "Alan"
-			},
-			{
-				"family": "Wallen",
-				"given": "Lincoln"
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					6,
-					3
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"1984"
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/HLN62MVN",
-		"type": "article-journal",
-		"abstract": "CommonLoops blends object-oriented programming smoothly and tightly with the procedure-oriented design of Lisp. Functions and methods are combined in a more general abstraction. Message passing is invoked via normal Lisp function call. Methods are viewed as partial descriptions of procedures. Lisp data types are integrated with object classes. With these integrations, it is easy to incrementally move a program between the procedure and object-oriented styles. One of the most important properties of CommonLoops is its extensive use of meta-objects. We discuss three kinds of meta-objects: objects for classes, objects for methods, and objects for discriminators. We argue that these meta-objects make practical both efficient implementation and experimentation with new ideas for object-oriented programming. CommonLoops' small kernel is powerful enough to implement the major object-oriented systems in use today.",
-		"container-title": "ACM SIGPLAN Notices",
-		"DOI": "10.1145/960112.28700",
-		"ISSN": "0362-1340",
-		"issue": "11",
-		"journalAbbreviation": "SIGPLAN Not.",
-		"page": "17–29",
-		"source": "Nov. 1986",
-		"title": "CommonLoops: merging Lisp and object-oriented programming",
-		"title-short": "CommonLoops",
-		"URL": "https://doi.org/10.1145/960112.28700",
-		"volume": "21",
-		"author": [
-			{
-				"family": "Bobrow",
-				"given": "Daniel G."
-			},
-			{
-				"family": "Kahn",
-				"given": "Kenneth"
-			},
-			{
-				"family": "Kiczales",
-				"given": "Gregor"
-			},
-			{
-				"family": "Masinter",
-				"given": "Larry"
-			},
-			{
-				"family": "Stefik",
-				"given": "Mark"
-			},
-			{
-				"family": "Zdybel",
-				"given": "Frank"
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					6,
-					3
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"1986",
-					6,
-					1
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/WW4XTYMU",
-		"type": "article-journal",
-		"abstract": "DrJava is a pedagogic programming environment for Java that enables students to focus on designing programs, rather than learning how to use the environment. The environment provides a simple interface based on a \"read-eval-print loop\" that enables a programmer to develop, test, and debug Java programs in an interactive, incremental fashion. This paper gives an overview of DrJava including its pedagogic rationale, functionality, and implementation.",
-		"container-title": "ACM SIGCSE Bulletin",
-		"DOI": "10.1145/563517.563395",
-		"ISSN": "0097-8418",
-		"issue": "1",
-		"journalAbbreviation": "SIGCSE Bull.",
-		"page": "137–141",
-		"source": "March 2002",
-		"title": "DrJava: a lightweight pedagogic environment for Java",
-		"title-short": "DrJava",
-		"URL": "https://doi.org/10.1145/563517.563395",
-		"volume": "34",
-		"author": [
-			{
-				"family": "Allen",
-				"given": "Eric"
-			},
-			{
-				"family": "Cartwright",
-				"given": "Robert"
-			},
-			{
-				"family": "Stoler",
-				"given": "Brian"
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					6,
-					3
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"2002",
-					2,
-					27
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/H5Q65H3M",
-		"type": "paper-conference",
-		"collection-title": "EUROSAM '79",
-		"container-title": "Proceedings of the International Symposiumon on Symbolic and Algebraic Computation",
-		"event-place": "Berlin, Heidelberg",
-		"ISBN": "978-3-540-09519-5",
-		"page": "481–489",
-		"publisher": "Springer-Verlag",
-		"publisher-place": "Berlin, Heidelberg",
-		"source": "ACM Digital Library",
-		"title": "Extending Interlisp for modularization and efficiency",
-		"URL": "https://dl.acm.org/doi/10.5555/646670.699000",
-		"author": [
-			{
-				"family": "Bobrow",
-				"given": "Daniel G."
-			},
-			{
-				"family": "Deutsch",
-				"given": "L. Peter"
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					6,
-					3
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"1979",
-					6,
-					1
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/ELDJNGJZ",
-		"type": "paper-conference",
-		"abstract": "This paper addresses the general problem of creating a suitable on-line environment for programming. The amount of software, and the effort required to produce it, to support such an on-line environment is very large relative to that needed to produce a programming language, and is largely responsible for the scarcity of such programming environments. The size of this effort was largely responsible for the scrapping of a major language (QA4) as a separate entity and its inclusion instead as a set of extensions in a LISP environment. The few systems which do exist (e.g., LISP, APL, BASIC, and PL/I) have greatly benefited their users and have strongly contributed to the widespread acceptance of the associated language.",
-		"collection-title": "AFIPS '74",
-		"container-title": "Proceedings of the May 6-10, 1974, national computer conference and exposition",
-		"DOI": "10.1145/1500175.1500251",
-		"event-place": "New York, NY, USA",
-		"ISBN": "978-1-4503-7920-5",
-		"language": "en",
-		"page": "365–370",
-		"publisher": "Association for Computing Machinery",
-		"publisher-place": "New York, NY, USA",
-		"source": "ACM Digital Library",
-		"title": "A language-independent programmer's interface",
-		"URL": "https://doi.org/10.1145/1500175.1500251",
-		"author": [
-			{
-				"family": "Balzer",
-				"given": "Robert M."
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					6,
-					3
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"1974",
-					5,
-					6
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/THLV47EY",
-		"type": "report",
-		"publisher": "The Andrew W. Mellon Foundation",
-		"source": "Google Scholar",
-		"title": "Emulation & Virtualization as Preservation Strategies",
-		"author": [
-			{
-				"family": "Rosenthal",
-				"given": "David S.H."
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2016",
-					1,
-					22
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"2015",
-					10
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/PVJ9RNNH",
-		"type": "book",
-		"publisher": "Citeseer",
-		"source": "Google Scholar",
-		"title": "The Interlisp virtual machine specification (revised)",
-		"URL": "http://www.cs.utexas.edu/~moore/publications/interlisp-vm.pdf",
-		"author": [
-			{
-				"family": "Moore",
-				"given": "J. Strother"
-			}
-		],
-		"issued": {
-			"date-parts": [
-				[
-					"1976"
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/WRHC5YI7",
-		"type": "paper-conference",
-		"container-title": "Proceedings of the June 7-10, 1976, national computer conference and exposition",
-		"page": "349-356",
-		"source": "Google Scholar",
-		"title": "Qlisp: a language for the interactive development of complex systems",
-		"title-short": "Qlisp",
-		"author": [
-			{
-				"family": "Sacerdoti",
-				"given": "Earl D."
-			},
-			{
-				"family": "Fikes",
-				"given": "Richard E."
-			},
-			{
-				"family": "Reboh",
-				"given": "Rene"
-			},
-			{
-				"family": "Sagalowicz",
-				"given": "Daniel"
-			},
-			{
-				"family": "Waldinger",
-				"given": "Richard J."
-			},
-			{
-				"family": "Wilber",
-				"given": "B. Michael"
-			}
-		],
-		"issued": {
-			"date-parts": [
-				[
-					"1976"
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/U7GGH7HE",
-		"type": "webpage",
-		"title": "Attendees | Larry Masinter, The Medley Interlisp Project: Status and Plans | Meetup",
-		"URL": "https://www.meetup.com/LispNYC/events/vqhmbpybcqblb/attendees/",
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					6,
-					21
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/7EPMG3KN",
-		"type": "article",
-		"language": "English",
-		"note": "Austin, TX 7879",
-		"publisher": "Texas Imstruments",
-		"title": "Texas Instruments Explorer Technical Summary, DDYB022",
-		"issued": {
-			"date-parts": [
-				[
-					"1984"
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/WXM4V4SP",
-		"type": "article",
-		"note": "Austin, TX 78792",
-		"publisher": "Texas Instruments",
-		"title": "Texas Instruments Expert System Development Tools, DNJS058",
-		"issued": {
-			"date-parts": [
-				[
-					"1984"
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/2PNW5DWU",
-		"type": "article",
-		"note": "Austin, TX 78792",
-		"publisher": "Texas Instruments",
-		"title": "TI Explorer Symbolic Processing System, DEES055 (brochure)",
-		"issued": {
-			"date-parts": [
-				[
-					"1984"
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/T33JWZ9V",
-		"type": "article",
-		"note": "Austin, TX 78792",
-		"publisher": "Texas Instruments",
-		"title": "Texas Instruments New Developments in Artificial Intelligence, DEEB024 (brochure)",
-		"issued": {
-			"date-parts": [
-				[
-					"1984"
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/JNSPBY9L",
-		"type": "report",
-		"event-place": "Fort Belvoir, VA",
-		"language": "en",
-		"note": "DOI: 10.21236/ADA122437",
-		"publisher": "Defense Technical Information Center",
-		"publisher-place": "Fort Belvoir, VA",
-		"source": "DOI.org (Crossref)",
-		"title": "KLONE Reference Manual:",
-		"title-short": "KLONE Reference Manual",
-		"URL": "http://www.dtic.mil/docs/citations/ADA122437",
-		"author": [
-			{
-				"family": "Brachman",
-				"given": "Ronald"
-			},
-			{
-				"family": "Ciccarelli",
-				"given": "Eugene"
-			},
-			{
-				"family": "Greenfeld",
-				"given": "Norton"
-			},
-			{
-				"family": "Yonke",
-				"given": "Martin"
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					7,
-					13
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"1978",
-					7,
-					1
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/5QC8XEBV",
-		"type": "article-journal",
-		"abstract": "It is with deep sorrow that we report the passing of former AAAI President Danny Bobrow on March 20, 2017. His family, friends, and colleagues from the Palo Alto Research Center and around the world recently gathered at PARC to commemorate his life and work.",
-		"container-title": "The AI Magazine",
-		"DOI": "10.1609/aimag.v38i4.2767",
-		"ISSN": "0738-4602",
-		"language": "en",
-		"note": "publisher: Association for the Advancement of Artificial Intelligence (AAAI)\nReport Number: 38\nFatcat ID: release_wg4g7ikocbagxinabbk2eni52q",
-		"page": "78",
-		"source": "fatcat.wiki",
-		"title": "Daniel G. Bobrow: In Memoriam",
-		"title-short": "Daniel G. Bobrow",
-		"URL": "https://web.archive.org/web/201904301959/https://aaai.org/ojs/index.php/aimagazine/article/download/2767/2664",
-		"volume": "38",
-		"author": [
-			{
-				"family": "DeKleer",
-				"given": "Johann"
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					7,
-					18
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"2017",
-					12,
-					28
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/UYMFQ6DW",
-		"type": "article-journal",
-		"container-title": "Computer",
-		"DOI": "10.1109/c-m.1978.218184",
-		"ISSN": "0018-9162",
-		"language": "en",
-		"note": "publisher: Institute of Electrical and Electronics Engineers\nReport Number: 11\nFatcat ID: release_q5bn52bkmvgfnfpyj3fa6wfnzy",
-		"page": "57-67",
-		"source": "fatcat.wiki",
-		"title": "The Maxc Systems",
-		"URL": "https://web.archive.org/web/2017/https://www.computer.org/web/csdl/index/-/csdl/mags/co/1978/05/01646959.pdf",
-		"volume": "11",
-		"author": [
-			{
-				"family": "Fiala",
-				"given": "E. R."
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					7,
-					18
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"1978"
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/BL7WTV9T",
-		"type": "article",
-		"title": "ACS Full Text Snapshot",
-		"URL": "https://pubs.acs.org/doi/full/10.1021/acsomega.9b00642",
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					7,
-					19
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/RILWT5DH",
-		"type": "report",
-		"genre": "Draft standard",
-		"number": "X3J13/94-101R",
-		"publisher": "ANSI",
-		"title": "ANSI Common Lisp",
-		"URL": "https://franz.com/support/documentation/cl-ansi-standard-draft-w-sidebar.pdf",
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					6,
-					29
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"1994",
-					8,
-					12
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/PHI92FUI",
-		"type": "webpage",
-		"title": "FAQ: Lisp Implementations and Mailing Lists 4/7 [Monthly posting] - [4-1] Commercial Common Lisp implementations.",
-		"URL": "https://www.cs.cmu.edu/Groups/AI/html/faqs/lang/lisp/part4/faq-doc-2.html",
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					7,
-					28
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/M74EDUS2",
-		"type": "webpage",
-		"abstract": "In commemoration of the 40th anniversary of the release of Smalltalk-80, the Computer History Museum is proud to announce a collaboration with Dan Ingalls to preserve and host the “Smalltalk Zoo.”",
-		"container-title": "CHM",
-		"language": "en",
-		"note": "section: Software History Center",
-		"title": "Introducing the Smalltalk Zoo",
-		"URL": "https://computerhistory.org/blog/introducing-the-smalltalk-zoo-48-years-of-smalltalk-history-at-chm/",
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					8,
-					3
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"2020",
-					12,
-					17
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/5W4HPW7Y",
-		"type": "article",
-		"title": "999017_Users_Guide_To_Symbolics_Computers_Jul86.pdf"
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/424E5JE4",
-		"type": "article",
-		"title": "genera-handbook.pdf"
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/QCUSPBJ4",
-		"type": "article",
-		"title": "genera-concepts.pdf"
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/9INNYFUY",
-		"type": "article",
-		"title": "EDITORS.pdf"
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/XHHS7YPX",
-		"type": "article",
-		"title": "HARDWARE_1.pdf"
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/XURVZZJ4",
-		"type": "article",
-		"title": "LMI_LispSW_Overview_Jun82.pdf"
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/ZQJJKWXN",
-		"type": "article",
-		"title": "LMI_lambdaOverview_1982.pdf"
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/UJIB5QA8",
-		"type": "article",
-		"title": "LM-2_Unibus_IO_Sep81.pdf"
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/EDSDHLJB",
-		"type": "article",
-		"title": "Lisp-Machine_Data_Types.pdf"
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/IM9RHIFA",
-		"type": "article",
-		"title": "Lisp_Machine_Hardware_Memos.pdf"
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/26XMX25L",
-		"type": "article",
-		"title": "Chaosnet_Jun82.pdf"
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/XSBJJLVU",
-		"type": "article",
-		"title": "Chaosnet_File_Protocol_Sep81.pdf"
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/R2MVMB9H",
-		"type": "article",
-		"title": "3600_TechnicalSummary_Feb83.pdf"
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/4LT3PZKX",
-		"type": "article",
-		"title": "990075_Lisp_Machine_Summary_3600_Edition_Aug83.pdf"
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/VAP8TX7K",
-		"type": "article",
-		"title": "Symbolics_File_System_Aug81.pdf"
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/6VR68XSJ",
-		"type": "article",
-		"title": "Symbolics_Software_1981.pdf"
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/6RDAKQHK",
-		"type": "article",
-		"title": "Symbolics_Overview_1986.pdf"
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/KE7KG52R",
-		"type": "article",
-		"language": "English",
-		"publisher": "Symbolics Corporaiton",
-		"title": "Symbolics Software",
-		"issued": {
-			"date-parts": [
-				[
-					"1981"
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/HWM5FF7S",
-		"type": "article",
-		"language": "English",
-		"publisher": "Symbolics Corporaiton",
-		"title": "Symbolics Overview (Briefing)",
-		"issued": {
-			"date-parts": [
-				[
-					"1986"
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/U34DPFVP",
-		"type": "article",
-		"language": "English",
-		"publisher": "Symbolics Corporaiton",
-		"title": "Symbolics File Systems",
-		"issued": {
-			"date-parts": [
-				[
-					"1981",
-					8
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/Q4B7BAM3",
-		"type": "article",
-		"publisher": "Symbolics Corporaiton",
-		"title": "CHAOSNet File Protocol",
-		"issued": {
-			"date-parts": [
-				[
-					"1981",
-					9
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/35RNCCNY",
-		"type": "article",
-		"language": "English",
-		"note": "#990075",
-		"publisher": "Symbolics Corporation",
-		"title": "Lisp Machines Summary -3600Edition",
-		"issued": {
-			"date-parts": [
-				[
-					"1983",
-					8
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/JD4T9DIQ",
-		"type": "article",
-		"language": "English",
-		"publisher": "Symbolics Corporaiton",
-		"title": "3600 Technical Summary - Feb83",
-		"issued": {
-			"date-parts": [
-				[
-					"1983"
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/HI5WIUJQ",
-		"type": "article",
-		"title": "ED285570.pdf",
-		"URL": "https://files.eric.ed.gov/fulltext/ED285570.pdf",
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					8,
-					5
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/B63F5Q8E",
-		"type": "webpage",
-		"title": "Xerox Alto Emulator",
-		"URL": "https://archives.loomcom.com/contraltojs/",
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					8,
-					19
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/6IR4DI6L",
-		"type": "paper-conference",
-		"container-title": "IFIP Congress",
-		"page": "355–360",
-		"source": "Google Scholar",
-		"title": "Adding Type Declarations to Interlisp.",
-		"author": [
-			{
-				"family": "Kaplan",
-				"given": "Ronald M."
-			},
-			{
-				"family": "Sheil",
-				"given": "B. A."
-			}
-		],
-		"issued": {
-			"date-parts": [
-				[
-					"1980"
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/6K3KKUTC",
-		"type": "webpage",
-		"title": "PLDI 2021: The Evolution of Smalltalk from Smalltalk-72 through Squeak",
-		"URL": "https://www.pldi21.org/prerecorded_hopl.17.html",
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					8,
-					27
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/2HH65NKZ",
-		"type": "webpage",
-		"title": "PLDI 2021: The Evolution of Smalltalk from Smalltalk-72 through Squeak",
-		"URL": "https://www.pldi21.org/prerecorded_hopl.17.html",
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					9,
-					4
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/NMBE4L5F",
-		"type": "article-journal",
-		"abstract": "This interview is part of a series on Human Computer Interaction (HCI) conducted by the Charles Babbage Institute for ACM SIGCHI (Association for Computing Machinery Special Interest Group for Computer Human Interaction).  HCI Pioneer Stuart Card discusses early education, attending Oberlin College, and helping lead its computer center, before the bulk of the interview focuses on his graduate education at Carnegie Mellon University working under Allen Newell, and his long and influential tenure at Xerox PARC.  This includes his long and impactful collaboration with Newell and fellow Newell doctoral student Tom Moran. Newell, Card, and Moran were fundamentally important to theorizing early Human Computer Interaction, and the three co-wrote the widely used and deeply insightful textbook, The Psychology of Human Computer Interaction.  Card provides an overview of his decades of work of Xerox PARC and various aspects of his research contributions to HCI models, information visualization, and information access (especially foraging theory). He moved into managing research and also relates a portion of his leadership roles at PARC and outside on important committees such as for the National Academy of Science.  He briefly expresses his ideas on the early institutional history of SIGCHI and its evolution.  Regarding his work at PARC, Card discusses his influential work on computer mice research at greater length.  Card became an adjunct professor at Stanford University. He is an ACM Fellow and was awarded SIGCHI’s Lifetime Research Achievement Award.",
-		"language": "en",
-		"note": "Accepted: 2021-03-04T21:17:00Z\npublisher: Charles Babbage Institute",
-		"source": "conservancy.umn.edu",
-		"title": "Oral history interview with Stuart Card",
-		"URL": "http://conservancy.umn.edu/handle/11299/218989",
-		"author": [
-			{
-				"family": "Card",
-				"given": "Stuart"
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					9,
-					4
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"2020",
-					2,
-					17
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/ZKPNK7N8",
-		"type": "post-weblog",
-		"abstract": "The Code of Best Practices in Fair Use for Software Preservation provides clear guidance on the legality of archiving legacy software to ensure continued access to digital files of all...",
-		"container-title": "Association of Research Libraries",
-		"language": "en-US",
-		"title": "Code of Best Practices in Fair Use for Software Preservation",
-		"URL": "https://www.arl.org/resources/code-of-best-practices-in-fair-use-for-software-preservation/",
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					9,
-					4
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/YY43Z6F6",
-		"type": "webpage",
-		"abstract": "I must be mellowing in my old age (possibly as opposed to bellowing) because I have been getting praise and compliments recently on comments in various places. Dont worry, there are still people angrily shouting at me as well. This was the earlier comment, I think... There was a slightly…",
-		"title": "Some thoughts about raising the profile of Lisp",
-		"URL": "https://liam-on-linux.livejournal.com/81798.html",
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					9,
-					4
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/CER4PF8K",
-		"type": "webpage",
-		"title": "NOTES ON XEROX LISP MACH DEMO",
-		"URL": "https://ml.cddddr.org/lisp@parc/msg00137.html",
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					9,
-					15
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/24B6QE9B",
-		"type": "webpage",
-		"title": "(archives of email about the common lisp standard and related)",
-		"URL": "https://ml.cddddr.org/",
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					9,
-					15
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/RCFRZY85",
-		"type": "article-journal",
-		"abstract": "This paper explores the potential of distributed emulation networks to support research and pedagogy into historical and sociotechnical aspects of software. Emulation is a type of virtualization that re-creates the conditions for a piece of legacy software to operate on a modern system. The paper first offers a review of Computer-Supported Cooperative Work (CSCW), Human-Computer Interaction (HCI), and Science and Technology Studies (STS) literature engaging with software as historical and sociotechnical artifacts, and with emulation as a vehicle of scholarly inquiry. It then documents the novel use of software emulations as a pedagogical resource and research tool for legacy software systems analysis. This is accomplished through the integration of the Emulation as a Service Infrastructure (EaaSI) distributed emulation network into a university-level course focusing on computer-aided design (CAD). The paper offers a detailed case study of a pedagogical experience oriented to incorporate emulations into software research and learning. It shows how emulations allow for close, user-centered analyses of software systems that highlight both their historical evolution and core interaction concepts, and how they shape the work practices of their users.",
-		"container-title": "Proceedings of the ACM on Human-Computer Interaction",
-		"DOI": "10.1145/3476035",
-		"issue": "CSCW2",
-		"journalAbbreviation": "Proc. ACM Hum.-Comput. Interact.",
-		"page": "294:1–294:22",
-		"source": "October 2021",
-		"title": "An Archive of Interfaces: Exploring the Potential of Emulation for Software Research, Pedagogy, and Design",
-		"title-short": "An Archive of Interfaces",
-		"URL": "https://doi.org/10.1145/3476035",
-		"volume": "5",
-		"author": [
-			{
-				"family": "Cardoso-Llach",
-				"given": "Daniel"
-			},
-			{
-				"family": "Kaltman",
-				"given": "Eric"
-			},
-			{
-				"family": "Erdolu",
-				"given": "Emek"
-			},
-			{
-				"family": "Furste",
-				"given": "Zachary"
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					10,
-					21
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"2021",
-					10,
-					18
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/MSPJNWAV",
-		"type": "book",
-		"ISBN": "978-0-262-25619-3",
-		"language": "en",
-		"note": "DOI: 10.7551/mitpress/5298.001.0001",
-		"publisher": "The MIT Press",
-		"source": "DOI.org (Crossref)",
-		"title": "Performance and Evaluation of LISP Systems",
-		"URL": "https://direct.mit.edu/books/book/3870/performance-and-evaluation-of-lisp-systems",
-		"author": [
-			{
-				"family": "Gabriel",
-				"given": "Richard P."
-			}
-		],
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					10,
-					22
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"1985"
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/V3AS6UR5",
-		"type": "post-weblog",
-		"abstract": "MJSBlog - Workin on it",
-		"language": "en-US",
-		"title": "Truckin’ and the Knowledge Competitions | MJSBlog",
-		"URL": "https://www.markstefik.com/?page_id=359",
-		"accessed": {
-			"date-parts": [
-				[
-					"2021",
-					10,
-					25
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/ZNK9J6YF",
-		"type": "thesis",
-		"abstract": "This thesis is about list structures: how they are used in practice, how they\ncan be moved and copied efficiently, and how they can be represented by space-saving encodings. The approach taken to these subjects is mainly empirical.\nMeasurement results are based on five large programs written in Interlisp, a\nsophisticated Lisp system that runs on the PDP-10.",
-		"publisher": "CMU",
-		"title": "List Structure: Measurements, Algorithms, and Encodings",
-		"author": [
-			{
-				"family": "Clark",
-				"given": "Douglas W."
-			}
-		],
-		"issued": {
-			"date-parts": [
-				[
-					"1976"
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/5BCFD3VW",
-		"type": "webpage",
-		"title": "Dan Murphy's TECO, TENEX, and TOPS-20 Papers",
-		"URL": "https://opost.com/tenex/",
-		"accessed": {
-			"date-parts": [
-				[
-					"2022",
-					1,
-					30
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/GSH9NUT6",
-		"type": "article",
-		"title": "ahc_20150101_jan_2015.pdf",
-		"URL": "https://opost.com/tenex/ahc_20150101_jan_2015.pdf",
-		"accessed": {
-			"date-parts": [
-				[
-					"2022",
-					1,
-					30
-				]
-			]
-		}
-	},
-	{
-		"id": "http://zotero.org/groups/2914042/items/ZPQT7YKY",
-		"type": "webpage",
-		"abstract": "At Grammarly, the foundation of our business, our core grammar engine, is written in Common Lisp. It currently processes more than a thousand sentences per…",
-		"container-title": "Running Lisp in Production | Grammarly Engineering Blog",
-		"language": "en",
-		"title": "Running Lisp in Production",
-		"URL": "https://www.grammarly.com/blog/engineering/running-lisp-in-production/",
-		"accessed": {
-			"date-parts": [
-				[
-					"2022",
-					2,
-					1
-				]
-			]
-		},
-		"issued": {
-			"date-parts": [
-				[
-					"2015",
-					6,
-					26
-				]
-			]
-		}
-	}
-]
+{
+  "Undated": [
+    {
+      "id": "9296070/9VAUTPVT",
+      "type": "article",
+      "title": "1982-Bobrow-Stefik-Data-Object-Pgming.pdf"
+    },
+    {
+      "id": "9296070/EPG3LWQF",
+      "type": "article",
+      "title": "1986-commonloops-oopsla66.pdf"
+    },
+    {
+      "id": "9296070/2GN25ESU",
+      "type": "article",
+      "title": "1979-stefik-examination-of-frame-structured.pdf"
+    },
+    {
+      "id": "9296070/7MG5RV9Y",
+      "type": "article",
+      "title": "1987-Themes-Variations-Stefik-Loops-.pdf"
+    },
+    {
+      "id": "9296070/Z3QZB88Q",
+      "type": "article",
+      "title": "1986-access-oriented.pdf"
+    },
+    {
+      "id": "9296070/UK4LUYSV",
+      "type": "article",
+      "title": "CSD-84-215.pdf",
+      "URL": "https://digitalassets.lib.berkeley.edu/techreports/ucb/text/CSD-84-215.pdf",
+      "accessed": {
+        "date-parts": [
+          [
+            2022,
+            12,
+            20
+          ]
+        ]
+      }
+    },
+    {
+      "id": "9296070/HI5WIUJQ",
+      "type": "article",
+      "title": "ED285570.pdf",
+      "URL": "https://files.eric.ed.gov/fulltext/ED285570.pdf",
+      "accessed": {
+        "date-parts": [
+          [
+            2021,
+            8,
+            6
+          ]
+        ]
+      }
+    },
+    {
+      "id": "9296070/KFW6YRLW",
+      "type": "article",
+      "title": "CSL-77-3_A_Display_Oriented_Programmers_Assistant.pdf",
+      "URL": "http://bitsavers.trailing-edge.com/pdf/xerox/parc/techReports/CSL-77-3_A_Display_Oriented_Programmers_Assistant.pdf",
+      "accessed": {
+        "date-parts": [
+          [
+            2022,
+            6,
+            15
+          ]
+        ]
+      }
+    },
+    {
+      "id": "9296070/RNYPDS4F",
+      "type": "article",
+      "title": "CSL-79-6_Raster_Graphics_for_Interactive_Programming_Environments.pdf",
+      "URL": "http://bitsavers.trailing-edge.com/pdf/xerox/parc/techReports/CSL-79-6_Raster_Graphics_for_Interactive_Programming_Environments.pdf",
+      "accessed": {
+        "date-parts": [
+          [
+            2022,
+            6,
+            15
+          ]
+        ]
+      }
+    },
+    {
+      "id": "9296070/ZB2TAD4S",
+      "type": "article",
+      "title": "Xerox_Globalview_Document_Services_for_Sun_Technical_Reference_Manual_Jun92.pdf",
+      "URL": "http://www.bitsavers.org/pdf/xerox/xns_services/services_sparc/Xerox_Globalview_Document_Services_for_Sun_Technical_Reference_Manual_Jun92.pdf",
+      "accessed": {
+        "date-parts": [
+          [
+            2022,
+            7,
+            26
+          ]
+        ]
+      }
+    },
+    {
+      "id": "9296070/GSH9NUT6",
+      "type": "article",
+      "title": "ahc_20150101_jan_2015.pdf",
+      "URL": "https://opost.com/tenex/ahc_20150101_jan_2015.pdf",
+      "accessed": {
+        "date-parts": [
+          [
+            2022,
+            1,
+            30
+          ]
+        ]
+      }
+    },
+    {
+      "id": "9296070/RJPVRIGF",
+      "type": "post-weblog",
+      "title": "Truckin’ and the Knowledge Competitions | MJSBlog",
+      "abstract": "MJSBlog - Workin on it",
+      "URL": "https://www.markstefik.com/?page_id=359",
+      "language": "en-US",
+      "accessed": {
+        "date-parts": [
+          [
+            2022,
+            7,
+            17
+          ]
+        ]
+      }
+    },
+    {
+      "id": "9296070/9LHKWE3T",
+      "type": "article-journal",
+      "title": "Perspectives on Artificial Intelligence Programming",
+      "page": "8",
+      "volume": "231",
+      "language": "en",
+      "author": [
+        {
+          "family": "Bobrow",
+          "given": "G"
+        },
+        {
+          "family": "Stefik",
+          "given": "J"
+        }
+      ]
+    },
+    {
+      "id": "9296070/GZU4TBQ5",
+      "type": "article-journal",
+      "title": "Perspectives on Artificial Intelligence Programming",
+      "page": "8",
+      "volume": "231",
+      "language": "en",
+      "author": [
+        {
+          "family": "Bobrow",
+          "given": "G"
+        },
+        {
+          "family": "Stefik",
+          "given": "J"
+        }
+      ]
+    },
+    {
+      "id": "9296070/CER4PF8K",
+      "type": "webpage",
+      "title": "NOTES ON XEROX LISP MACH DEMO",
+      "URL": "https://ml.cddddr.org/lisp@parc/msg00137.html",
+      "accessed": {
+        "date-parts": [
+          [
+            2021,
+            9,
+            16
+          ]
+        ]
+      }
+    },
+    {
+      "id": "9296070/B63F5Q8E",
+      "type": "webpage",
+      "title": "Xerox Alto Emulator",
+      "URL": "https://archives.loomcom.com/contraltojs/",
+      "accessed": {
+        "date-parts": [
+          [
+            2021,
+            8,
+            20
+          ]
+        ]
+      }
+    },
+    {
+      "id": "9296070/3UNHV59N",
+      "type": "webpage",
+      "title": "Lisp and Symbolic Computation",
+      "container-title": "Table of contents for issues of Lisp and Symbolic Computation",
+      "URL": "http://ftp.math.utah.edu/pub/tex/bib/toc/lispsymbcomput.html",
+      "accessed": {
+        "date-parts": [
+          [
+            2021,
+            4,
+            25
+          ]
+        ]
+      }
+    }
+  ],
+  "1966": [
+    {
+      "id": "9296070/LQQWKMEZ",
+      "type": "paper-conference",
+      "title": "Format-directed list processing in LISP",
+      "container-title": "Proceedings of the first ACM symposium on Symbolic and algebraic manipulation",
+      "collection-title": "SYMSAC '66",
+      "publisher": "Association for Computing Machinery",
+      "publisher-place": "New York, NY, USA",
+      "page": "0301–0329",
+      "event-place": "New York, NY, USA",
+      "abstract": "This article describes a notation and a programming language for expressing, from within a LISP system, string transformations such as those performed in COMIT or SNOBOL. A simple transformation (or transformation rule) is specified by providing a pattern which must match the structure to be transformed and a format which specifies how to construct a new structure according to the segmentation specified by the pattern. The patterns and formats are greatly generalized versions of the left-half and right-half rules of COMIT and SNOBOL. For example, elementary patterns and formats can be variable names, results of computations, disjunctive sets, or repeating subpatterns; predicates can be associated with elementary patterns which check relationships among separated elements of the match; it is no longer necessary to restrict the operations to linear strings since elementary patterns can themselves match structures. The FLIP language has been implemented in LISP 1.5, and has been successfully used in such disparate tasks as editing LISP functions and parsing Kleene regular expressions.",
+      "URL": "https://doi.org/10.1145/800005.807968",
+      "DOI": "10.1145/800005.807968",
+      "ISBN": "978-1-4503-7371-5",
+      "author": [
+        {
+          "family": "Bobrow",
+          "given": "Daniel G."
+        },
+        {
+          "family": "Teitelman",
+          "given": "Warren"
+        }
+      ],
+      "issued": {
+        "date-parts": [
+          [
+            "1966",
+            1,
+            1
+          ]
+        ]
+      },
+      "accessed": {
+        "date-parts": [
+          [
+            2021,
+            5,
+            31
+          ]
+        ]
+      }
+    },
+    {
+      "id": "9296070/6M8ISEUL",
+      "type": "article",
+      "title": "Preliminary Specification for BBN 940 LISP",
+      "URL": "http://www.softwarepreservation.org/projects/LISP/bbnlisp/BBN940LispPrelimSpec_Oct1966.pdf",
+      "language": "English",
+      "author": [
+        {
+          "family": "Daniel G. Bobrow",
+          "given": ""
+        },
+        {
+          "family": "Daniel L. Murphy",
+          "given": ""
+        }
+      ],
+      "issued": {
+        "date-parts": [
+          [
+            "1966",
+            10,
+            13
+          ]
+        ]
+      }
+    }
+  ],
+  "1967": [
+    {
+      "id": "9296070/G796KZSG",
+      "type": "article-journal",
+      "title": "Structure of a LISP system using two-level storage: Communications of the ACM",
+      "container-title": "Communications of the ACM",
+      "page": "155-159",
+      "volume": "10",
+      "issue": "3",
+      "abstract": "In an ideal list-processing system there would be enough core memory to contain all the data and programs. Described in this paper are a number of techniques that have been used to build a LISP system utilizing a drum for its principal storage medium, with a surprisingly low time penalty for use of this slow storage device. The techniques include careful segmentation of system programs, allocation of virtual memory to allow address arithmetic for type determination, and a special algorithm for building reasonably linearized lists. A scheme for binding variables is described which is good in this environment and allows for complete compatibility between compiled and interpreted programs with no special declarations.",
+      "URL": "https://dl.acm.org/doi/10.1145/363162.363185",
+      "DOI": "10.1145/363162.363185",
+      "journalAbbreviation": "Commun. ACM",
+      "language": "en",
+      "author": [
+        {
+          "family": "Bobrow",
+          "given": "Daniel G."
+        },
+        {
+          "family": "Murphy",
+          "given": "Daniel L."
+        }
+      ],
+      "issued": {
+        "date-parts": [
+          [
+            "1967"
+          ]
+        ]
+      },
+      "accessed": {
+        "date-parts": [
+          [
+            2021,
+            4,
+            16
+          ]
+        ]
+      }
+    },
+    {
+      "id": "9296070/PGGC8GAZ",
+      "type": "article",
+      "title": "Recent Improvements to 940 LISP Library",
+      "URL": "http://bitsavers.org/pdf/sds/9xx/940/ucbProjectGenie/940_LISP_Memo_2_Apr67.pdf",
+      "author": [
+        {
+          "family": "Teitelman",
+          "given": "Warren"
+        }
+      ],
+      "issued": {
+        "date-parts": [
+          [
+            "1967",
+            4,
+            10
+          ]
+        ]
+      },
+      "accessed": {
+        "date-parts": [
+          [
+            2021,
+            4,
+            21
+          ]
+        ]
+      }
+    },
+    {
+      "id": "9296070/LQAA78HI",
+      "type": "report",
+      "title": "The BBN-LISP System",
+      "page": "138",
+      "abstract": "This report describes the LISP system implemented at BBN on the \nSDS 940 Computer. This LISP is an upward compatible extension of \nLISP 1.5 for the IBM 7090, with a number of new features which \nmake it work well as an on-line language. These new features \ninclude tracing, and conditional breakpoints in functions for \ndebugging and a sophisticated LISP oriented editor. The BBN 940 \nLISP SYSTEM has a large memory store (approximately 50,000 free \nwords) utilizing special paging techniques for a drum to provide \nreasonable computation times. The system includes both an \ninterpreter, a fully compatible compiler, and an assembly language \nfacility for inserting machine code subroutines.",
+      "URL": "http://www.softwarepreservation.org/projects/LISP/bbnlisp/BBN940Lisp_Jul67.pdf/view",
+      "number": "9",
+      "language": "English",
+      "author": [
+        {
+          "family": "Daniel G. Bobrow",
+          "given": ""
+        },
+        {
+          "family": "D. Lucille Darley",
+          "given": ""
+        },
+        {
+          "family": "L. Peter Deutsch",
+          "given": ""
+        },
+        {
+          "family": "Daniel L. Murphy",
+          "given": ""
+        },
+        {
+          "family": "Warren Teitelman",
+          "given": ""
+        }
+      ],
+      "issued": {
+        "date-parts": [
+          [
+            "1967",
+            7,
+            15
+          ]
+        ]
+      },
+      "accessed": {
+        "date-parts": [
+          [
+            2021,
+            4,
+            23
+          ]
+        ]
+      }
+    }
+  ],
+  "1972": [
+    {
+      "id": "9296070/KP33M4DP",
+      "type": "article",
+      "title": "BBN - LISP, TENEX Reference Manual, Revised",
+      "publisher": "Bolt, Beranek and Newman, Inc. (BBN)",
+      "URL": "http://www.bitsavers.org/pdf/bbn/tenex/TenexLispRef_Aug72.pdf",
+      "author": [
+        {
+          "family": "Teitelman",
+          "given": "W."
+        },
+        {
+          "family": "Bobrow",
+          "given": "D. G."
+        },
+        {
+          "family": "Hartley",
+          "given": "A. K."
+        },
+        {
+          "family": "Murphy",
+          "given": "D. L."
+        }
+      ],
+      "issued": {
+        "date-parts": [
+          [
+            "1972",
+            8
+          ]
+        ]
+      },
+      "accessed": {
+        "date-parts": [
+          [
+            2021,
+            6,
+            1
+          ]
+        ]
+      }
+    },
+    {
+      "id": "9296070/QWKIX8DW",
+      "type": "paper-conference",
+      "title": "Automated programmering: the programmer's assistant",
+      "container-title": "Proceedings of the December 5-7, 1972, fall joint computer conference, part II",
+      "collection-title": "AFIPS '72 (Fall, part II)",
+      "publisher": "Association for Computing Machinery",
+      "publisher-place": "New York, NY, USA",
+      "page": "917–921",
+      "event-place": "New York, NY, USA",
+      "abstract": "This paper describes a research effort and programming system designed to facilitate the production of programs. Unlike automated programming, which focuses on developing systems that write programs, automated programmering involves developing systems which automate (or at least greatly facilitate) those tasks that a programmer performs other than writing programs: e.g., repairing syntactical errors to get programs to run in the first place, generating test cases, making tentative changes, retesting, undoing changes, reconfiguring, massive edits, et al., plus repairing and recovering from mistakes made during the above. When the system in which the programmer is operating is cooperative and helpful with respect to these activities, the programmer can devote more time and energy to the task of programming itself, i.e., to conceptualizing, designing and implementing. Consequently, he can be more ambitious, and more productive.",
+      "URL": "https://doi.org/10.1145/1480083.1480119",
+      "DOI": "10.1145/1480083.1480119",
+      "ISBN": "978-1-4503-7913-7",
+      "shortTitle": "Automated programmering",
+      "author": [
+        {
+          "family": "Teitelman",
+          "given": "Warren"
+        }
+      ],
+      "issued": {
+        "date-parts": [
+          [
+            "1972",
+            12,
+            5
+          ]
+        ]
+      },
+      "accessed": {
+        "date-parts": [
+          [
+            2021,
+            5,
+            31
+          ]
+        ]
+      }
+    }
+  ],
+  "1973": [
+    {
+      "id": "9296070/EM6WJF9A",
+      "type": "article-journal",
+      "title": "A model and stack implementation of multiple environments",
+      "container-title": "Communications of the ACM",
+      "page": "591-603",
+      "volume": "16",
+      "issue": "10",
+      "abstract": "Many control and access environment structures require that storage for a procedure activation exist at times when control is not nested within the procedure activated. This is straightforward to implement by dynamic storage allocation with linked blocks for each activation, but rather expensive in both time and space. This paper presents an implementation technique using a single stack to hold procedure activation storage which allows retention of that storage for durations not necessarily tied to control flow. The technique has the property that, in the simple case, it runs identically to the usual automatic stack allocation and deallocation procedure. Applications of this technique to multitasking, coroutines, backtracking, label-valued variables, and functional arguments are discussed. In the initial model, a single real processor is assumed, and the implementation assumes multiple-processes coordinate by passing control explicitly to one another. A multiprocessor implementation requires only a few changes to the basic technique, as described.",
+      "URL": "https://dl.acm.org/doi/10.1145/362375.362379",
+      "DOI": "10.1145/362375.362379",
+      "journalAbbreviation": "Commun. ACM",
+      "language": "en",
+      "author": [
+        {
+          "family": "Bobrow",
+          "given": "Daniel G."
+        },
+        {
+          "family": "Wegbreit",
+          "given": "Ben"
+        }
+      ],
+      "issued": {
+        "date-parts": [
+          [
+            "1973"
+          ]
+        ]
+      },
+      "accessed": {
+        "date-parts": [
+          [
+            2021,
+            4,
+            16
+          ]
+        ]
+      }
+    },
+    {
+      "id": "9296070/NQXP9QH8",
+      "type": "paper-conference",
+      "title": "A LISP machine with very compact programs",
+      "container-title": "Proceedings of the 3rd international joint conference on Artificial intelligence",
+      "collection-title": "IJCAI'73",
+      "publisher": "Morgan Kaufmann Publishers Inc.",
+      "publisher-place": "San Francisco, CA, USA",
+      "page": "697–703",
+      "event-place": "San Francisco, CA, USA",
+      "abstract": "This paper presents a machine designed for compact representation and rapid execution of LISP programs. The machine language is a factor of 2 to 5 more compact than S-expressions or conventional compiled code, and the compiler is extremely simple. The encoding scheme is potentially applicable to data as well as program. The machine also provides for user-defined data structures.",
+      "URL": "https://dl.acm.org/doi/abs/10.5555/1624775.1624860",
+      "author": [
+        {
+          "family": "Deutsch",
+          "given": "L. Peter"
+        }
+      ],
+      "issued": {
+        "date-parts": [
+          [
+            "1973",
+            8,
+            20
+          ]
+        ]
+      },
+      "accessed": {
+        "date-parts": [
+          [
+            2021,
+            5,
+            31
+          ]
+        ]
+      }
+    },
+    {
+      "id": "9296070/LSJRVJU8",
+      "type": "article-journal",
+      "title": "INTERLISP",
+      "container-title": "ACM SIGART Bulletin",
+      "page": "8-9",
+      "issue": "43",
+      "abstract": "INTERLISP (INTERactive LISP) is a LISP system currently implemented on the DEC PDP-10 under the BBN TENEX time sharing system<*R1>. INTERLISP is designed to provide the user access to the large virtual memory allowed by TENEX, with a relatively small penalty in speed (using special paging techniques described in <*R2>). Additional data types have been added, including strings, arrays, and hash association tables (hash links). The system includes a compatible compiler and interpreter. Machine code can be intermixed with INTERLISP expressions via the assemble directive of the compiler. The compiler also contains a facility for \"block compilation\" which allows a group of functions to be compiled as a unit, suppressing internal names. Each successive level of computation, from interpreted through compiled, to block-compiled provides greater speed at a cost of debugging ease.",
+      "URL": "https://doi.org/10.1145/1056786.1056787",
+      "DOI": "10.1145/1056786.1056787",
+      "journalAbbreviation": "SIGART Bull.",
+      "author": [
+        {
+          "family": "Teitelman",
+          "given": "Warren"
+        }
+      ],
+      "issued": {
+        "date-parts": [
+          [
+            "1973",
+            12,
+            1
+          ]
+        ]
+      },
+      "accessed": {
+        "date-parts": [
+          [
+            2021,
+            4,
+            15
+          ]
+        ]
+      }
+    },
+    {
+      "id": "9296070/I5AH4B95",
+      "type": "report",
+      "title": "An interactive program verifier",
+      "publisher-place": "California",
+      "event-place": "California",
+      "abstract": "Program verification refers to the idea that the intent or effect of a program can be stated in a precise way that is not a simple \"rewording \" of the program itself, and that one can prove (in the mathematical sense) that a program actually conforms to a given statement of intent. This thesis describes a software system which can verify (prove) some non-trivial programs automatically. The system described here is organized in a novel manner compared to most other theorem-proving systems. IL has a great deal of specific knowledge about integers and arrays of integers, yet it is not \"special-purpose\", since this knowledge is represented in procedures which are separate from the underlying structure of the system. It also incorporates some knowledge, gained by the author from both experiment and introspection, about how programs are often constructed, and uses this knowledge to guide the proof process. It uses its knowledge, plus contextual information from the program being verified, to simplify the theorems dramatically as they are being constructed, rather than relying on a super-powerful proof procedure. The system also provides for interactive editing of programs and assertions, and for detailed human control of the proof process when the system cannot produce a proof (or counter-example) on its own.",
+      "URL": "http://citeseerx.ist.psu.edu/viewdoc/summary?doi=10.1.1.696.5498",
+      "author": [
+        {
+          "family": "Deutsch",
+          "given": "L. Peter"
+        }
+      ],
+      "issued": {
+        "date-parts": [
+          [
+            "1973",
+            5
+          ]
+        ]
+      }
+    }
+  ],
+  "1975": [
+    {
+      "id": "9296070/QFBSW8AZ",
+      "type": "article-journal",
+      "title": "A note on hash linking",
+      "container-title": "Communications of the ACM",
+      "page": "413-415",
+      "volume": "18",
+      "issue": "7",
+      "abstract": "In current machine designs, a machine address gives the user direct access to a single piece of information, namely the contents of that machine word. This note is based on the observation that it is often useful to associate additional information, with some (relatively few) address locations determined at run time, without the necessity of preallocating the storage at all possible such addresses. That is, it can be useful to have an effective extra bit, field, or address in some words without every word having to contain a bit (or bits) to mark this as a special case. The key idea is that this extra associated information can be found by a table search. Although it could be found by any search technique (e.g. linear, binary sorted, etc.), we suggest that an appropriate low overhead mechanism is to use hash search on a table in which the key is the address of the cell to be augmented.",
+      "URL": "https://dl.acm.org/doi/10.1145/360881.360920",
+      "DOI": "10.1145/360881.360920",
+      "journalAbbreviation": "Commun. ACM",
+      "language": "en",
+      "author": [
+        {
+          "family": "Bobrow",
+          "given": "Daniel G."
+        }
+      ],
+      "issued": {
+        "date-parts": [
+          [
+            "1975"
+          ]
+        ]
+      },
+      "accessed": {
+        "date-parts": [
+          [
+            2021,
+            4,
+            16
+          ]
+        ]
+      }
+    },
+    {
+      "id": "9296070/KQM2N5FW",
+      "type": "report",
+      "title": "PIVOT source listing",
+      "publisher-place": "California",
+      "event-place": "California",
+      "abstract": "Program verification refers to the idea that the intent or effect of a program can be stated in a precise way that is not a simple \"rewording \" of the program itself, and that one can prove (in the mathematical sense) that a program actually conforms to a given statement of intent. This thesis describes a software system which can verify (prove) some non-trivial programs automatically. The system described here is organized in a novel manner compared to most other theorem-proving systems. IL has a great deal of specific knowledge about integers and arrays of integers, yet it is not \"special-purpose\", since this knowledge is represented in procedures which are separate from the underlying structure of the system. It also incorporates some knowledge, gained by the author from both experiment and introspection, about how programs are often constructed, and uses this knowledge to guide the proof process. It uses its knowledge, plus contextual information from the program being verified, to simplify the theorems dramatically as they are being constructed, rather than relying on a super-powerful proof procedure. The system also provides for interactive editing of programs and assertions, and for detailed human control of the proof process when the system cannot produce a proof (or counter-example) on its own.",
+      "URL": "http://www.softwarepreservation.org/projects/verification/pivot/Deutsch-Pivot.pdf",
+      "author": [
+        {
+          "family": "Deutsch",
+          "given": "L. Peter"
+        }
+      ],
+      "issued": {
+        "date-parts": [
+          [
+            "1975",
+            3,
+            19
+          ]
+        ]
+      }
+    },
+    {
+      "id": "9296070/JP52RFKS",
+      "type": "report",
+      "title": "Status Report on Alto Lisp",
+      "publisher": "PARC/CSL",
+      "publisher-place": "Palo Alto",
+      "page": "2",
+      "event-place": "Palo Alto",
+      "URL": "http://www.bitsavers.org/pdf/xerox/alto/memos_1975/Status_Report_on_Alto_Lisp_May75.pdf",
+      "shortTitle": "xerox",
+      "language": "eng",
+      "author": [
+        {
+          "family": "Deutsch",
+          "given": "P."
+        }
+      ],
+      "issued": {
+        "date-parts": [
+          [
+            "1975",
+            5,
+            14
+          ]
+        ]
+      },
+      "accessed": {
+        "date-parts": [
+          [
+            2021,
+            5,
+            31
+          ]
+        ]
+      }
+    }
+  ],
+  "1976": [
+    {
+      "id": "9296070/RAASKHRE",
+      "type": "article-journal",
+      "title": "An efficient, incremental, automatic garbage collector",
+      "container-title": "Communications of the ACM",
+      "page": "522-526",
+      "volume": "19",
+      "issue": "9",
+      "abstract": "This paper describes a new way of solving the storage reclamation problem for a system such as Lisp that allocates storage automatically from a heap, and does not require the programmer to give any indication that particular items are no longer useful or accessible. A reference count scheme for reclaiming non-self-referential structures, and a linearizing, compacting, copying scheme to reorganize all storage at the users discretion are proposed. The algorithms are designed to work well in systems which use multiple levels of storage, and large virtual address space. They depend on the fact that most cells are referenced exactly once, and that reference counts need only be accurate when storage is about to be reclaimed. A transaction file stores changes to reference counts, and a multiple reference table stores the count for items which are referenced more than once.",
+      "URL": "https://dl.acm.org/doi/10.1145/360336.360345",
+      "DOI": "10.1145/360336.360345",
+      "journalAbbreviation": "Commun. ACM",
+      "language": "en",
+      "author": [
+        {
+          "family": "Deutsch",
+          "given": "L. Peter"
+        },
+        {
+          "family": "Bobrow",
+          "given": "Daniel G."
+        }
+      ],
+      "issued": {
+        "date-parts": [
+          [
+            "1976"
+          ]
+        ]
+      },
+      "accessed": {
+        "date-parts": [
+          [
+            2021,
+            4,
+            16
+          ]
+        ]
+      }
+    },
+    {
+      "id": "9296070/QBBQSH3V",
+      "type": "article-journal",
+      "title": "Clisp: Conversational Lisp",
+      "container-title": "IEEE Transactions on Computers",
+      "page": "354-357",
+      "volume": "C-25",
+      "issue": "4",
+      "abstract": "Clisp is an attempt to make Lisp programs easier to read and write by extending the syntax of Lisp to include infix operators, IF-THEN statements, FOR-DO-WHILE statements, and similar Algol-like constructs, without changing the structure or representation of the language. Clisp is implemented through Lisp's error handling machinery, rather than by modifying the interpreter. When an expression is encountered whose evaluation causes an error, the expression is scanned for possible Clisp constructs, which are then converted to the equivalent Lisp expressions. Thus, users can freely intermix Lisp and Clisp without ut having to distinguish which is which. Emphasis in the design and development of Clisp has been on the system aspects of such a facility, with the goal of producing a useful tool, not just another language. To this end, Clisp includes interactive error correction and many \"do-what-I-mean\" features.",
+      "URL": "http://www.softwarepreservation.org/projects/LISP/interlisp/Teitelman-3IJCAI.pdf/view",
+      "DOI": "10.1109/TC.1976.1674617",
+      "note": "Conference Name: IEEE Transactions on Computers",
+      "shortTitle": "Clisp",
+      "author": [
+        {
+          "family": "Teitelman",
+          "given": "Warren"
+        }
+      ],
+      "issued": {
+        "date-parts": [
+          [
+            "1976",
+            4
+          ]
+        ]
+      }
+    },
+    {
+      "id": "9296070/P43BUE35",
+      "type": "webpage",
+      "title": "PARCMESSAGE.TXT.1.",
+      "container-title": "Software Preservation Group",
+      "URL": "http://www.softwarepreservation.org/projects/LISP/interlisp/tenex/twenex.org/PARCMESSAGE.TXT.1/view",
+      "author": [
+        {
+          "family": "Masinter",
+          "given": "Larry"
+        }
+      ],
+      "issued": {
+        "date-parts": [
+          [
+            "1976",
+            1
+          ]
+        ]
+      },
+      "accessed": {
+        "date-parts": [
+          [
+            2021,
+            4,
+            23
+          ]
+        ]
+      }
+    }
+  ],
+  "1978": [
+    {
+      "id": "9296070/QXZFUW4U",
+      "type": "article-journal",
+      "title": "Experience with a microprogrammed Interlisp system",
+      "container-title": "ACM SIGMICRO Newsletter",
+      "page": "128–129",
+      "volume": "9",
+      "issue": "4",
+      "abstract": "This paper presents the design of an Interlisp system running on a microprogrammed minicomputer. We discuss the constraints imposed by compatibility requirements and by the hardware, the important design decisions, and the most prominent successes and failures of our design, and offer some suggestions for future designers of small Lisp systems. This extended abstract contains only qualitative results. Supporting measurement data will be presented at MICRO-11.",
+      "URL": "https://doi.org/10.1145/1014198.804321",
+      "DOI": "10.1145/1014198.804321",
+      "journalAbbreviation": "SIGMICRO Newsl.",
+      "author": [
+        {
+          "family": "Deutsch",
+          "given": "L. Peter"
+        }
+      ],
+      "issued": {
+        "date-parts": [
+          [
+            "1978",
+            11,
+            19
+          ]
+        ]
+      },
+      "accessed": {
+        "date-parts": [
+          [
+            2021,
+            5,
+            31
+          ]
+        ]
+      }
+    },
+    {
+      "id": "9296070/JEW9IHTC",
+      "type": "article",
+      "title": "INSIDE INTERLISP: TWO IMPLEMENTATIONS",
+      "publisher": "Xerox Palo Alto Research Center",
+      "URL": "http://www.softwarepreservation.org/projects/LISP/interlisp/Deutsch-Inside_Interlisp-1978.pdf",
+      "language": "English",
+      "author": [
+        {
+          "family": "Deutsch",
+          "given": "L. Peter"
+        }
+      ],
+      "issued": {
+        "date-parts": [
+          [
+            "1978",
+            11,
+            26
+          ]
+        ]
+      }
+    }
+  ],
+  "1979": [
+    {
+      "id": "9296070/PE98QZ2L",
+      "type": "paper-conference",
+      "title": "Raster graphics for interactive programming environments",
+      "container-title": "Proceedings of the 6th annual conference on Computer graphics and interactive techniques",
+      "collection-title": "SIGGRAPH '79",
+      "publisher": "Association for Computing Machinery",
+      "publisher-place": "New York, NY, USA",
+      "page": "83–93",
+      "event-place": "New York, NY, USA",
+      "abstract": "Raster-scan display terminals can significantly improve the quality of interaction with conventional computer systems. The design of a graphics package to provide a “window” into the extensive programming environment of interlisp is presented. Two aspects of the package are described: first, the functional view of display output and interactive input facilities as seen by the programmer, and second, the methods used to link the display terminal to the main computer via a packet-switched computer network. Recommendations are presented for designing operating systems and programming languages so as to simplify attaching display terminals.",
+      "URL": "https://doi.org/10.1145/800249.807428",
+      "DOI": "10.1145/800249.807428",
+      "ISBN": "978-0-89791-004-4",
+      "author": [
+        {
+          "family": "Sproull",
+          "given": "Robert F."
+        }
+      ],
+      "issued": {
+        "date-parts": [
+          [
+            "1979",
+            8,
+            1
+          ]
+        ]
+      },
+      "accessed": {
+        "date-parts": [
+          [
+            2021,
+            4,
+            15
+          ]
+        ]
+      }
+    },
+    {
+      "id": "9296070/H5Q65H3M",
+      "type": "paper-conference",
+      "title": "Extending Interlisp for modularization and efficiency",
+      "container-title": "Proceedings of the International Symposiumon on Symbolic and Algebraic Computation",
+      "collection-title": "EUROSAM '79",
+      "publisher": "Springer-Verlag",
+      "publisher-place": "Berlin, Heidelberg",
+      "page": "481–489",
+      "event-place": "Berlin, Heidelberg",
+      "URL": "https://dl.acm.org/doi/10.5555/646670.699000",
+      "ISBN": "978-3-540-09519-5",
+      "author": [
+        {
+          "family": "Bobrow",
+          "given": "Daniel G."
+        },
+        {
+          "family": "Deutsch",
+          "given": "L. Peter"
+        }
+      ],
+      "issued": {
+        "date-parts": [
+          [
+            "1979",
+            6,
+            1
+          ]
+        ]
+      },
+      "accessed": {
+        "date-parts": [
+          [
+            2021,
+            6,
+            3
+          ]
+        ]
+      }
+    },
+    {
+      "id": "9296070/IZ6P44N3",
+      "type": "article-journal",
+      "title": "A display oriented programmer's assistant",
+      "container-title": "International Journal of Man-Machine Studies",
+      "page": "157-187",
+      "volume": "11",
+      "issue": "2",
+      "abstract": "This paper continues and extends previous work by the author in developing systems which provide the user with various forms of explicit and implicit assistance, and in general co-operate with the user in the development of his programs. The system described in this paper makes extensive use of a bit map display and pointing device (a mouse) to significantly enrich the user's interactions with the system, and to provide capabilities not possible with terminals that essentially emulate hard copy devices. For example, any text that is displayed on the screen can be pointed at and treated as input, exactly as though it were typed, i.e. the user can say use this expression or that value, and then simply point. The user views his programming environment through a collection of display windows, each of which corresponds to a different task or context. The user can manipulate the windows, or the contents of a particular window, by a combination of keyboard inputs or pointing operations. The technique of using different windows for different tasks makes it easy for the user to manage several simultaneous tasks and contexts, e.g. defining programs, testing programs, editing, asking the system for assistance, sending and receiving messages, etc. and to switch back and forth between these tasks at his convenience.",
+      "URL": "https://www.sciencedirect.com/science/article/pii/S0020737379800152",
+      "DOI": "10.1016/S0020-7373(79)80015-2",
+      "journalAbbreviation": "International Journal of Man-Machine Studies",
+      "language": "en",
+      "author": [
+        {
+          "family": "Teitelman",
+          "given": "Warren"
+        }
+      ],
+      "issued": {
+        "date-parts": [
+          [
+            "1979",
+            3,
+            1
+          ]
+        ]
+      },
+      "accessed": {
+        "date-parts": [
+          [
+            2021,
+            5,
+            31
+          ]
+        ]
+      }
+    },
+    {
+      "id": "9296070/59BVIIF8",
+      "type": "report",
+      "title": "The INTERLISP Virtual Machine Specification: Revised",
+      "page": "126",
+      "abstract": "The INTERLISP Virtual Machine is the environment in which the INTERLISP System is implemented. It includes such abstract objects as ~Literal Atom s~. List CelIs~, ‘Integers. etc.. the basic LISP functions for manipulating them, the underlying program control, and variable binding mechanisms. the input/output facilities, and interrupt processing facilities. In order to implement the INTERLISP System (as described in The INTERLISP Reference Manual by W. Teitelman. et. al.) on some physical machine, it is only necessary to implement the INTERLISP Virtual Machine. since Virtual Machine compatible source code for the rest of the INTERLISP System can be obtained from publicly available files. This document specifies the behavior of the INTERLISP Virtual Machine from the implementor s point of view. That is. it is an attempt to make explicit those things that must be implemented to allow the INTERLISP System to run on some machine.",
+      "URL": "http://www.cs.utexas.edu/~moore/publications/interlisp-vm.pdf",
+      "author": [
+        {
+          "family": "Moore",
+          "given": "J. Strother"
+        }
+      ],
+      "issued": {
+        "date-parts": [
+          [
+            "1979",
+            3
+          ]
+        ]
+      }
+    },
+    {
+      "id": "9296070/BSE5UV9A",
+      "type": "article-journal",
+      "title": "Compact Encodings of List Structure",
+      "container-title": "ACM Transactions on Programming Languages and Systems",
+      "page": "266-286",
+      "volume": "1",
+      "issue": "2",
+      "abstract": "List structures provide a general mechanism for representing easily changed structured data, but can introduce inefficiencies in the use of space when fields of uniform size are used to contain pointers to data and to link the structure. Empirically determined regularity can be exploited to provide more space-efficient encodings without losing the flexibility inherent in list structures. The basic scheme is to provide compact pointer fields big enough to accommodate most values that occur in them and to provide “escape” mechanisms for exceptional cases. Several examples of encoding designs are presented and evaluated, including two designs currently used in Lisp machines. Alternative escape mechanisms are described, and various questions of cost and implementation are discussed. In order to extrapolate our results to larger systems than those measured, we propose a model for the generation of list pointers and we test the model against data from two programs. We show that according to our model, list structures with compact cdr fields will, as address space grows, continue to be compacted well with a fixed-width small field. Our conclusion is that with a microcodable processor, about a factor of two gain in space efficiency for list structure can be had for little or no cost in processing time.",
+      "URL": "https://dl.acm.org/doi/10.1145/357073.357081",
+      "DOI": "10.1145/357073.357081",
+      "journalAbbreviation": "ACM Trans. Program. Lang. Syst.",
+      "language": "en",
+      "author": [
+        {
+          "family": "Bobrow",
+          "given": "Daniel G."
+        },
+        {
+          "family": "Clark",
+          "given": "Douglas W."
+        }
+      ],
+      "issued": {
+        "date-parts": [
+          [
+            "1979",
+            10
+          ]
+        ]
+      },
+      "accessed": {
+        "date-parts": [
+          [
+            2021,
+            4,
+            21
+          ]
+        ]
+      }
+    }
+  ],
+  "1980": [
+    {
+      "id": "9296070/4EDHAKDB",
+      "type": "paper-conference",
+      "title": "Local optimization in a compiler for stack-based Lisp machines",
+      "container-title": "Proceedings of the 1980 ACM conference on LISP and functional programming",
+      "collection-title": "LFP '80",
+      "publisher": "Association for Computing Machinery",
+      "publisher-place": "New York, NY, USA",
+      "page": "223–230",
+      "event-place": "New York, NY, USA",
+      "abstract": "We describe the local optimization phase of a compiler for translating the INTERLISP dialect of LISP into stack-architecture (0-address) instruction sets. We discuss the general organization of the compiler, and then describe the set of optimization techniques found most useful, based on empirical results gathered by compiling a large set of programs. The compiler and optimization phase are machine independent, in that they generate a stream of instructions for an abstract stack machine, which an assembler subsequently turns into the actual machine instructions. The compiler has been in successful use for several years, producing code for two different instruction sets.",
+      "URL": "https://doi.org/10.1145/800087.802810",
+      "DOI": "10.1145/800087.802810",
+      "ISBN": "978-1-4503-7396-8",
+      "author": [
+        {
+          "family": "Masinter",
+          "given": "Larry M."
+        },
+        {
+          "family": "Deutsch",
+          "given": "L. Peter"
+        }
+      ],
+      "issued": {
+        "date-parts": [
+          [
+            "1980",
+            8,
+            25
+          ]
+        ]
+      },
+      "accessed": {
+        "date-parts": [
+          [
+            2021,
+            4,
+            26
+          ]
+        ]
+      }
+    },
+    {
+      "id": "9296070/8SMP58AA",
+      "type": "paper-conference",
+      "title": "ByteLisp and its Alto implementation",
+      "container-title": "Proceedings of the 1980 ACM conference on LISP and functional programming",
+      "collection-title": "LFP '80",
+      "publisher": "Association for Computing Machinery",
+      "publisher-place": "New York, NY, USA",
+      "page": "231–242",
+      "event-place": "New York, NY, USA",
+      "abstract": "This paper describes in detail the most interesting aspects of ByteLisp, a transportable Lisp system architecture which implements the Interlisp dialect of Lisp, and its first implementation, on a microprogrammed minicomputer called the Alto. Two forthcoming related papers will deal with general questions of Lisp machine and system architecture, and detailed measurements of the Alto ByteLisp system described here. A highly condensed summary of the series was published at MICRO-11 in November 197815.",
+      "URL": "https://doi.org/10.1145/800087.802811",
+      "DOI": "10.1145/800087.802811",
+      "ISBN": "978-1-4503-7396-8",
+      "author": [
+        {
+          "family": "Deutsch",
+          "given": "L. Peter"
+        }
+      ],
+      "issued": {
+        "date-parts": [
+          [
+            "1980",
+            8,
+            25
+          ]
+        ]
+      },
+      "accessed": {
+        "date-parts": [
+          [
+            2021,
+            5,
+            31
+          ]
+        ]
+      }
+    },
+    {
+      "id": "9296070/WPDGQV37",
+      "type": "paper-conference",
+      "title": "Overview and status of DoradoLisp",
+      "container-title": "Proceedings of the 1980 ACM conference on LISP and functional programming",
+      "collection-title": "LFP '80",
+      "publisher": "Association for Computing Machinery",
+      "publisher-place": "New York, NY, USA",
+      "page": "243-247",
+      "event-place": "New York, NY, USA",
+      "abstract": "DoradoLisp is an implementation of the Interlisp programming system on a large personal computer. It has evolved from AltoLisp, an implementation on a less powerful machine. The major goal of the Dorado implementation was to eliminate the performance deficiencies of the previous system. This paper describes the current status of the system and discusses some of the issues that arose during its implementation. Among the techniques that helped us meet our performance goal were transferring much of the kernel software into Lisp, intensive use of performance measurement tools to determine the areas of worst performance, and use of the Interlisp programming environment to allow rapid and widespread improvements to the system code. The paper lists some areas in which performance was critical and offers some observations on how our experience might be useful to other implementations of Interlisp.",
+      "URL": "https://doi.org/10.1145/800087.802812",
+      "DOI": "10.1145/800087.802812",
+      "ISBN": "978-1-4503-7396-8",
+      "author": [
+        {
+          "family": "Burton",
+          "given": "Richard R."
+        },
+        {
+          "family": "Masinter",
+          "given": "L. M."
+        },
+        {
+          "family": "Bobrow",
+          "given": "Daniel G."
+        },
+        {
+          "family": "Haugeland",
+          "given": "Willie Sue"
+        },
+        {
+          "family": "Kaplan",
+          "given": "Ronald M."
+        },
+        {
+          "family": "Sheil",
+          "given": "B. A."
+        }
+      ],
+      "issued": {
+        "date-parts": [
+          [
+            "1980",
+            8,
+            25
+          ]
+        ]
+      },
+      "accessed": {
+        "date-parts": [
+          [
+            2021,
+            4,
+            25
+          ]
+        ]
+      }
+    },
+    {
+      "id": "9296070/L6DXES8K",
+      "type": "article-journal",
+      "title": "Special issue on knowledge representation",
+      "container-title": "ACM SIGART Bulletin",
+      "page": "1-138",
+      "issue": "70",
+      "abstract": "In the fall of 1978 we decided to produce a special issue of the SIGART Newsletter devoted to a survey of current knowledge representation research. We felt that there were twe useful functions such an issue could serve. First, we hoped to elicit a clear picture of how people working in this subdiscipline understand knowledge representation research, to illuminate the issues on which current research is focused, and to catalogue what approaches and techniques are currently being developed. Second -- and this is why we envisaged the issue as a survey of many different groups and projects -- we wanted to provide a document that would enable the reader to acquire at least an approximate sense of how each of the many different research endesvours around the world fit into the field as a whole.It would of course be impossible to produce a final or definitive document accomplishing these goals: rather, we hoped that this survey could initiate a continuing dialogue on issues in representation, a project for which this newsletter seems the ideal forum. It has been many months since our original decision was made, but we are finally able to present the results of that survey. Perhaps more than anything else, it has emerged as a testament to an astounding range and variety of opinions held by many different people in many different places.The following few pages are intended as an introduction to the survey as a whole, and to this issue of the newsletter. We will briefly summarize the form that the survey took, discuss the strategies we followed in analyzing and tabulating responses, briefly review the overall sense we received from the answers that were submitted, and discuss various criticisms which were submitted along with the responses. The remainder of the volume has been designed to be roughly self-explanatory at each point, so that one may dip into it at different places at will. Certain conventions, however, particularly regarding indexing and tabulating, will also be explained in the remainder of this introduction.As editors, we are enormously grateful to the many people who devoted substantial effort to responding to our survey. It is our hope that the material presented here will be interesting and helpful to our readers, and that fruitful discussion of these and other issues will continue energetically and enthusiastically into the future.",
+      "URL": "https://doi.org/10.1145/1056751.1056752",
+      "DOI": "10.1145/1056751.1056752",
+      "journalAbbreviation": "SIGART Bull.",
+      "author": [
+        {
+          "family": "Brachman",
+          "given": "Ronald J."
+        },
+        {
+          "family": "Smith",
+          "given": "Brian C."
+        }
+      ],
+      "issued": {
+        "date-parts": [
+          [
+            "1980",
+            2,
+            1
+          ]
+        ]
+      },
+      "accessed": {
+        "date-parts": [
+          [
+            2021,
+            4,
+            25
+          ]
+        ]
+      }
+    },
+    {
+      "id": "9296070/9B3ESHMP",
+      "type": "report",
+      "title": "Papers on interlisp-D",
+      "collection-title": "COGNITIVE AND INSTRUCTIONAL SCIENCES SERIES CIS.5 (SSL-80-4",
+      "page": "52",
+      "abstract": "This report consists of five papers on Interlisp-0, a refinement and implementation of the\nI[ tnterlisp virtual machine [Moore, 761 which supports the interlisp programming system\n[Teitelman et at., 781 on the Dolphin and Dorado personal computers",
+      "URL": "http://www.softwarepreservation.net/projects/LISP/interlisp-d/Papers_On_Interlisp-D.pdf",
+      "author": [
+        {
+          "family": "Burton",
+          "given": "Richard R."
+        },
+        {
+          "family": "Kaplan",
+          "given": "Ronald M."
+        },
+        {
+          "family": "Masinter",
+          "given": "B."
+        },
+        {
+          "family": "Sheil",
+          "given": "B. A."
+        },
+        {
+          "family": "Bell",
+          "given": "A."
+        },
+        {
+          "family": "Bobrow",
+          "given": "D. G."
+        },
+        {
+          "family": "Deutsch",
+          "given": "L. P."
+        },
+        {
+          "family": "Haugeland",
+          "given": "W. S."
+        }
+      ],
+      "issued": {
+        "date-parts": [
+          [
+            "1980",
+            9
+          ]
+        ]
+      }
+    }
+  ],
+  "1981": [
+    {
+      "id": "9296070/6BCFJ639",
+      "type": "report",
+      "title": "Interlisp-VAX: A Report",
+      "publisher": "Department of Computer Science, Stanford University",
+      "publisher-place": "Stailford University Stanford, CA 94305",
+      "page": "13",
+      "event-place": "Stailford University Stanford, CA 94305",
+      "URL": "http://www.softwarepreservation.org/projects/LISP/interlisp/Interlisp-VAX_A_Report.pdf/view",
+      "number": "SUN-CS-81-879",
+      "author": [
+        {
+          "family": "Masintcr",
+          "given": "Larry M."
+        }
+      ],
+      "issued": {
+        "date-parts": [
+          [
+            "1981",
+            8,
+            1
+          ]
+        ]
+      },
+      "accessed": {
+        "date-parts": [
+          [
+            2021,
+            4,
+            23
+          ]
+        ]
+      }
+    },
+    {
+      "id": "9296070/W96JCCYH",
+      "type": "paper-conference",
+      "title": "Overview of a display-oriented editor for INTERLISP",
+      "container-title": "Proceedings of the 7th international joint conference on Artificial intelligence - Volume 2",
+      "collection-title": "IJCAI'81",
+      "publisher": "Morgan Kaufmann Publishers Inc.",
+      "publisher-place": "San Francisco, CA, USA",
+      "page": "927–929",
+      "event-place": "San Francisco, CA, USA",
+      "abstract": "DED is a display-oriented editor that was designed to add the power and convenience of display terminals to INTERLISPs teletype-oriented structure editor. DED divides the display screen into a Prettypnnt Region and an Interaction Region. The Prettypnnt Region gives a prettyprinted view of the structure being edited; the Interaction Region contains the interaction between the user and INTERLISPs standard editor. DEDs prettyprinter allows ellision, and the user may zoom in or out to see the expression being edited with more or less detail. There are several arrow keys which allow the user to change quite easily the locus of attention in certain structural ways, as well as a menu-like facility for common command sequences. Together, these features provide a display-facility that considerably augments INTERLISPs otherwise quite sophisticated user interface.",
+      "URL": "https://dl.acm.org/doi/abs/10.5555/1623264.1623329",
+      "author": [
+        {
+          "family": "Barstow",
+          "given": "David R."
+        }
+      ],
+      "issued": {
+        "date-parts": [
+          [
+            "1981",
+            8,
+            24
+          ]
+        ]
+      },
+      "accessed": {
+        "date-parts": [
+          [
+            2021,
+            5,
+            4
+          ]
+        ]
+      }
+    },
+    {
+      "id": "9296070/C6TTQVYB",
+      "type": "article-journal",
+      "title": "Interlisp-D: further steps in the flight from time-sharing",
+      "container-title": "ACM SIGART Bulletin",
+      "page": "31–32",
+      "issue": "77",
+      "abstract": "The Interslip-D project was formed to develop a personal machine inplementation of Interlisp for use as an environment for research in artificial intelligence and cognitive science [Burton et al., 80b]. This note describes the principal developments since our last report almost a year ago [Burton et al., 80a].",
+      "URL": "https://doi.org/10.1145/1056743.1056745",
+      "DOI": "10.1145/1056743.1056745",
+      "shortTitle": "Interlisp-D",
+      "journalAbbreviation": "SIGART Bull.",
+      "author": [
+        {
+          "family": "Sheil",
+          "given": "Beau"
+        }
+      ],
+      "issued": {
+        "date-parts": [
+          [
+            "1981",
+            7,
+            1
+          ]
+        ]
+      },
+      "accessed": {
+        "date-parts": [
+          [
+            2021,
+            4,
+            15
+          ]
+        ]
+      }
+    }
+  ],
+  "1982": [
+    {
+      "id": "9296070/G4F5FZND",
+      "type": "paper-conference",
+      "title": "Implementation of Interlisp on the VAX",
+      "container-title": "Proceedings of the 1982 ACM symposium on LISP and functional programming  - LFP '82",
+      "publisher": "ACM Press",
+      "publisher-place": "Pittsburgh, Pennsylvania, United States",
+      "page": "81-87",
+      "event": "the 1982 ACM symposium",
+      "event-place": "Pittsburgh, Pennsylvania, United States",
+      "abstract": "This paper presents some of the issues involved in implementing Interlisp [19] on a VAX computer [24] with the goal of producing a version that runs under UNIX[17], specifically Berkeley VM/UNIX. This implementation has the following goals:\n• To be compatible with and functionally equivalent to Interlisp-10.\n\n• To serve as a basis for future Interlisp implementations on other mainframe computers. This goal requires that the implementation to be portable.\n\n• To support a large virtual address space.\n\n• To achieve a reasonable speed.\n\nThe implemention draws directly from three sources, Interlisp-10 [19], Interlisp-D [5], and Multilisp [12]. Interlisp-10, the progenitor of all Interlisps, runs on the PDP-10 under the TENEX [2] and TOPS-20 operating systems. Interlisp-D, developed at Xerox Palo Alto Research Center, runs on personal computers also developed at PARC. Multilisp, developed at the University of British Columbia, is a portable interpreter containing a kernel of Interlisp, written in Pascal [9] and running on the IBM Series/370 and the VAX. The Interlisp-VAX implementation relies heavily on these implementations. In turn, Interlisp-D and Multilisp were developed from The Interlisp Virtual Machine Specification [15] by J Moore (subsequently referred to as the VM specification), which discusses what is needed to implement an Interlisp by describing an Interlisp Virtual Machine from the implementors' point of view. Approximately six man-years of effort have been spent exclusively in developing Interlisp-VAX, plus the benefit of many years of development for the previous Interlisp implementations.",
+      "URL": "http://portal.acm.org/citation.cfm?doid=800068.802138",
+      "DOI": "10.1145/800068.802138",
+      "ISBN": "978-0-89791-082-6",
+      "language": "en",
+      "author": [
+        {
+          "family": "Bates",
+          "given": "Raymond L."
+        },
+        {
+          "family": "Dyer",
+          "given": "David"
+        },
+        {
+          "family": "Koomen",
+          "given": "Johannes A. G. M."
+        }
+      ],
+      "issued": {
+        "date-parts": [
+          [
+            "1982",
+            8
+          ]
+        ]
+      },
+      "accessed": {
+        "date-parts": [
+          [
+            2021,
+            4,
+            16
+          ]
+        ]
+      }
+    },
+    {
+      "id": "9296070/8AB9NPK7",
+      "type": "book",
+      "title": "Interlisp-VAX Users Manual",
+      "publisher": "Xerox Corporation",
+      "publisher-place": "300 N. Halstead St. Pasadena CA 91107 USA",
+      "number-of-pages": "57",
+      "edition": "First",
+      "event-place": "300 N. Halstead St. Pasadena CA 91107 USA",
+      "URL": "http://www.softwarepreservation.org/projects/LISP/interlisp/Interlisp-VAX-Users_Manual.pdf/view",
+      "language": "English",
+      "author": [
+        {
+          "family": "Bates",
+          "given": "Raymond"
+        },
+        {
+          "family": "David",
+          "given": "Dayer"
+        },
+        {
+          "family": "Koomen",
+          "given": "Johannes"
+        },
+        {
+          "family": "Saunders",
+          "given": "Steven"
+        },
+        {
+          "family": "Voreck",
+          "given": "Donald"
+        }
+      ],
+      "issued": {
+        "date-parts": [
+          [
+            "1982",
+            12,
+            5
+          ]
+        ]
+      },
+      "accessed": {
+        "date-parts": [
+          [
+            2021,
+            4,
+            23
+          ]
+        ]
+      }
+    }
+  ],
+  "1983": [
+    {
+      "id": "9296070/XR77BB2T",
+      "type": "paper-conference",
+      "title": "Large-scale system development in several lisp environments",
+      "container-title": "Proceedings of the Eighth international joint conference on Artificial intelligence - Volume 2",
+      "collection-title": "IJCAI'83",
+      "publisher": "Morgan Kaufmann Publishers Inc.",
+      "publisher-place": "San Francisco",
+      "page": "859–861",
+      "event-place": "San Francisco",
+      "abstract": "ROSS [7] is an object-oriented language developed for building knowledge-based simulations [4]. SWIRL [5, 6] is a program written in ROSS that embeds knowledge about defensive and offensive air battle strategies. Given an initial configuration of military forces, SWIRL simulates the resulting air battle. We have implemented ROSS and SWIRL in several different Lisp environments. We report upon this experience by comparing the various environments in terms of cpu usage, real-time usage, and various user aids.",
+      "URL": "https://dl.acm.org/doi/10.5555/1623516.1623579",
+      "author": [
+        {
+          "family": "Naraln",
+          "given": "Sanjai"
+        },
+        {
+          "family": "McArthur",
+          "given": "David"
+        },
+        {
+          "family": "Klahr",
+          "given": "Philip"
+        }
+      ],
+      "issued": {
+        "date-parts": [
+          [
+            "1983",
+            8,
+            8
+          ]
+        ]
+      },
+      "accessed": {
+        "date-parts": [
+          [
+            2021,
+            6,
+            3
+          ]
+        ]
+      }
+    },
+    {
+      "id": "9296070/MSBZ5IMI",
+      "type": "article",
+      "title": "Interlisp reference manual",
+      "publisher": "Xerox Corporation",
+      "abstract": "Interlisp began with an implementation of the Lisp programming language for the PDP-1 at Bolt. Beranek and Newman in 1966. It was followed in 1967 by 940 Lisp, an upward compatible implementation for\nthe SDS-940 computer. 940 Lisp was the first Lisp system to demonstrate the feasibility of using software paging techniques and a large vinual memory in conjunction with a list-processing system [Bobrow & ( -----\\\n) Murphy, 1967]. 940 Lisp was patterned after the Lisp 1.5 ~plementation for CTSS at MIT, with several' ) 1ew facilities added to take advantage of its timeshared. on-line environment. DWIM, the Do-What+\nMean error correction facility, was introduced into this system in 1968 by Warren Teitelman [Teitelman. 1969].",
+      "URL": "https://larrymasinter.net/86-interlisp-manual-opt.pdf",
+      "note": "OCLC: 802551877",
+      "shortTitle": "Interlisp reference manual",
+      "language": "English",
+      "author": [
+        {
+          "family": "Xerox",
+          "given": ""
+        }
+      ],
+      "issued": {
+        "date-parts": [
+          [
+            "1983",
+            10
+          ]
+        ]
+      }
+    },
+    {
+      "id": "9296070/E5NDSA26",
+      "type": "report",
+      "title": "AQINTERLISP: An INTERLISP Program for Inductive Generalization of VL1 Event Sets",
+      "publisher": "University of Illinois Urbana-Champaign",
+      "URL": "https://www.mli.gmu.edu/papers/81-85/83-28.pdf",
+      "number": "ISG 83-28",
+      "shortTitle": "AQINTERLISP",
+      "author": [
+        {
+          "family": "Becker",
+          "given": "Jeffrey M."
+        }
+      ],
+      "issued": {
+        "date-parts": [
+          [
+            "1983",
+            9
+          ]
+        ]
+      }
+    }
+  ],
+  "1984": [
+    {
+      "id": "9296070/BNAYT94G",
+      "type": "paper-conference",
+      "title": "Recent developments in ISI-interlisp",
+      "container-title": "Proceedings of the 1984 ACM Symposium on LISP and functional programming",
+      "collection-title": "LFP '84",
+      "publisher": "Association for Computing Machinery",
+      "publisher-place": "New York, NY, USA",
+      "page": "129–139",
+      "event-place": "New York, NY, USA",
+      "abstract": "This paper reports on recent developments of the ISI- Interlisp implementation of Interlisp on a VAX computer. ISI-Interlisp currently runs under UNIX, specifically the Berkeley VM/UNIX and VMS operating systems. Particular attention is paid to the current status of the implementation and the growing pains experienced in the last few years. Included is a discussion of the conversion from UNIX to VAX/VMS, recent modifications and improvements, current limitations, and projected goals. Since much of the recent effort has concerned performance tuning, our observations on this activity are included. ISI-Interlisp, formerly known as Interlisp-VAX, was reported in 1982 ACM Symposium on LISP and Functional Programming, August 1982 [1]. Experiences and recommendations since the 1982 LISP conference are presented.",
+      "URL": "https://doi.org/10.1145/800055.802029",
+      "DOI": "10.1145/800055.802029",
+      "ISBN": "978-0-89791-142-3",
+      "author": [
+        {
+          "family": "Bates",
+          "given": "Raymond L."
+        },
+        {
+          "family": "Dyer",
+          "given": "David"
+        },
+        {
+          "family": "Feber",
+          "given": "Mark"
+        }
+      ],
+      "issued": {
+        "date-parts": [
+          [
+            "1984",
+            8,
+            6
+          ]
+        ]
+      },
+      "accessed": {
+        "date-parts": [
+          [
+            2021,
+            6,
+            2
+          ]
+        ]
+      }
+    }
+  ],
+  "1985": [
+    {
+      "id": "9296070/MVHYRDBF",
+      "type": "article-journal",
+      "title": "Understanding and solving arithmetic word problems: A computer simulation",
+      "container-title": "Behavior Research Methods, Instruments, & Computers",
+      "page": "565-571",
+      "volume": "17",
+      "issue": "5",
+      "URL": "http://link.springer.com/10.3758/BF03207654",
+      "DOI": "10.3758/BF03207654",
+      "shortTitle": "Understanding and solving arithmetic word problems",
+      "journalAbbreviation": "Behavior Research Methods, Instruments, & Computers",
+      "language": "en",
+      "author": [
+        {
+          "family": "Fletcher",
+          "given": "Charles R."
+        }
+      ],
+      "issued": {
+        "date-parts": [
+          [
+            "1985"
+          ]
+        ]
+      },
+      "accessed": {
+        "date-parts": [
+          [
+            2022,
+            8,
+            4
+          ]
+        ]
+      }
+    },
+    {
+      "id": "9296070/PMXCAM4Y",
+      "type": "article",
+      "title": "1985 Harmony and Intermezzo releases Koto release (for Xerox 1186), some bits of Common Lisp",
+      "URL": "https://www.google.com/search?client=firefox-b-d&q=1985+Harmony+and+Intermezzo+releases+Koto+release+%28for+Xerox+1186%29%2C+some+bits+of+Common+Lisp",
+      "language": "English",
+      "author": [
+        {
+          "family": "XEROX",
+          "given": ""
+        }
+      ],
+      "issued": {
+        "date-parts": [
+          [
+            "1985",
+            12
+          ]
+        ]
+      },
+      "accessed": {
+        "date-parts": [
+          [
+            2021,
+            4,
+            21
+          ]
+        ]
+      }
+    },
+    {
+      "id": "9296070/YC65PT77",
+      "type": "article",
+      "title": "Koro INTERLISP-D RELEASE NOTES",
+      "publisher": "Xerox Corporation",
+      "abstract": "The Koto release of Interlisp-D provides a wide range of added functionality, increased performance and improved reliability Central among these is that Koto is the first release of Interlisp that supports the new Xerox 1185i1186 artificial intelligence work stations, including the new features of these work stations such as the expanded 19\" display and the PC emulation option. Of course, like previous releases of Interlisp, Koto also supports the other current members of the 1100 series of machines, specifically the 1132 and various models of the 1108.",
+      "URL": "http://www.bitsavers.org/pdf/xerox/interlisp-d/198706_Lyric/3102464_Lyric_Common_Lisp_Implementation_Notes_Jun87.pdf",
+      "language": "English",
+      "author": [
+        {
+          "family": "Anonymous",
+          "given": ""
+        }
+      ],
+      "issued": {
+        "date-parts": [
+          [
+            "1985",
+            12
+          ]
+        ]
+      }
+    },
+    {
+      "id": "9296070/FKDCVZJ5",
+      "type": "paper-conference",
+      "title": "Language-based environment for natural language parsing",
+      "container-title": "Proceedings of the second conference on European chapter of the Association for Computational Linguistics",
+      "collection-title": "EACL '85",
+      "publisher": "Association for Computational Linguistics",
+      "publisher-place": "USA",
+      "page": "98–106",
+      "event-place": "USA",
+      "abstract": "This paper introduces a special programming environment for the definition of grammars and for the implementation of corresponding parsers. In natural language processing systems it is advantageous to have linguistic knowledge and processing mechanisms separated. Our environment accepts grammars consisting of binary dependency relations and grammatical functions. Well-formed expressions of functions and relations provide constituent surroundings for syntactic categories in the form of two-way automata. These relations, functions, and automata are described in a special definition language.In focusing on high level descriptions a linguist may ignore computational details of the parsing process. He writes the grammar into a DPL-description and a compiler translates it into efficient LISP-code. The environment has also a tracing facility for the parsing process, grammar-sensitive lexical maintenance programs, and routines for the interactive graphic display of parse trees and grammar definitions. Translator routines are also available for the transport of compiled code between various LISP-dialects. The environment itself exists currently in INTERLISP and FRANZLISP. This paper focuses on knowledge engineering issues and does not enter linguistic argumentation.",
+      "URL": "https://doi.org/10.3115/976931.976946",
+      "DOI": "10.3115/976931.976946",
+      "author": [
+        {
+          "family": "Lehtola",
+          "given": "A."
+        },
+        {
+          "family": "Jäppinen",
+          "given": "H."
+        },
+        {
+          "family": "Nelimarkka",
+          "given": "E."
+        }
+      ],
+      "issued": {
+        "date-parts": [
+          [
+            "1985",
+            3,
+            27
+          ]
+        ]
+      },
+      "accessed": {
+        "date-parts": [
+          [
+            2021,
+            4,
+            15
+          ]
+        ]
+      }
+    },
+    {
+      "id": "9296070/6D2EJDZD",
+      "type": "book",
+      "title": "Interlisp-D Reference Manual, Volume III: Input/Output",
+      "publisher": "Xerox Corporation",
+      "publisher-place": "S.l.",
+      "volume": "3",
+      "number-of-pages": "388",
+      "event-place": "S.l.",
+      "URL": "http://www.bitsavers.org/pdf/xerox/interlisp-d/198510_Koto/3101274_Interlisp-D_Vol_3_Input_Output_Oct85.pdf",
+      "note": "OCLC: 802551877",
+      "shortTitle": "Volume III: Input/Output",
+      "language": "English",
+      "editor": [
+        {
+          "family": "Sannella",
+          "given": "Michael"
+        }
+      ],
+      "issued": {
+        "date-parts": [
+          [
+            "1985",
+            10
+          ]
+        ]
+      }
+    },
+    {
+      "id": "9296070/PUQ8EKTK",
+      "type": "book",
+      "title": "Interlisp-D Reference Manual, Volume II: Environment",
+      "publisher": "Xerox Corporation",
+      "publisher-place": "S.l.",
+      "volume": "2",
+      "number-of-pages": "436",
+      "event-place": "S.l.",
+      "URL": "http://www.bitsavers.org/pdf/xerox/interlisp-d/198510_Koto/3101273_Interlisp-D_Vol_2_Environment_Oct85.pdf",
+      "note": "OCLC: 802551877",
+      "shortTitle": "Volume II: Environment",
+      "language": "English",
+      "editor": [
+        {
+          "family": "Sannella",
+          "given": "Michael"
+        }
+      ],
+      "issued": {
+        "date-parts": [
+          [
+            "1985",
+            10
+          ]
+        ]
+      }
+    },
+    {
+      "id": "9296070/DXD65IKD",
+      "type": "book",
+      "title": "Interlisp-D Reference Manual, Volume I: Language",
+      "publisher": "Xerox Corporation",
+      "publisher-place": "S.l.",
+      "volume": "1",
+      "number-of-pages": "296",
+      "event-place": "S.l.",
+      "URL": "http://www.bitsavers.org/pdf/xerox/interlisp-d/198510_Koto/3101272_Interlisp-D_Vol_1_Language_Oct85.pdf",
+      "note": "OCLC: 802551877",
+      "shortTitle": "Volume I: Language",
+      "language": "English",
+      "editor": [
+        {
+          "family": "Sannella",
+          "given": "Michael"
+        }
+      ],
+      "issued": {
+        "date-parts": [
+          [
+            "1985",
+            10
+          ]
+        ]
+      }
+    },
+    {
+      "id": "9296070/2B4J79N6",
+      "type": "article-journal",
+      "title": "Computer manipulation of geological exploration data",
+      "container-title": "Journal of the Geological Society of London",
+      "page": "925-926",
+      "volume": "142",
+      "issue": "5",
+      "abstract": "Report of a meeting held by the Geological Information Group at the British Petroleum Research Centre, Sunbury, 24 January 1985\n\nThis meeting, concerned mainly with computer manipulation of petroleum exploration data, attracted c. 95 participants. In addition to eight papers presented, there were two computer demonstrations of log analysis systems and a number of poster displays.\n\nThe morning session, concerned with large-scale, integrated hardware and software systems, was chaired by R. Howarth. R. Till of British Petroleum gave the opening paper concerning BP Exploration’s integrated database system. BP Exploration databases fall into three main groups: those containing largely numerical data; databases specifically concerned with text handling; and well-based databases. The ‘numerical’ databases, implemented under the ULTRA database management system (dbms), include a seismic data system, a generalized cartographic database and an earth constants database. Textual databases include a library information system and a Petroconsultants scout data database, both implemented under the BASIS dbms. The well-based systems include a generalized well-data database, a wireline log archive, storage and retrieval system, and a master well index; all three are implemented under the INGRES dbms. Two related BASIS databases contain geochemical and biostratigraphical data.\n\nG. Baxter (co-author M. Hemingway) described the development of Britoil’s well log database which was prompted by the need to have rapid access to digitized wireline log data for c. 1500 wells on the UKCS. Early work involved both locating log information and digitizing those logs held in sepia form only. Each digitized log occupies approximately 1 Mbyte.",
+      "URL": "http://jgs.lyellcollection.org/lookup/doi/10.1144/gsjgs.142.5.0925",
+      "DOI": "10.1144/gsjgs.142.5.0925",
+      "journalAbbreviation": "Journal of the Geological Society",
+      "language": "en",
+      "author": [
+        {
+          "family": "Burwell",
+          "given": "A. D. M."
+        }
+      ],
+      "issued": {
+        "date-parts": [
+          [
+            "1985",
+            9,
+            1
+          ]
+        ]
+      },
+      "accessed": {
+        "date-parts": [
+          [
+            2021,
+            4,
+            15
+          ]
+        ]
+      }
+    }
+  ],
+  "1986": [
+    {
+      "id": "9296070/3QK929A2",
+      "type": "chapter",
+      "title": "POWER TOOLS FOR PROGRAMMERS",
+      "container-title": "Readings in Artificial Intelligence and Software Engineering",
+      "publisher": "Morgan Kaufmann",
+      "page": "573-580",
+      "abstract": "This chapter discusses the power tools for programmers. Essentially, all of the intelligent programming tools described in this volume are at most experimental prototypes. Given that these tools are still quite far from being commercial realities, it is worthwhile to note that there is a completely different way in which artificial intelligence research has to help programmers. Artificial intelligence researchers are themselves programmers. Creating such programs is more a problem of exploration than implementation and does not conform to conventional software lifecycle models. The artificial intelligence programming community has always been faced with this kind of exploratory programming and has, therefore, had a head start on developing appropriate language, environment, and hardware features. Redundancy protects the design from unintentional change, the conventional programming technology restrains the programmer, and the programming languages used in exploratory systems minimize and defer constraints on the programmer.",
+      "URL": "https://www.sciencedirect.com/science/article/pii/B9780934613125500483",
+      "ISBN": "978-0-934613-12-5",
+      "note": "DOI: 10.1016/B978-0-934613-12-5.50048-3",
+      "shortTitle": "DATAMATION®",
+      "language": "en",
+      "author": [
+        {
+          "family": "Sheil",
+          "given": "Beau"
+        }
+      ],
+      "editor": [
+        {
+          "family": "Rich",
+          "given": "Charles"
+        },
+        {
+          "family": "Waters",
+          "given": "Richard C."
+        }
+      ],
+      "issued": {
+        "date-parts": [
+          [
+            "1986",
+            1,
+            1
+          ]
+        ]
+      },
+      "accessed": {
+        "date-parts": [
+          [
+            2021,
+            6,
+            2
+          ]
+        ]
+      }
+    },
+    {
+      "id": "9296070/YR58NY6F",
+      "type": "paper-conference",
+      "title": "CommonLoops: merging Lisp and object-oriented programming",
+      "container-title": "Conference proceedings on Object-oriented programming systems, languages and applications",
+      "collection-title": "OOPSLA '86",
+      "publisher": "Association for Computing Machinery",
+      "publisher-place": "New York, NY, USA",
+      "page": "17-29",
+      "event-place": "New York, NY, USA",
+      "abstract": "CommonLoops blends object-oriented programming smoothly and tightly with the procedure-oriented design of Lisp. Functions and methods are combined in a more general abstraction. Message passing is invoked via normal Lisp function call. Methods are viewed as partial descriptions of procedures. Lisp data types are integrated with object classes. With these integrations, it is easy to incrementally move a program between the procedure and object-oriented styles. One of the most important properties of CommonLoops is its extensive use of meta-objects. We discuss three kinds of meta-objects: objects for classes, objects for methods, and objects for discriminators. We argue that these meta-objects make practical both efficient implementation and experimentation with new ideas for object-oriented programming. CommonLoops' small kernel is powerful enough to implement the major object-oriented systems in use today.",
+      "URL": "https://doi.org/10.1145/28697.28700",
+      "DOI": "10.1145/28697.28700",
+      "ISBN": "978-0-89791-204-7",
+      "shortTitle": "CommonLoops",
+      "author": [
+        {
+          "family": "Bobrow",
+          "given": "Daniel G."
+        },
+        {
+          "family": "Kahn",
+          "given": "Kenneth"
+        },
+        {
+          "family": "Kiczales",
+          "given": "Gregor"
+        },
+        {
+          "family": "Masinter",
+          "given": "Larry"
+        },
+        {
+          "family": "Stefik",
+          "given": "Mark"
+        },
+        {
+          "family": "Zdybel",
+          "given": "Frank"
+        }
+      ],
+      "issued": {
+        "date-parts": [
+          [
+            "1986",
+            6,
+            1
+          ]
+        ]
+      },
+      "accessed": {
+        "date-parts": [
+          [
+            2021,
+            4,
+            25
+          ]
+        ]
+      }
+    },
+    {
+      "id": "9296070/HLN62MVN",
+      "type": "article-journal",
+      "title": "CommonLoops: merging Lisp and object-oriented programming",
+      "container-title": "ACM SIGPLAN Notices",
+      "page": "17–29",
+      "volume": "21",
+      "issue": "11",
+      "abstract": "CommonLoops blends object-oriented programming smoothly and tightly with the procedure-oriented design of Lisp. Functions and methods are combined in a more general abstraction. Message passing is invoked via normal Lisp function call. Methods are viewed as partial descriptions of procedures. Lisp data types are integrated with object classes. With these integrations, it is easy to incrementally move a program between the procedure and object-oriented styles. One of the most important properties of CommonLoops is its extensive use of meta-objects. We discuss three kinds of meta-objects: objects for classes, objects for methods, and objects for discriminators. We argue that these meta-objects make practical both efficient implementation and experimentation with new ideas for object-oriented programming. CommonLoops' small kernel is powerful enough to implement the major object-oriented systems in use today.",
+      "URL": "https://doi.org/10.1145/960112.28700",
+      "DOI": "10.1145/960112.28700",
+      "shortTitle": "CommonLoops",
+      "journalAbbreviation": "SIGPLAN Not.",
+      "author": [
+        {
+          "family": "Bobrow",
+          "given": "Daniel G."
+        },
+        {
+          "family": "Kahn",
+          "given": "Kenneth"
+        },
+        {
+          "family": "Kiczales",
+          "given": "Gregor"
+        },
+        {
+          "family": "Masinter",
+          "given": "Larry"
+        },
+        {
+          "family": "Stefik",
+          "given": "Mark"
+        },
+        {
+          "family": "Zdybel",
+          "given": "Frank"
+        }
+      ],
+      "issued": {
+        "date-parts": [
+          [
+            "1986",
+            6,
+            1
+          ]
+        ]
+      },
+      "accessed": {
+        "date-parts": [
+          [
+            2021,
+            6,
+            3
+          ]
+        ]
+      }
+    },
+    {
+      "id": "9296070/YEUXRBGZ",
+      "type": "article",
+      "title": "Artificial Intelligence Systems, Interlisp-D: A Friendly Primer",
+      "publisher": "Xerox Corporation",
+      "URL": "http://www.bitsavers.org/pdf/xerox/interlisp-d/198510_Koto/3102300_Interlisp-D_A_Friendly_Primer_Nov86.pdf",
+      "language": "en",
+      "author": [
+        {
+          "family": "Xerox",
+          "given": ""
+        }
+      ],
+      "issued": {
+        "date-parts": [
+          [
+            "1986",
+            11
+          ]
+        ]
+      },
+      "accessed": {
+        "date-parts": [
+          [
+            2021,
+            4,
+            23
+          ]
+        ]
+      }
+    }
+  ],
+  "1987": [
+    {
+      "id": "9296070/EFHC285D",
+      "type": "paper-conference",
+      "title": "The background of INTERNIST I and QMR",
+      "container-title": "Proceedings of ACM conference on History of medical informatics",
+      "collection-title": "HMI '87",
+      "publisher": "Association for Computing Machinery",
+      "publisher-place": "New York, NY, USA",
+      "page": "195–197",
+      "event-place": "New York, NY, USA",
+      "abstract": "During my tenure as Chairman of the Department of Medicine at the University of Pittsburgh, 1955 to 1970, two points became clear in regard to diagnosis in internal medicine. The first was that the knowledge base in that field had become vastly too large for any single person to encompass it. The second point was that the busy practitioner, even though he knew the items of information pertinent to his patients correct diagnosis, often did not consider the right answer particularly if the diagnosis was an unusual disease. I resigned the position of Chairman in 1970 intending to resume my position as Professor of Medicine. However, the University saw fit to offer me the appointment as University Professor (Medicine). The University of Pittsburgh follows the practice of Harvard University, established by President James Bryant Conant in the late 1930s, in which a University Professor is a professor at large and reports only to the president of the university. He has no department, no school and is not under administrative supervision by a dean or vice-president. Thus the position allows maximal academic freedom. In this new position I felt strongly that I should conduct worthwhile research. It was almost fifteen years since I had worked in my chosen field of clinical investigation, namely splanchnic blood flow and metabolism, and I felt that research in that area had passed me by. Remembering the two points mentioned earlier — the excessive knowledge base of internal medicine and the problem of considering the correct diagnosis — I asked myself what could be done to correct these problems. It seemed that the computer with its huge memory could correct the first and I wondered if it could not help as well with the second. At that point I knew no more about computers than the average layman so I sought advice. Dr. Gerhard Werner, our Chairman of Pharmacology, was working with computers in an attempt to map all of the neurological centers of the human brain stem with particular reference to their interconnections and functions. He was particularly concerned about the actions of pharmacological agents on this complex system. Working with him on this problem was Dr. Harry Pople, a computer scientist with special interest in “artificial intelligence”. The problem chosen was so complex and difficult that Werner and Pople were making little progress. Gerhard listened patiently to my ideas and promptly stated that he thought the projects were feasible utilizing the computer. In regard to the diagnostic component of my ambition he strongly advised that “artificial intelligence” be used. Pople was brought into the discussion and was greatly interested, I believe because of the feasibility of the project and the recognition of its practical application to the practice of medicine. The upshot was that Pople joined me in my project and Werner and Pople abandoned the work on the brain stem. Pople knew nothing about medicine and I knew nothing about computer science. Thus the first step in our collaboration was my analysis for Pople of the diagnostic process. I chose a goodly number of actual cases from clinical pathological conferences (CPCs) because they contained ample clinical data and because the correct diagnoses were known. At each small step of the way through the diagnostic process I was required to explain what the clinical information meant in context and my reasons for considering certain diagnoses. This provided to Pople insight into the diagnostic process. After analyzing dozens of such cases I felt as though I had undergone a sort of “psychoanalysis”. From this experience Pople wrote the first computer diagnostic programs seeking to emulate my diagnostic process. This has led certain “wags” to nickname our project “Jack in the box”. For this initial attempt Pople used the LISP computer language. We were granted access to the PROPHET PDP-10, a time-sharing mainframe maintained in Boston by the National Institutes of Health (NIH) but devoted particularly to pharmacological research. Thus we were interlopers. The first name we applied to our project was DIALOG, for diagnostic logic, but this had to be dropped because the name was in conflict with a computer program already on the market and copyrighted. The next name chosen was INTERNIST for obvious reason. However, the American Society for Internal Medicine publishes a journal entitled “The Internist” and they objected to our use of INTERNIST although there seems to be little relationship or conflict between a printed journal and a computer software program. Rather than fight the issue we simply added the Roman numeral one to our title which then became INTERNIST-I, which continues to this day. Pople's initial effort was unsuccessful, however. He diligently had incorporated details regarding anatomy and much basic pathophysiology, I believe because in my initial CPC analyses I had brought into consideration such items of information so that Pople could understand how I got from A to B etc. The diagnostician in internal medicine knows, of course, much anatomy and patho-physiology but these are brought into consideration in only a minority of diagnostic problems. He knows, for example, that the liver is in the right upper quadrant and just beneath the right leaf of the diaphragm. In most diagnostic instances this information is “subconscious”. Our first computer diagnostic program included too many such details and as a result was very slow and frequently got into analytical “loops” from which it could not extricate itself. We decided that we had to simplify the program but by that juncture much of 1971 had passed on. The new program was INTERNIST-I and even today most of the basic structure devised in 1972 remains intact. INTERNIST-I is written in INTERLISP and has operated on the PDP-10 and the DEC 2060. It has also been adapted to the VAX 780. Certain younger people have contributed significantly to the program, particularly Dr. Zachary Moraitis and Dr. Randolph Miller. The latter interrupted his regular medical school education to spend the year 1974-75 as a fellow in our laboratory and since finishing his formal medical education in 1979 has been active as a full time faculty member of the team. Several Ph.D. candidates in computer science have also made significant contributions as have dozens of medical students during electives on the project. INTERNIST-I is really quite a simple system as far as its operating system or inference engine is concerned. Three basic numbers are concerned in and manipulated in the ranking of elicited disease hypotheses. The first of these is the importance (IMPORT) of each of the more than 4,100 manifestations of disease which are contained in the knowledge base. IMPORTS are a global representation of the clinical importance of a given finding graded from 1 to 5, the latter being maximal, focusing on how necessary it is to explain the manifestation regardless of the final diagnosis. Thus massive splenomegaly has an IMPORT of 5 whereas anorexia has an IMPORT of 1. Mathematical weights are assigned to IMPORT numbers on a non-linear scale. The second basic number is the evoking strength (EVOKS), the numbers ranging from 0 to 5. The number answers the question, that given a particular manifestation of disease, how strongly does one consider disease A versus all other diagnostic possibilities in a clinical situation. A zero indicates that a particular clinical manifestation is non-specific, i.e. so widely spread among diseases that the above question cannot be answered usefully. Again, anorexia is a good example of a non-specific manifestation. The EVOKS number 5, on the other hand, indicates that a manifestation is essentially pathognomonic for a particular disease. The third basic number is the frequency (FREQ) which answers the question that given a particular disease what is the frequency or incidence of occurrence of a particular clinical finding. FREQ numbers range from 1 to 5, one indicating that the finding is rare or unusual in the disease and 5 indicating that the finding is present in essentially all instances of the disease. Each diagnosis which is evoked is ranked mathematically on the basis of support for it, both positive and negative. Like the import number, the values for EVOKS and FREQ numbers increase in a non-linear fashion. The establishment or conclusion of a diagnosis is not based on any absolute score, as in Bayesian systems, but on how much better is the support of diagnosis A as compared to its nearest competitor. This difference is anchored to the value of an EVOKS of 5, a pathognomonic finding. When the list of evoked diagnoses is ranked mathematically on the basis of EVOKS, FREQ and IMPORT, the list is partitioned based upon the similarity of support for individual diagnoses. Thus a heart disease is compared with other heart diseases and not brain diseases since the patient may have a heart disorder and a brain disease concommitantly. Thus apples are compared with apples and not oranges. When a diagnosis is concluded, the computer consults a list of interrelationships among diseases (LINKS) and bonuses are awarded, again in a non-linear fashion for numbers ranging from 1 to 5 — 1 indicating a weak interrelationship and 5 a universal interrelationship. Thus multiple interrelated diagnoses are preferred over independent ones provided the support for the second and other diagnoses is adequate. Good clinicians use this same rule of thumb. LINKS are of various types: PCED is used when disease A precedes disease B, e.g. acute rheumatic fever precedes early rheumatic valvular disease; PDIS - disease A predisposes to disease B, e.g. AIDS predisposes to pneumocystis pneumonia; CAUS - disease A causes disease B, e.g. thrombophlebitis of the lower extremities may cause pulmonary embolism; and COIN - there is a statistical interrelationship between disease A and disease B but scientific medical information is not explicit on the relationship, e.g. Hashimoto's thyroiditis coincides with pernicious anemia, both so called autoimmune diseases. The maximal number of correct diagnoses made in a single case analysis is, to my recollection, eleven. In working with INTERNIST-I during the remainder of the 1970s several important points about the system were learned or appreciated. The first and foremost of these is the importance of a complete and accurate knowledge base. Omissions from a disease profile can be particularly troublesome. If a manifestation of disease is not listed on a disease profile the computer can only conclude that that manifestation does not occur in the disease, and if a patient demonstrates the particular manifestation it counts against the diagnosis. Fortunately, repeated exercise of the diagnostic system brings to attention many inadvertent omissions. It is important to establish the EVOKS and FREQ numbers as accurately as possible. Continual updating of the knowledge base, including newly described diseases and new information about diseases previously profiled, is critical. Dr. Edward Feigenbaum recognized the importance of the accuracy and completeness of knowledge bases as the prime requisite of expert systems of any sort. He emphasized this point in his keynote address to MEDINFO-86 (1). Standardized, clear and explicit nomenclature is required in expressing disease names and particularly in naming the thousands of individual manifestations of disease. Such rigidity can make the use of INTERNIST-I difficult for the uninitiated user. Therefore, in QMR more latitude and guidance is provided the user. For example, the user of INTERNIST-I must enter ABDOMEN PAIN RIGHT UPPER QUADRANT exactly whereas in QMR the user may enter PAI ABD RUQ and the system recognizes the term as above. The importance of “properties” attached to the great majority of clinical manifestations was solidly evident. Properties express such conditions that if A is true then B is automatically false (or true as the case may be). The properties also allow credit to be awarded for or against B as the case may be. Properties also provide order to the asking of questions in the interrogative mode. They also state prerequisites and unrequisites for various procedures. As examples, one generally does not perform a superficial lymph node biopsy unless lymph nodes are enlarged (prerequisite). Similarly, a percutaneous liver biopsy is inadvisable if the blood platelets are less than 50,000 (unrequisite). It became clear quite early in the utilization of INTERNIST-I that systemic or multisystem diseases had an advantage versus localized disorders in diagnosis. This is because systemic diseases have very long and more inclusive manifestation lists. It became necessary, therefore, to subdivide systemic diseases into various components when appropriate. Systemic lupus erythematosus provides a good example. Lupus nephritis must be compared in our system with other renal diseases and such comparison is allowed by our partitioning algorithm. Likewise, cerebral lupus must be differentiated from other central nervous system disorders. Furthermore, either renal lupus or cerebral lupus can occur at times without significant clinical evidence of other systemic involvement. In order to reassemble the components of a systemic disease we devised the systemic LINK (SYST) which expresses the interrelationship of each subcomponent to the parent systemic disease. It became apparent quite early that expert systems like INTERNIST do not deal with the time axis of a disease well at all, and this seems to be generally true of expert systems in “artificial intelligence”. Certain parameters dealing with time can be expressed by devising particular manifestations, e.g. a blood transfusion preceding the development of acute hepatitis B by 2 to 6 months. But time remains a problem which is yet to be solved satisfactorily including QMR. It has been clearly apparent over the years that both the knowledge base and the diagnostic consultant programs of both INTERNIST-I and QMR have considerable educational value. The disease profiles, the list of diseases in which a given clinical manifestation occurs (ordered by EVOKS and FREQ), and the interconnections among diseases (LINKS) provide a quick and ready means of acquiring at least orienting clinical information. Such has proved useful not only to medical students and residents but to clinical practitioners as well. In the interrogative mode of the diagnostic systems the student will frequently ask “Why was that question asked?” An instructor can either provide insight or ready consultation of the knowledge base by the student will provide a simple semi-quantitative reason for the question. Lastly, let the author state that working with INTERNIST-I and QMR over the years seems to have had real influence on his own diagnostic approaches and habits. Thus my original psycho-analysis when working with Pople has been reinforced.",
+      "URL": "https://doi.org/10.1145/41526.41543",
+      "DOI": "10.1145/41526.41543",
+      "ISBN": "978-0-89791-248-8",
+      "author": [
+        {
+          "family": "Myers",
+          "given": "J. D."
+        }
+      ],
+      "issued": {
+        "date-parts": [
+          [
+            "1987",
+            12,
+            1
+          ]
+        ]
+      },
+      "accessed": {
+        "date-parts": [
+          [
+            2021,
+            4,
+            15
+          ]
+        ]
+      }
+    },
+    {
+      "id": "9296070/25TEJPHA",
+      "type": "article",
+      "title": "XEROX COMMON LISP IMPLEMENTATION NOTES",
+      "publisher": "XEROX",
+      "abstract": "The Xerox Common Lisp Implementation Notes cover several aspects of the Lyric release. In these notes you will find:\n• An explanation of how Xerox Common Lisp extends the Common Lisp standard. For example, in Xerox Common Lisp the Common Lisp array-constructing function make-array has additional keyword\narguments that enhance its functionality.\n• An explanation of how several ambiguities in Steele's Common Lisp: the Language were\nresolved.\n• A description of additional features that provide far more than extensions to Common Lisp.",
+      "URL": "http://www.bitsavers.org/pdf/xerox/interlisp-d/198706_Lyric/3102464_Lyric_Common_Lisp_Implementation_Notes_Jun87.pdf",
+      "shortTitle": "IMPLEMENTATION NOTES",
+      "language": "English",
+      "author": [
+        {
+          "family": "Anonymous",
+          "given": ""
+        }
+      ],
+      "issued": {
+        "date-parts": [
+          [
+            "1987",
+            6
+          ]
+        ]
+      }
+    },
+    {
+      "id": "9296070/F9XE85C9",
+      "type": "article",
+      "title": "Artificial intelligence Systems Xerox LOOPS, A Friendly Primer",
+      "publisher": "Xerox Corporation",
+      "URL": "http://www.bitsavers.org/pdf/xerox/interlisp-d/198510_Koto/3102242_Xerox_LOOPS_A_Friendly_Primer_Mar87.pdf",
+      "shortTitle": "Interlisp-D_A-Friendly-Primer",
+      "language": "en",
+      "author": [
+        {
+          "family": "Mears",
+          "given": "Lyn Ann"
+        },
+        {
+          "family": "Rees",
+          "given": "Ted"
+        }
+      ],
+      "issued": {
+        "date-parts": [
+          [
+            "1987",
+            3
+          ]
+        ]
+      },
+      "accessed": {
+        "date-parts": [
+          [
+            2021,
+            4,
+            23
+          ]
+        ]
+      }
+    },
+    {
+      "id": "9296070/F9XE85C9",
+      "type": "article",
+      "title": "Artificial intelligence Systems Xerox LOOPS, A Friendly Primer",
+      "publisher": "Xerox Corporation",
+      "URL": "http://www.bitsavers.org/pdf/xerox/interlisp-d/198510_Koto/3102242_Xerox_LOOPS_A_Friendly_Primer_Mar87.pdf",
+      "shortTitle": "Interlisp-D_A-Friendly-Primer",
+      "language": "en",
+      "author": [
+        {
+          "family": "Mears",
+          "given": "Lyn Ann"
+        },
+        {
+          "family": "Rees",
+          "given": "Ted"
+        }
+      ],
+      "issued": {
+        "date-parts": [
+          [
+            "1987",
+            3
+          ]
+        ]
+      },
+      "accessed": {
+        "date-parts": [
+          [
+            2021,
+            4,
+            23
+          ]
+        ]
+      }
+    }
+  ],
+  "1988": [
+    {
+      "id": "9296070/FDA3AUNV",
+      "type": "article-journal",
+      "title": "Bridging the gap between object-oriented and logic programming",
+      "container-title": "IEEE Software",
+      "page": "36-42",
+      "volume": "5",
+      "issue": "4",
+      "URL": "http://ieeexplore.ieee.org/document/17800/",
+      "DOI": "10.1109/52.17800",
+      "journalAbbreviation": "IEEE Softw.",
+      "language": "en",
+      "author": [
+        {
+          "family": "Koschmann",
+          "given": "T."
+        },
+        {
+          "family": "Evens",
+          "given": "M.W."
+        }
+      ],
+      "issued": {
+        "date-parts": [
+          [
+            "1988"
+          ]
+        ]
+      },
+      "accessed": {
+        "date-parts": [
+          [
+            2022,
+            8,
+            4
+          ]
+        ]
+      }
+    }
+  ],
+  "1990": [
+    {
+      "id": "9296070/SYHYTLHH",
+      "type": "patent",
+      "title": "Design system using visual language",
+      "abstract": "A computer-based tool, in the form of a computer system and method, for designing, constructing and interacting with any system containing or comprising concurrent asychronous processes, such as a factory operation. In the system according to the invention a variety of development and execution tools are supported. The invention features a highly visual user presentation of a control system, including structure, specification, and operation, offering a user an interactive capability for rapid design, modification, and exploration of the operating characteristics of a control system comprising asynchronous processes. The invention captures a representation of the system (RS) that is equivalent to the actual system (AS)--rather than a simulation of the actual system. This allows the invention to perform tests and modification on RS instead of AS, yet get accurate results. RS and AS are equivalent because AS is generated directly from RS by an automated process. Effectively, pressing a button in the RS environment can \"create\" the AS version or any selected portion of it, by \"downloading\" a translation of the RS version that can be executed by a programmable processor in the AS environment. Information can flow both ways between AS and RS. That AS and RS can interact is important. This allows RS to \"take on\" the \"state\" of AS whenever desired, through an \"uploading\" procedure, thereby reflecting accurately the condition of AS at a specific point in time.",
+      "URL": "https://patents.google.com/patent/US4914567A/en",
+      "number": "US4914567A",
+      "author": [
+        {
+          "family": "Lipkis",
+          "given": "Thomas A."
+        },
+        {
+          "family": "Mark",
+          "given": "William S."
+        },
+        {
+          "family": "Pirtle",
+          "given": "Melvin W."
+        }
+      ],
+      "issued": {
+        "date-parts": [
+          [
+            1990,
+            4,
+            3
+          ]
+        ]
+      },
+      "accessed": {
+        "date-parts": [
+          [
+            2021,
+            6,
+            1
+          ]
+        ]
+      }
+    }
+  ],
+  "1991": [
+    {
+      "id": "9296070/J62GHLSJ",
+      "type": "patent",
+      "title": "Method of and apparatus for composing a press imposition",
+      "abstract": "An apparatus and a method are disclosed for composing an imposition in terms of an arrangement of printing plates on selected of the image positions on selected units of a printing press to print a given edition, by first assigning each section of this edition to one of the press areas. Thereafter, each printing unit is examined to determine an utilization value thereof in terms of the placement of the printing plates on the image positions and the relative number of image positions to which printing plates are assigned with respect to the total number of image positions. Thereafter, a list of the image positions for each of the sections and its area, is constructed by examining one printing unit at a time in an order according to the placement of that printing unit in the array and examining its utilization value to determine whether or not to include a particular image position of that printing unit in the list. As a result, a list of the image positions is constructed in a sequence corresponding to numerical order of the pages in the section under consideration. Finally, that list of the image positions and the corresponding section and page numbers is displayed in a suitable fashion to inform a user of how to place the printing plates in the desired arrangement onto the printing units of the press to print this given edition.",
+      "URL": "https://patents.google.com/patent/US4984773A/en",
+      "number": "US4984773A",
+      "author": [
+        {
+          "family": "Balban",
+          "given": "Morton S."
+        },
+        {
+          "family": "Lan",
+          "given": "Ming-Shong"
+        },
+        {
+          "family": "Panos",
+          "given": "Rodney M."
+        }
+      ],
+      "issued": {
+        "date-parts": [
+          [
+            1991,
+            1,
+            15
+          ]
+        ]
+      },
+      "accessed": {
+        "date-parts": [
+          [
+            2021,
+            6,
+            1
+          ]
+        ]
+      }
+    },
+    {
+      "id": "9296070/KXVS2RBT",
+      "type": "patent",
+      "title": "User interface with multiple workspaces for sharing display system objects",
+      "abstract": "Workspaces provided by an object-based user interface appear to share windows and other display objects. Each workspace's data structure includes, for each window in that workspace, a linking data structure called a placement which links to the display system object which provides that window, which may be a display system object in a preexisting window system. The placement also contains display characteristics of the window when displayed in that workspace, such as position and size. Therefore, a display system object can be linked to several workspaces by a placement in each of the workspaces' data structures, and the window it provides to each of those workspaces can have unique display characteristics, yet appear to the user to be the same window or versions of the same window. As a result, the workspaces appear to be sharing a window. Workspaces can also appear to share a window if each workspace's data structure includes data linking to another workspace with a placement to the shared window. The user can invoke a switch between workspaces by selecting a display object called a door, and a back door to the previous workspace is created automatically so that the user is not trapped in a workspace. A display system object providing a window to a workspace being left remains active so that when that workspace is reentered, the window will have the same contents as when it disappeared. Also, the placements of a workspace are updated so that when the workspace is reentered its windows are organized the same as when the user left that workspace. The user can enter an overview display which shows a representation of each workspace and the windows it contains so that the user can navigate to any workspace from the overview.",
+      "URL": "https://patents.google.com/patent/US5072412A/en",
+      "number": "US5072412A",
+      "author": [
+        {
+          "family": "Henderson",
+          "given": "D. Austin"
+        },
+        {
+          "family": "Card",
+          "given": "Stuart K."
+        },
+        {
+          "family": "Maxwell",
+          "given": "John T."
+        }
+      ],
+      "issued": {
+        "date-parts": [
+          [
+            1991,
+            12,
+            10
+          ]
+        ]
+      },
+      "accessed": {
+        "date-parts": [
+          [
+            2021,
+            6,
+            1
+          ]
+        ]
+      }
+    },
+    {
+      "id": "9296070/5QACWN9U",
+      "type": "patent",
+      "title": "Interactive method of developing software interfaces",
+      "abstract": "A system and method for interactive design of user manipulable graphic elements. A computer has display and stored tasks wherein the appearance of graphic elements and methods for their manipulation are defined. Each graphic element is defined by at least one figure specification, one mask specification and one map specification. An interactive display editor program defines specifications of said graphic elements. An interactive program editor program defines programming data and methods associated with said graphic elements. A display program uses the figure, map and mask specifications for assembling graphic elements upon the display and enabling user manipulation of said graphic elements.",
+      "URL": "https://patents.google.com/patent/US5041992A/en",
+      "number": "US5041992A",
+      "author": [
+        {
+          "family": "Cunningham",
+          "given": "Robert E."
+        },
+        {
+          "family": "Bonar",
+          "given": "Jeffery G."
+        },
+        {
+          "family": "Corbett",
+          "given": "John D."
+        }
+      ],
+      "issued": {
+        "date-parts": [
+          [
+            1991,
+            8,
+            20
+          ]
+        ]
+      },
+      "accessed": {
+        "date-parts": [
+          [
+            2021,
+            6,
+            1
+          ]
+        ]
+      }
+    },
+    {
+      "id": "9296070/TN3W6XLN",
+      "type": "paper-conference",
+      "title": "PEPYS: Generating Autobiographies by Automatic Tracking",
+      "abstract": "This paper presents one part of a broad research project entitled 'Activity-Based Information Retrieval' (AIR) which is being carded out at EuroPARC. The basic hypothesis of this project is that if contextual data about human activities can be automatically captured and later presented as recognisable descriptions of past episodes, then human memory of those past episodes can be improved. This paper describes an application called Pepys, designed to yield descriptions of episodes based on automatically collected location data. The program pays particular attention to meetings and other episodes involving two or more people. The episodes are presented to the user as a diary generated at the end of each day and distributed by electronic mail. The paper also discusses the methods used to assess the accuracy of the descriptions generated by the recogniser.",
+      "DOI": "10.1007/978-94-011-3506-1_13",
+      "ISBN": "978-0-7923-1439-4",
+      "shortTitle": "PEPYS",
+      "author": [
+        {
+          "family": "Newman",
+          "given": "William"
+        },
+        {
+          "family": "Eldridge",
+          "given": "Margery"
+        },
+        {
+          "family": "Lamming",
+          "given": "Michael"
+        }
+      ],
+      "issued": {
+        "date-parts": [
+          [
+            1991,
+            1,
+            1
+          ]
+        ]
+      }
+    }
+  ],
+  "1992": [
+    {
+      "id": "9296070/9SEIVVBA",
+      "type": "paper-conference",
+      "title": "Interactive constraint-based search and replace",
+      "container-title": "Proceedings of the SIGCHI Conference on Human Factors in Computing Systems",
+      "collection-title": "CHI '92",
+      "publisher": "Association for Computing Machinery",
+      "publisher-place": "New York, NY, USA",
+      "page": "609–618",
+      "event-place": "New York, NY, USA",
+      "abstract": "We describe enhancements to graphical search and replace that allow users to extend the capabilities of a graphical editor. Interactive constraint-based search and replace can search for objects that obey user-specified sets of constraints and automatically apply other constraints to modify these objects. We show how an interactive tool that employs this technique makes it possible for users to define sets of constraints graphically that modify existing illustrations or control the creation of new illustrations. The interace uses the same visual language as the editor and allows users to understand and create powerful rules without conventional programming. Rules can be saved and retrieved for use alone or in combination. Examples, generated with a working implementation, demonstrate applications to drawing beautification and transformation.",
+      "URL": "https://doi.org/10.1145/142750.143053",
+      "DOI": "10.1145/142750.143053",
+      "ISBN": "978-0-89791-513-5",
+      "author": [
+        {
+          "family": "Kurlander",
+          "given": "David"
+        },
+        {
+          "family": "Feiner",
+          "given": "Steven"
+        }
+      ],
+      "issued": {
+        "date-parts": [
+          [
+            "1992",
+            6,
+            1
+          ]
+        ]
+      },
+      "accessed": {
+        "date-parts": [
+          [
+            2021,
+            4,
+            15
+          ]
+        ]
+      }
+    }
+  ],
+  "1993": [
+    {
+      "id": "9296070/J6WNHTXX",
+      "type": "paper-conference",
+      "title": "Hyperform: using extensibility to develop dynamic, open, and distributed hypertext systems",
+      "container-title": "Proceedings of the ACM conference on Hypertext",
+      "collection-title": "ECHT '92",
+      "publisher": "Association for Computing Machinery",
+      "publisher-place": "New York, NY, USA",
+      "page": "251–261",
+      "event-place": "New York, NY, USA",
+      "abstract": "An approach to flexible hyperbase (hypertext database) support predicated on the notion of ex-tensibility is presented. The extensible hypertext platform (Hyperform) implements basic hyperbase services that can be tailored to provide specialised hyperbase support. Hypeeform is based on an inter-nal computational engine that provides an object-oriented extension language which allows new data model objects and operations to be added at run-time. Hyperform has a number of built-in classes to pro-vide basic hyperbase features such as concurrency control, notification control (events), access control, version control and search and query. Each of these classes can be specialised using multiple inheritance to form virtually any type of hyperbase support needed in next-generation hypertext systems. This approach greatly reduces the effort required to provide high-quality customized hyperbase support for distributed hypertext applications. Hyper-form is implemented and operational in Unix environments. This paper describes the Hyperform approach, discusses its advantages and disadvantages, and gives examples of simulating the 11AM and the Danish Hyperlime in Hyperform. Hyper-form is compared with related work from the HAM generation of hyperbase systems and the current status of the project is reviewed.",
+      "URL": "https://doi.org/10.1145/168466.171510",
+      "DOI": "10.1145/168466.171510",
+      "ISBN": "978-0-89791-547-X",
+      "shortTitle": "Hyperform",
+      "author": [
+        {
+          "family": "Wiil",
+          "given": "Uffe K."
+        },
+        {
+          "family": "Leggett",
+          "given": "John J."
+        }
+      ],
+      "issued": {
+        "date-parts": [
+          [
+            "1993",
+            12,
+            1
+          ]
+        ]
+      },
+      "accessed": {
+        "date-parts": [
+          [
+            2021,
+            4,
+            15
+          ]
+        ]
+      }
+    },
+    {
+      "id": "9296070/6L8UHVSY",
+      "type": "article-journal",
+      "title": "Isolation and analysis of optimization errors",
+      "container-title": "ACM SIGPLAN Notices",
+      "page": "26–35",
+      "volume": "28",
+      "issue": "6",
+      "abstract": "This paper describes two related tools developed to support the isolation and analysts of optimization errors in the vpo optimizer. Both tools rely on vpo identifying sequences of changes, referred to as transformations. that result in semantically equivalent (and usually improved) code. One tool determines the first transfer. motion that causes incorrect output of the execution of the compiled program. This tool not only automatically isolates the illegal transformation, but also identifies the location and instant the transformation is performed in vpo. To assist in the analysis of an optimization error, a graphical optimization viewer was also implemented that can display the state of the generated instructions before and after each transformation performed by vpo. Unique features of the optimization viewer include reverse viewing (or undoing) of transformations and the ability to stop at breakpoints associated with the generated instructions. Both tools are useful independently. Together these tools form a powerful environment for facilitating the retargeting of vpo to a new machine and supporting experimentation with new optimizations. In addition, the optimization viewercan be used as a teaching aid in compiler classes.",
+      "URL": "https://doi.org/10.1145/173262.155093",
+      "DOI": "10.1145/173262.155093",
+      "journalAbbreviation": "SIGPLAN Not.",
+      "author": [
+        {
+          "family": "Boyd",
+          "given": "Mickey R."
+        },
+        {
+          "family": "Whalley",
+          "given": "David B."
+        }
+      ],
+      "issued": {
+        "date-parts": [
+          [
+            "1993",
+            6,
+            1
+          ]
+        ]
+      },
+      "accessed": {
+        "date-parts": [
+          [
+            2021,
+            6,
+            3
+          ]
+        ]
+      }
+    }
+  ],
+  "1994": [
+    {
+      "id": "9296070/CI5AB787",
+      "type": "patent",
+      "title": "Iterative technique for phrase query formation and an information retrieval...",
+      "abstract": "An information retrieval system and method are provided in which an operator inputs one or more query words which are used to determine a search key for searching through a corpus of documents, and which returns any matches between the search key and the corpus of documents as a phrase containing the word data matching the query word(s), a non-stop (content) word next adjacent to the matching word data, and all intervening stop-words between the matching word data and the next adjacent non-stop word. The operator, after reviewing one or more of the returned phrases can then use one or more of the next adjacent non-stop-words as new query words to reformulate the search key and perform a subsequent search through the document corpus. This process can be conducted iteratively, until the appropriate documents of interest are located. The additional non-stop-words from each phrase are preferably aligned with each other (e.g., by columnation) to ease viewing of the \"new\" content words.",
+      "URL": "https://patents.google.com/patent/US5278980A",
+      "number": "US5278980A",
+      "author": [
+        {
+          "family": "Jan O. Pedersen",
+          "given": ""
+        },
+        {
+          "family": "Per-Kristian Halvorsen",
+          "given": ""
+        },
+        {
+          "family": "Douglass R. Cutting",
+          "given": ""
+        },
+        {
+          "family": "John W. Tukey",
+          "given": ""
+        },
+        {
+          "family": "Eric A. Bier",
+          "given": ""
+        },
+        {
+          "family": "Daniel G. Bobrow",
+          "given": ""
+        }
+      ],
+      "issued": {
+        "date-parts": [
+          [
+            1994,
+            1,
+            11
+          ]
+        ]
+      },
+      "accessed": {
+        "date-parts": [
+          [
+            2021,
+            4,
+            16
+          ]
+        ]
+      }
+    },
+    {
+      "id": "9296070/ELBQRBKS",
+      "type": "patent",
+      "title": "Text-compression technique using frequency-ordered array of word-number mappers",
+      "abstract": "A text-compression technique utilizes a plurality of word-number mappers (\"WNMs\") in a frequency-ordered hierarchical structure. The particular structure of the set of WNMs depends on the specific encoding regime, but can be summarized as follows. Each WNM in the set is characterized by an ordinal WNM number and a WNM size (maximum number of tokens) that is in general a non-decreasing function of the WNM number. A given token is assigned a number pair, the first being one of the WNM numbers, and the second being the token's position or number in that WNM. Typically, the most frequently occurring tokens are mapped with a smaller-numbered WNM. The set of WNMs is generated on a first pass through the database to be compressed. The database is parsed into tokens, and a rank-order list based on the frequency of occurrence is generated. This list is partitioned in a manner to define the set of WNMs. Actual compression of the data base occurs on a second pass, using the set of WNMs generated on the first pass. The database is parsed into tokens, and for each token, the set of WNMs is searched to find the token. Once the token is found, it is assigned the appropriate number pair and is encoded. This proceeds until the entire database has been compressed.",
+      "URL": "https://patents.google.com/patent/US5325091A/en",
+      "number": "US5325091A",
+      "author": [
+        {
+          "family": "Kaplan",
+          "given": "Ronald M."
+        },
+        {
+          "family": "Maxwell",
+          "given": "John T. III"
+        }
+      ],
+      "issued": {
+        "date-parts": [
+          [
+            1994,
+            6,
+            28
+          ]
+        ]
+      },
+      "accessed": {
+        "date-parts": [
+          [
+            2021,
+            6,
+            1
+          ]
+        ]
+      }
+    }
+  ],
+  "1995": [
+    {
+      "id": "9296070/A52363YK",
+      "type": "article-journal",
+      "title": "Rich interaction in the digital library",
+      "container-title": "Communications of the ACM",
+      "page": "29-39",
+      "volume": "38",
+      "issue": "4",
+      "abstract": "Effective information access involves rich interactions between users and information residing in diverse locations. Users seek and retrieve information from the sources—for example, file serves, databases, and digital libraries—and use various tools to browse, manipulate, reuse, and generally process the information. We have developed a number of techniques that support various aspects of the process of user/information interaction. These techniques can be considered attempts to increase the bandwidth and quality of the interactions between users and information in an information workspace—an environment designed to support information work (see Figure 1).",
+      "URL": "https://doi.org/10.1145/205323.205326",
+      "DOI": "10.1145/205323.205326",
+      "journalAbbreviation": "Commun. ACM",
+      "author": [
+        {
+          "family": "Rao",
+          "given": "Ramana"
+        },
+        {
+          "family": "Pedersen",
+          "given": "Jan O."
+        },
+        {
+          "family": "Hearst",
+          "given": "Marti A."
+        },
+        {
+          "family": "Mackinlay",
+          "given": "Jock D."
+        },
+        {
+          "family": "Card",
+          "given": "Stuart K."
+        },
+        {
+          "family": "Masinter",
+          "given": "Larry"
+        },
+        {
+          "family": "Halvorsen",
+          "given": "Per-Kristian"
+        },
+        {
+          "family": "Robertson",
+          "given": "George C."
+        }
+      ],
+      "issued": {
+        "date-parts": [
+          [
+            "1995",
+            4,
+            1
+          ]
+        ]
+      },
+      "accessed": {
+        "date-parts": [
+          [
+            2021,
+            4,
+            25
+          ]
+        ]
+      }
+    },
+    {
+      "id": "9296070/HFRDQ97U",
+      "type": "article-journal",
+      "title": "Freeing the essence of a computation",
+      "container-title": "ACM SIGPLAN Lisp Pointers",
+      "page": "25-36",
+      "volume": "VIII",
+      "issue": "2",
+      "abstract": "In theory, abstraction is important, but in practice, so is performance. Thus, there is a struggle between an abstract description of an algorithm and its efficient implementation. This struggle can be mediated by using an interpreter or a compiler. An interpreter takes a program that is a high level abstract description of an algorithm and applies it to some data. Don't think of an interpreter as slow. An interpreter is important enough to software that it is often implemented in hardware. A compiler takes the program and produces another program, perhaps in another language. The resulting program is applied to some data by another interpreter.",
+      "URL": "https://dl.acm.org/doi/10.1145/224133.224136",
+      "DOI": "10.1145/224133.224136",
+      "journalAbbreviation": "SIGPLAN Lisp Pointers",
+      "language": "en",
+      "author": [
+        {
+          "family": "Anderson",
+          "given": "Kenneth R."
+        }
+      ],
+      "issued": {
+        "date-parts": [
+          [
+            "1995",
+            5,
+            5
+          ]
+        ]
+      },
+      "accessed": {
+        "date-parts": [
+          [
+            2021,
+            4,
+            25
+          ]
+        ]
+      }
+    },
+    {
+      "id": "9296070/6L976844",
+      "type": "article-journal",
+      "title": "Ambitious evaluation: a new reading of an old issue",
+      "container-title": "ACM SIGPLAN Lisp Pointers",
+      "page": "1-44",
+      "volume": "VIII",
+      "issue": "2",
+      "abstract": "Much has been written about Lazy Evaluation in Lisp---less about the other end of the spectrum---Ambitious Evaluation. Ambition is a very subjective concept, though, and if you have some preconceived idea of what you think an Ambitious Evaluator might be about, you might want to set it aside for a few minutes because this probably isn't going to be what you expect.",
+      "URL": "https://dl.acm.org/doi/10.1145/224133.224137",
+      "DOI": "10.1145/224133.224137",
+      "shortTitle": "Ambitious evaluation",
+      "journalAbbreviation": "SIGPLAN Lisp Pointers",
+      "language": "en",
+      "author": [
+        {
+          "family": "Pitman",
+          "given": "Kent M."
+        }
+      ],
+      "issued": {
+        "date-parts": [
+          [
+            "1995",
+            5,
+            5
+          ]
+        ]
+      },
+      "accessed": {
+        "date-parts": [
+          [
+            2021,
+            4,
+            25
+          ]
+        ]
+      }
+    }
+  ],
+  "1998": [
+    {
+      "id": "9296070/ZRI4MHTQ",
+      "type": "article-journal",
+      "title": "A conversation with Austin Henderson",
+      "container-title": "Interactions",
+      "page": "36–47",
+      "volume": "5",
+      "issue": "6",
+      "URL": "https://doi.org/10.1145/287821.287827",
+      "DOI": "10.1145/287821.287827",
+      "journalAbbreviation": "interactions",
+      "author": [
+        {
+          "family": "Ehrlich",
+          "given": "Kate"
+        }
+      ],
+      "issued": {
+        "date-parts": [
+          [
+            "1998",
+            11,
+            1
+          ]
+        ]
+      },
+      "accessed": {
+        "date-parts": [
+          [
+            2021,
+            4,
+            15
+          ]
+        ]
+      }
+    }
+  ],
+  "2001": [
+    {
+      "id": "9296070/XMCBCFMT",
+      "type": "chapter",
+      "title": "On CAST.FSM Computation of Hierarchical Multi-layer Networks of Automata",
+      "container-title": "Computer Aided Systems Theory — EUROCAST 2001",
+      "publisher": "Springer Berlin Heidelberg",
+      "publisher-place": "Berlin",
+      "page": "36-44",
+      "volume": "2178",
+      "event-place": "Berlin",
+      "abstract": "CAST.FSM denotes a CAST tool which has been developed at the Institute of Systems Science at the University of Linz during the years 1986–1993. The first version of CAST.FSM was implemented in INTERLISP-D and LOOPS for the Siemens-Xerox workstation 5815 (“Dandelion”). CAST.FSM supports the application of the theory of finite state machines for hardware design tasks between the architecture level and the level of gate circuits. The application domain, to get practical experience for CAST.FSM, was the field of VLSI design of ASICS’s where the theory of finite state machines can be applied to improve the testability of such circuits (“design for testability”) and to optimise the required silicon area of the circuit (“floor planning”). An overview of CAST as a whole and of CAST.FSM as a CAST tool is given in [11]. In our presentation we want to report on the re-engineering of CAST.FSM and on new types of applications of CAST.FSM which are currently under investigation. In this context we will distinguish between three different problems:\n1.\nthe implementation of CAST.FSM in ANSI Common Lisp and the design of a new user interface by Rudolf Mittelmann [5].\n\n \n2.\nthe search for systemstheoretical concepts in modelling intelligent hierarchical systems based on the past work of Arthur Koestler [3] following the concepts presented by Franz Pichler in [10].\n\n \n3.\nthe construction of hierarchical formal models (of multi-layer type) to study attributes which are assumed for SOHO-structures (SOHO = Self Organizing Hierarchical Order) of A. Koestler.\n\n \nThe latter problem will deserve the main attention in our presentation. In the present paper we will build such a hierarchical model following the concepts of parallel decomposition of finite state machines (FSMs) and interpret it as a multi-layer type of model.",
+      "URL": "http://link.springer.com/10.1007/3-540-45654-6_3",
+      "ISBN": "978-3-540-42959-3 978-3-540-45654-4",
+      "note": "Series Title: Lecture Notes in Computer Science\nDOI: 10.1007/3-540-45654-6_3",
+      "language": "en",
+      "collection-editor": [
+        {
+          "family": "Goos",
+          "given": "Gerhard"
+        },
+        {
+          "family": "Hartmanis",
+          "given": "Juris"
+        },
+        {
+          "family": "van Leeuwen",
+          "given": "Jan"
+        }
+      ],
+      "editor": [
+        {
+          "family": "Moreno-Díaz",
+          "given": "Roberto"
+        },
+        {
+          "family": "Buchberger",
+          "given": "Bruno"
+        },
+        {
+          "family": "Luis Freire",
+          "given": "José"
+        }
+      ],
+      "author": [
+        {
+          "family": "Affenzeller",
+          "given": "Michael"
+        },
+        {
+          "family": "Pichler",
+          "given": "Franz"
+        },
+        {
+          "family": "Mittelmann",
+          "given": "Rudolf"
+        }
+      ],
+      "issued": {
+        "date-parts": [
+          [
+            2001
+          ]
+        ]
+      },
+      "accessed": {
+        "date-parts": [
+          [
+            2021,
+            4,
+            15
+          ]
+        ]
+      }
+    }
+  ],
+  "2003": [
+    {
+      "id": "9296070/IVA8R7A2",
+      "type": "report",
+      "title": "Programming Languages -- The LOOPS Project (1982-1986)",
+      "publisher": "Xerox Parc",
+      "abstract": "The LOOPS (Lisp Object-Oriented Language) project was started to support development of expert systems project at PARC. We wanted a language that had many of the\nfeatures of frame languages, such as objects, annotated values, inheritance, and attached procedures. We drew heavily on Smalltalk-80, which was being developed next door.",
+      "URL": "https://larrymasinter.net/stefik-loops.pdf",
+      "language": "en",
+      "author": [
+        {
+          "family": "Bobrow",
+          "given": "Daniel"
+        },
+        {
+          "family": "Mittal",
+          "given": "Sanjay"
+        },
+        {
+          "family": "Lanning",
+          "given": "Stanley"
+        },
+        {
+          "family": "Stefik",
+          "given": "Mark"
+        }
+      ],
+      "issued": {
+        "date-parts": [
+          [
+            2003
+          ]
+        ]
+      }
+    },
+    {
+      "id": "9296070/IVA8R7A2",
+      "type": "report",
+      "title": "Programming Languages -- The LOOPS Project (1982-1986)",
+      "publisher": "Xerox Parc",
+      "abstract": "The LOOPS (Lisp Object-Oriented Language) project was started to support development of expert systems project at PARC. We wanted a language that had many of the\nfeatures of frame languages, such as objects, annotated values, inheritance, and attached procedures. We drew heavily on Smalltalk-80, which was being developed next door.",
+      "URL": "https://larrymasinter.net/stefik-loops.pdf",
+      "language": "en",
+      "author": [
+        {
+          "family": "Bobrow",
+          "given": "Daniel"
+        },
+        {
+          "family": "Mittal",
+          "given": "Sanjay"
+        },
+        {
+          "family": "Lanning",
+          "given": "Stanley"
+        },
+        {
+          "family": "Stefik",
+          "given": "Mark"
+        }
+      ],
+      "issued": {
+        "date-parts": [
+          [
+            2003
+          ]
+        ]
+      }
+    },
+    {
+      "id": "9296070/IVA8R7A2",
+      "type": "report",
+      "title": "Programming Languages -- The LOOPS Project (1982-1986)",
+      "publisher": "Xerox Parc",
+      "abstract": "The LOOPS (Lisp Object-Oriented Language) project was started to support development of expert systems project at PARC. We wanted a language that had many of the\nfeatures of frame languages, such as objects, annotated values, inheritance, and attached procedures. We drew heavily on Smalltalk-80, which was being developed next door.",
+      "URL": "https://larrymasinter.net/stefik-loops.pdf",
+      "language": "en",
+      "author": [
+        {
+          "family": "Bobrow",
+          "given": "Daniel"
+        },
+        {
+          "family": "Mittal",
+          "given": "Sanjay"
+        },
+        {
+          "family": "Lanning",
+          "given": "Stanley"
+        },
+        {
+          "family": "Stefik",
+          "given": "Mark"
+        }
+      ],
+      "issued": {
+        "date-parts": [
+          [
+            2003
+          ]
+        ]
+      }
+    }
+  ],
+  "2006": [
+    {
+      "id": "9296070/88GP5KT3",
+      "type": "webpage",
+      "title": "PDP-10 software archive",
+      "URL": "http://pdp-10.trailing-edge.com/",
+      "shortTitle": "Tape Images from Computer History",
+      "author": [
+        {
+          "family": "Kossow",
+          "given": "Al"
+        }
+      ],
+      "issued": {
+        "date-parts": [
+          [
+            2006
+          ]
+        ]
+      },
+      "accessed": {
+        "date-parts": [
+          [
+            2021,
+            4,
+            25
+          ]
+        ]
+      }
+    }
+  ],
+  "2008": [
+    {
+      "id": "9296070/DVGRZ62H",
+      "type": "paper-conference",
+      "title": "History of Interlisp",
+      "container-title": "Celebrating the 50th Anniversary of Lisp",
+      "collection-title": "LISP50",
+      "publisher": "Association for Computing Machinery",
+      "publisher-place": "New York, NY, USA",
+      "page": "1–5",
+      "event-place": "New York, NY, USA",
+      "abstract": "I was first introduced to Lisp in 1962 as a first year graduate student at M.I.T. in a class taught by James Slagle. Having programmed in Fortran and assembly, I was impressed with Lisp's elegance. In particular, Lisp enabled expressing recursion in a manner that was so simple that many first time observers would ask the question, \"Where does the program do the work?\" (Answer - between the parentheses!) Lisp also provided the ability to manipulate programs, since Lisp programs were themselves data (S-expressions) the same as other list structures used to represent program data. This made Lisp an ideal language for writing programs that themselves constructed programs or proved things about programs. Since I was at M.I.T. to study Artificial Intelligence, program writing programs was something that interested me greatly.",
+      "URL": "https://doi.org/10.1145/1529966.1529971",
+      "DOI": "10.1145/1529966.1529971",
+      "ISBN": "978-1-60558-383-9",
+      "author": [
+        {
+          "family": "Teitelman",
+          "given": "Warren"
+        }
+      ],
+      "issued": {
+        "date-parts": [
+          [
+            "2008",
+            10,
+            20
+          ]
+        ]
+      },
+      "accessed": {
+        "date-parts": [
+          [
+            2021,
+            4,
+            15
+          ]
+        ]
+      }
+    }
+  ],
+  "2011": [
+    {
+      "id": "9296070/PUPZYPIV",
+      "type": "motion_picture",
+      "title": "The Colab Movie (1987)",
+      "abstract": "The Colab project at PARC was an experiment in creating an electronic meeting room. This project developed multi-user interfaces, telepointers, and other innovations at the time. This movie shows the Cognoter tool which was a multi-user brainstorming tool used for collaborative development of an outline for a paper. See /www.markstefik.com/?page_id=155\"",
+      "URL": "https://www.youtube.com/watch?v=iPZTOosKjAE",
+      "shortTitle": "The Colab Movie",
+      "author": [
+        {
+          "family": "Mark Stefik",
+          "given": ""
+        }
+      ],
+      "issued": {
+        "date-parts": [
+          [
+            2011,
+            4,
+            10
+          ]
+        ]
+      },
+      "accessed": {
+        "date-parts": [
+          [
+            2021,
+            5,
+            17
+          ]
+        ]
+      }
+    },
+    {
+      "id": "9296070/MJP8UYEV",
+      "type": "motion_picture",
+      "title": "Truckin Knowledge Competition (1983)",
+      "abstract": "In 1983 the Knowledge Systems Area at Xerox PARC taught experimental courses on knowledge programming. The Truckin' knowledge competition was the final exam at the end of a one week course. Students programmed their trucks to compete in Truckin' simulation world -- buying and selling goods, getting gas as needed, avoiding bandits, and so on. All of the trucks competed in the final. The winner was the truck with the most cash parked nearest Alice's Restaurant. See www.markstefik.com/?page_id=359",
+      "URL": "https://www.youtube.com/watch?v=Pt-Sv1ynGKc",
+      "author": [
+        {
+          "family": "Mark Stefik",
+          "given": ""
+        }
+      ],
+      "issued": {
+        "date-parts": [
+          [
+            2011,
+            4,
+            10
+          ]
+        ]
+      },
+      "accessed": {
+        "date-parts": [
+          [
+            2021,
+            5,
+            17
+          ]
+        ]
+      }
+    }
+  ],
+  "2012": [
+    {
+      "id": "9296070/ZE7EVJYM",
+      "type": "motion_picture",
+      "title": "Graphical Programming (1988) - Part 0",
+      "publisher": "Xerox Lisp Workstation",
+      "abstract": "Guy DesVignes and R. Wayne Oldford, 1988 \n \nThis video (in 3 pieces) describes the use of graphical programming with an example, showing the encapsulation of several steps of an analysis into a single reusable tool.   An INTERLISP-D programming environment with the object oriented system LOOPS is used for software development. \nWork is on a Xerox Lisp Workstation  (Xerox 1186). \n \nFirst of 3 pieces of a single video. \n \nFirst piece: Graphical Programming (1988) - Part 0 \n       Contains: \n        \"Opening\"   \n            -  Introduction by a young Wayne Oldford   \n               (refers to earlier video called \"Data Analysis Networks \n                in DINDE\")  \n       \"Part 0 Statistical Analysis Maps\" \n            - review of the interactive data analysis network representation  \n              of a statistical analysis. \n \nSecond piece:  Graphical Programming (1988) - Parts 1 and 2 \n       Contains: \n        \"Part 1   Toolboxes\"   \n            -  Review of the elements of a statistical toolbox in DINDE  \n       \"Part 2 The Analysis Path\" \n            - Demonstrates exploration of a path in an existing \n              analysis map and its representation as a pattern, \n              It is shown how to capture this pattern in DINDE as a new \n             new program represented as an \"AnalysisPath\" object.. \n              This is what is meant by  \"graphical programming\". \n \n \nThird piece: \"Graphical Programming (1988) - Part 3\" \n       Contains: \n        \"Part 3   Graphical Programming \n                        Example: Added Variable Plots\"   \n            - Demonstrates graphical programming by constructing \n              an added variable plot.  This is done by constructing the \n              appropriate analysis path on some data, capturing the pattern \n              adding it to the toolbox and then applying it to new data. \n \n        \"Summary\" \n \n \nSound has been cleaned up a little. \nComplete video also available in whole at  \n        stat-graphics.org/movies/graphical-programming.html",
+      "URL": "https://www.youtube.com/watch?v=J4F6ioMKiqw&t=53s",
+      "author": [
+        {
+          "family": "Oldford",
+          "given": "Wayne"
+        }
+      ],
+      "issued": {
+        "date-parts": [
+          [
+            2012,
+            2,
+            16
+          ]
+        ]
+      },
+      "accessed": {
+        "date-parts": [
+          [
+            2021,
+            5,
+            2
+          ]
+        ]
+      }
+    },
+    {
+      "id": "9296070/FJ2M3GNL",
+      "type": "motion_picture",
+      "title": "Graphical Programming (1988) - Parts 1 and 2",
+      "publisher": "Xerox Lisp Workstation",
+      "abstract": "Guy DesVignes and R. Wayne Oldford, 1988 \n \nThis video (in 3 pieces) describes the use of graphical programming with an example, showing the encapsulation of several steps of an analysis into a single reusable tool.   An INTERLISP-D programming environment with the object oriented system LOOPS is used for software development. \nWork is on a Xerox Lisp Workstation  (Xerox 1186). \n \nSecond of 3 pieces of a single video. \n \nFirst piece: Graphical Programming (1988) - Part 0 \n       Contains: \n        \"Opening\"   \n            -  Introduction by Wayne Oldford   \n               (refers to earlier video called \"Data Analysis Networks \n                in DINDE\")  \n       \"Part 0 Statistical Analysis Maps\" \n            - review of the interactive data analysis network representation  \n              of a statistical analysis. \n \nSecond piece:  Graphical Programming (1988) - Parts 1 and 2 \n       Contains: \n        \"Part 1   Toolboxes\"   \n            -  Review of the elements of a statistical toolbox in DINDE  \n       \"Part 2 The Analysis Path\" \n            - Demonstrates exploration of a path in an existing \n              analysis map and its representation as a pattern, \n              It is shown how to capture this pattern in DINDE as a new \n             new program represented as an \"AnalysisPath\" object.. \n              This is what is meant by  \"graphical programming\". \n \n \nThird piece: \"Graphical Programming (1988) - Part 3\" \n       Contains: \n        \"Part 3   Graphical Programming \n                        Example: Added Variable Plots\"   \n            - Demonstrates graphical programming by constructing \n              an added variable plot.  This is done by constructing the \n              appropriate analysis path on some data, capturing the pattern \n              adding it to the toolbox and then applying it to new data. \n \n        \"Summary\" \n \n \nSound has been cleaned up a little. \nComplete video also available in whole at  \n        stat-graphics.org/movies/graphical-programming.html",
+      "URL": "https://www.youtube.com/watch?v=wlN0hHLZL8c",
+      "author": [
+        {
+          "family": "Oldford",
+          "given": "Wayne"
+        }
+      ],
+      "issued": {
+        "date-parts": [
+          [
+            2012,
+            2,
+            17
+          ]
+        ]
+      },
+      "accessed": {
+        "date-parts": [
+          [
+            2021,
+            5,
+            2
+          ]
+        ]
+      }
+    },
+    {
+      "id": "9296070/TEHSJNIS",
+      "type": "motion_picture",
+      "title": "Computer-Assisted Instruction (Bits and Bytes, Episode 7)",
+      "abstract": "This clip looks at two examples of larger tutorial--CAI systems that were developed by the Ontario Institute for Studies and Education, and Xerox's PARC.\n\nIt is from Episode 7 of the classic 1983 television series, Bits and Bytes, which starred Luba Goy and Billy Van.  It was produced by TVOntario, but is no longer available for purchase.",
+      "URL": "https://www.youtube.com/watch?v=eURtTV_qKw8&t=147s",
+      "issued": {
+        "date-parts": [
+          [
+            2012,
+            5,
+            19
+          ]
+        ]
+      },
+      "accessed": {
+        "date-parts": [
+          [
+            2021,
+            5,
+            2
+          ]
+        ]
+      }
+    }
+  ],
+  "2017": [
+    {
+      "id": "9296070/S2ZC62QX",
+      "type": "webpage",
+      "title": "Interlisp-D at AAAI-82",
+      "container-title": "Google Photos",
+      "abstract": "17 new photos added to shared album",
+      "URL": "https://photos.google.com/share/AF1QipORUrk2uwraYYJVOZ2R8mH51U4n5uv30V1KJk5zvu5Pd5XtEXuXp8jg1BfwdHBHkw?key=OGxZSU5LbXZPaTdmbnU3QmZiOTRlYnR6SDdMNUJ3",
+      "language": "en",
+      "author": [
+        {
+          "family": "Masinter",
+          "given": "Larry"
+        }
+      ],
+      "issued": {
+        "date-parts": [
+          [
+            "2017",
+            9,
+            30
+          ]
+        ]
+      },
+      "accessed": {
+        "date-parts": [
+          [
+            2021,
+            4,
+            16
+          ]
+        ]
+      }
+    }
+  ],
+  "2020": [
+    {
+      "id": "9296070/XK2RYFWN",
+      "type": "book",
+      "title": "livingcomputermuseum/Darkstar",
+      "abstract": "A Xerox Star 8010 Emulator. Contribute to livingcomputermuseum/Darkstar development by creating an account on GitHub.",
+      "URL": "https://github.com/livingcomputermuseum/Darkstar",
+      "note": "original-date: 2019-01-15T20:40:02Z",
+      "author": [
+        {
+          "family": "Museum+Labs",
+          "given": "Living Computers:"
+        }
+      ],
+      "issued": {
+        "date-parts": [
+          [
+            "2020",
+            12,
+            25
+          ]
+        ]
+      },
+      "accessed": {
+        "date-parts": [
+          [
+            2021,
+            4,
+            15
+          ]
+        ]
+      }
+    }
+  ],
+  "2021": [
+    {
+      "id": "9296070/JELN3BBL",
+      "type": "entry-encyclopedia",
+      "title": "Interlisp",
+      "container-title": "Wikipedia",
+      "abstract": "Interlisp (also seen with a variety of capitalizations) is a programming environment built around a version of the programming language Lisp. Interlisp development began in 1966 at Bolt, Beranek and Newman (renamed BBN Technologies) in Cambridge, Massachusetts with Lisp implemented for the Digital Equipment Corporation (DEC) PDP-1 computer by Danny Bobrow and D. L. Murphy. In 1970, Alice K. Hartley implemented BBN LISP, which ran on PDP-10 machines running the operating system TENEX (renamed TOPS-20). In 1973, when Danny Bobrow, Warren Teitelman and Ronald Kaplan moved from BBN to the Xerox Palo Alto Research Center (PARC), it was renamed Interlisp. Interlisp became a popular Lisp development tool for artificial intelligence (AI) researchers at Stanford University and elsewhere in the community of the Defense Advanced Research Projects Agency (DARPA). Interlisp was notable for integrating interactive development tools into an integrated development environment (IDE), such as a debugger, an automatic correction tool for simple errors (via do what I mean (DWIM) software design, and analysis tools.",
+      "URL": "https://en.wikipedia.org/w/index.php?title=Interlisp&oldid=1014034897",
+      "language": "en",
+      "editor": [
+        {
+          "family": "Jekkara",
+          "given": ""
+        }
+      ],
+      "issued": {
+        "date-parts": [
+          [
+            "2021",
+            3,
+            24
+          ]
+        ]
+      },
+      "accessed": {
+        "date-parts": [
+          [
+            2021,
+            4,
+            21
+          ]
+        ]
+      }
+    },
+    {
+      "id": "9296070/RCFRZY85",
+      "type": "article-journal",
+      "title": "An Archive of Interfaces: Exploring the Potential of Emulation for Software Research, Pedagogy, and Design",
+      "container-title": "Proceedings of the ACM on Human-Computer Interaction",
+      "page": "294:1–294:22",
+      "volume": "5",
+      "issue": "CSCW2",
+      "abstract": "This paper explores the potential of distributed emulation networks to support research and pedagogy into historical and sociotechnical aspects of software. Emulation is a type of virtualization that re-creates the conditions for a piece of legacy software to operate on a modern system. The paper first offers a review of Computer-Supported Cooperative Work (CSCW), Human-Computer Interaction (HCI), and Science and Technology Studies (STS) literature engaging with software as historical and sociotechnical artifacts, and with emulation as a vehicle of scholarly inquiry. It then documents the novel use of software emulations as a pedagogical resource and research tool for legacy software systems analysis. This is accomplished through the integration of the Emulation as a Service Infrastructure (EaaSI) distributed emulation network into a university-level course focusing on computer-aided design (CAD). The paper offers a detailed case study of a pedagogical experience oriented to incorporate emulations into software research and learning. It shows how emulations allow for close, user-centered analyses of software systems that highlight both their historical evolution and core interaction concepts, and how they shape the work practices of their users.",
+      "URL": "https://doi.org/10.1145/3476035",
+      "DOI": "10.1145/3476035",
+      "shortTitle": "An Archive of Interfaces",
+      "journalAbbreviation": "Proc. ACM Hum.-Comput. Interact.",
+      "author": [
+        {
+          "family": "Cardoso-Llach",
+          "given": "Daniel"
+        },
+        {
+          "family": "Kaltman",
+          "given": "Eric"
+        },
+        {
+          "family": "Erdolu",
+          "given": "Emek"
+        },
+        {
+          "family": "Furste",
+          "given": "Zachary"
+        }
+      ],
+      "issued": {
+        "date-parts": [
+          [
+            "2021",
+            10,
+            18
+          ]
+        ]
+      },
+      "accessed": {
+        "date-parts": [
+          [
+            2021,
+            10,
+            21
+          ]
+        ]
+      }
+    }
+  ],
+  "1963": [
+    {
+      "id": "9296070/EIATQTVR",
+      "type": "article-journal",
+      "title": "A Heuristic Program that Solves Symbolic Integration Problems in Freshman Calculus",
+      "container-title": "Journal of the ACM",
+      "page": "413-581",
+      "volume": "10",
+      "issue": "4",
+      "abstract": "A large high-speed general-purpose digital computer (IBM 7090) was programmed to solve elementary symbolic integration problems at approximately the level of a good college freshman. The program is called SAINT, an acronym for \"Symbolic Automatic INTegrator.\" This paper discusses the SAINT program and its performance. SAINT performs indefinite integration. It also performs definite and multiple integration when these are trivial extensions of indefinite integration. It uses many of the methods and heuristics of students attacking the same prombles. SAINT took an average of two minutes each to solve 52 of the 54 attempted problems taken from the Massachusetts Institute of Technology freshman calculus final examinations. Based on this and other experiments with SAINT, some conclusions coneering computer solution of such problems are: (1) Pattern recognition is of fundamental importance. (2) Great benefit would have been derived from a large memory and more convenient symbol manipulating facilities. (3) The solution of a symbolic integration problem by a commercially available computer is far cheaper and faster than by man.",
+      "URL": "https://dl.acm.org/doi/10.1145/321186.321193",
+      "DOI": "10.1145/321186.321193",
+      "journalAbbreviation": "J. ACM",
+      "language": "en",
+      "author": [
+        {
+          "family": "Slagle",
+          "given": "James R."
+        }
+      ],
+      "issued": {
+        "date-parts": [
+          [
+            "1963",
+            10
+          ]
+        ]
+      },
+      "accessed": {
+        "date-parts": [
+          [
+            2021,
+            4,
+            25
+          ]
+        ]
+      }
+    }
+  ],
+  "1965": [
+    {
+      "id": "9296070/RTRAYUTG",
+      "type": "article",
+      "title": "930 LISP Reference Manual",
+      "URL": "http://bitsavers.org/pdf/sds/9xx/940/ucbProjectGenie/30.50.40_930_LISP_Reference_Feb66.pdf",
+      "language": "English",
+      "author": [
+        {
+          "family": "Deutsch",
+          "given": "L. Peter"
+        },
+        {
+          "family": "Lampson",
+          "given": "Butler W."
+        }
+      ],
+      "issued": {
+        "date-parts": [
+          [
+            "1965",
+            6,
+            5
+          ]
+        ]
+      }
+    }
+  ],
+  "1968": [
+    {
+      "id": "9296070/DNCVYGJC",
+      "type": "article-journal",
+      "title": "A note on the efficiency of a LISP computation in a paged machine",
+      "container-title": "Communications of the ACM",
+      "page": "558",
+      "volume": "11",
+      "issue": "8",
+      "abstract": "The problem of the use of two levels of storage for programs is explored in the context of a LISP system which uses core memory as a buffer for a large virtual memory stored on a drum. Details of timing are given for one particular problem.",
+      "URL": "https://dl.acm.org/doi/10.1145/363567.363581",
+      "DOI": "10.1145/363567.363581",
+      "journalAbbreviation": "Commun. ACM",
+      "language": "en",
+      "author": [
+        {
+          "family": "Bobrow",
+          "given": "Daniel G."
+        },
+        {
+          "family": "Murphy",
+          "given": "Daniel L."
+        }
+      ],
+      "issued": {
+        "date-parts": [
+          [
+            "1968",
+            8
+          ]
+        ]
+      },
+      "accessed": {
+        "date-parts": [
+          [
+            2021,
+            4,
+            21
+          ]
+        ]
+      }
+    }
+  ],
+  "1969": [
+    {
+      "id": "9296070/9SDF3BWD",
+      "type": "book",
+      "title": "The BBN-LISP system: Reference Manual",
+      "publisher": "Bolt, Beranek and Newman Inc",
+      "publisher-place": "Cambridge",
+      "number-of-pages": "368",
+      "event-place": "Cambridge",
+      "abstract": "This document describes the BEN-LISP system currently implemented on the SDS 940. It is a dialect of LISP 1.5 and the differences between IBM 7090 version and this system are described in Appendix\n1 and 2. Principally, this system has been expanded from the LISP 1.5 on the 7090 in a number of different ways. BBN-LISP is\ndesigned to utilize a drum for storage and to provide the user a large virtual memory, with a relatively small penalty in speed (using special paging techniques described in Bobrow and Murphy 1967).",
+      "URL": "http://www.bitsavers.org/pdf/bbn/The_BBN-LISP_System_Apr69.pdf",
+      "call-number": "Z699.5.L28 B62 1969",
+      "shortTitle": "The BBN-LISP system",
+      "editor": [
+        {
+          "family": "Bobrow",
+          "given": "Daniel G."
+        },
+        {
+          "family": "Murphy",
+          "given": "D. L."
+        },
+        {
+          "family": "Teitelman",
+          "given": "Warren"
+        }
+      ],
+      "issued": {
+        "date-parts": [
+          [
+            "1969",
+            4
+          ]
+        ]
+      }
+    },
+    {
+      "id": "9296070/I2U8XT9Z",
+      "type": "article-journal",
+      "title": "LISP bulletin",
+      "container-title": "ACM SIGPLAN Notices",
+      "page": "17-57",
+      "volume": "4",
+      "issue": "9",
+      "abstract": "This first (long delayed) LISP Bulletin contains samples of most of those types of items which the editor feels are relevant to this publication. These include announcements of new (i.e. not previously announced here) implementations of LISP (or closely related) systems; quick tricks in LISP; abstracts of LISP related papers; short writeups and listings of useful programs; and longer articles on problems of general interest to the entire LISP community. Printing of these last articles in the Bulletin does not interfere with later publications in formal journals or books. Short write-ups of new features added to LISP are of interest, preferably upward compatible with LISP 1.5, especially if they are illustrated by programming examples.",
+      "URL": "https://doi.org/10.1145/1132291.1132032",
+      "DOI": "10.1145/1132291.1132032",
+      "journalAbbreviation": "SIGPLAN Not.",
+      "author": [
+        {
+          "family": "Bobrow",
+          "given": "D. G."
+        }
+      ],
+      "issued": {
+        "date-parts": [
+          [
+            "1969",
+            9,
+            1
+          ]
+        ]
+      },
+      "accessed": {
+        "date-parts": [
+          [
+            2021,
+            4,
+            25
+          ]
+        ]
+      }
+    }
+  ],
+  "1971": [
+    {
+      "id": "9296070/JCVVQUVD",
+      "type": "article",
+      "title": "BBN - LISP, TENEX Reference Manual",
+      "publisher": "Bolt, Beranek and Newman, Inc. (BBN)",
+      "URL": "http://www.softwarepreservation.org/projects/LISP/bbnlisp/TenexLispRef_Jul71.pdf",
+      "author": [
+        {
+          "family": "Teitelman",
+          "given": "W."
+        },
+        {
+          "family": "Bobrow",
+          "given": "D. G."
+        },
+        {
+          "family": "Hartley",
+          "given": "A. K."
+        },
+        {
+          "family": "Murphy",
+          "given": "D. L."
+        }
+      ],
+      "issued": {
+        "date-parts": [
+          [
+            "1971",
+            7
+          ]
+        ]
+      },
+      "accessed": {
+        "date-parts": [
+          [
+            2021,
+            6,
+            1
+          ]
+        ]
+      }
+    }
+  ],
+  "1974": [
+    {
+      "id": "9296070/QQ4WARPF",
+      "type": "article-journal",
+      "title": "INTERLISP documentation",
+      "container-title": "ACM SIGART Bulletin",
+      "page": "5-22",
+      "issue": "44",
+      "abstract": "Documentation for INTERSLIP in the form of the INTERSLIP Reference Manual is now available and may be obtained from Warren Teitelman, Xerox Palo Alto Research Center. The new manual replaces all existing documentation, and is completely up to date (as to January, 1974). The manual is available in either loose-leaf or bound form. The lose-leaf version (binders not supplied) comes with printed separator tabs between the chapters. The bound version also includes colored divider pages between chapters, and is printed on somewhat thinner paper than the loose-leaf version, in an effort to make it 'portable' (the manual being approximately 700 pages long). Both versions contain a complete master index (approximately 1600 entries), as well as a separate index for each chapter. Although the manual is intended primarily to be used for reference, many chapters, e.g., the programmer's assistant, do-what-I-mean, CLISP, etc., include introductory and tutorial material. The manual is available in machine-readable form, and an on-line question-answering system using the manual as a data base is currently being implemented.",
+      "URL": "https://doi.org/10.1145/1045183.1045186",
+      "DOI": "10.1145/1045183.1045186",
+      "journalAbbreviation": "SIGART Bull.",
+      "author": [
+        {
+          "family": "Teitelman",
+          "given": "Warren"
+        }
+      ],
+      "issued": {
+        "date-parts": [
+          [
+            "1974",
+            2,
+            1
+          ]
+        ]
+      },
+      "accessed": {
+        "date-parts": [
+          [
+            2021,
+            4,
+            15
+          ]
+        ]
+      }
+    },
+    {
+      "id": "9296070/K4LSMPDE",
+      "type": "article",
+      "title": "Display primitives in Lisp",
+      "publisher": "Palo Alto Research Center, Xerox Corporation",
+      "abstract": "Several conflicting goal must be resolved in deciding on a set of display facilities for Lisp: ease of lisp, efficient access to hardware facilities, and device and system independence. Thiss memo suggests a set of facilities constructed in two layers: a lower layer that gives direct access to the Alto\nbitmap capability, while retaining Lisp's tradition of freeing the programmer\nfrom  storage allocation worries and an upper Iayer that uses the lower (on the Alto) or a character-stream protocol (for VTS t on MAXC) to provide for writing strings, scrolling, edting, etc. on the screen,",
+      "URL": "http://www.bitsavers.org/pdf/xerox/alto/memos_1974/Display_Primitives_in_Lisp_Nov74.pdf",
+      "author": [
+        {
+          "family": "Deutsch",
+          "given": "P."
+        }
+      ],
+      "issued": {
+        "date-parts": [
+          [
+            "1974",
+            11,
+            18
+          ]
+        ]
+      }
+    }
+  ],
+  "1977": [
+    {
+      "id": "9296070/3H5F6TBA",
+      "type": "paper-conference",
+      "title": "A display oriented programmer's assistant",
+      "container-title": "Proceedings of the 5th international joint conference on Artificial intelligence - Volume 2",
+      "collection-title": "IJCAI'77",
+      "publisher": "Morgan Kaufmann Publishers Inc.",
+      "publisher-place": "San Francisco, CA, USA",
+      "page": "905–915",
+      "event-place": "San Francisco, CA, USA",
+      "abstract": "This paper continues and extends previous work by the author in developing systems which provide the user with various forms of explicit and implicit assistance, and in general cooperate with the user in the development of his programs. The system described in this paper makes extensive use of a bit map display and pointing device (a mouse) to significantly enrich the user's interactions with the system, and to provide capabilities not possible with terminals that essentially emulate hard copy devices. For example, any text that is displayed on the screen can be pointed at and treated as input, exactly as though it were typed, i.e., the user can say use this expression or that value, and then simply point. The user views his programming environment through a collection of display windows, each of which corresponds to a different task or context. The user can manipulate the windows, or the contents of a particular window, by a combination of keyboard inputs or pointing operations. The technique of using different windows for different tasks makes it easy for the user to manage several simultaneous tasks and contexts, e.g., defining programs, testing programs, editing, asking the system for assistance, sending and receiving messages, etc and to switch back and forth between these tasks at his convenience.",
+      "URL": "https://dl.acm.org/doi/10.5555/1622943.1623025",
+      "author": [
+        {
+          "family": "Teitelman",
+          "given": "Warren"
+        }
+      ],
+      "issued": {
+        "date-parts": [
+          [
+            "1977",
+            8,
+            22
+          ]
+        ]
+      },
+      "accessed": {
+        "date-parts": [
+          [
+            2021,
+            5,
+            31
+          ]
+        ]
+      }
+    },
+    {
+      "id": "9296070/P5MUCJX3",
+      "type": "article-journal",
+      "title": "Semantic grammar: an engineering technique for constructing natural language understanding systems",
+      "container-title": "ACM SIGART Bulletin",
+      "page": "26",
+      "issue": "61",
+      "abstract": "One of the major stumbling blocks to more effective used computers by naive users is the lack of natural means of communication between the user and the computer system. This report discusses a paradigm for constructing efficient and friendly man-machine interface systems involving subsets of natural language for limited domains of discourse. As such this work falls somewhere between highly constrained formal language query systems and unrestricted natural language under-standing systems. The primary purpose of this research is not to advance our theoretical under-standing of natural language but rather to put forth a set of techniques for embedding both semantic/conceptual and pragmatic information into a useful natural language interface module. Our intent has been to produce a front end system which enables the user to concentrate on his problem or task rather than making him worry about how to communicate his ideas or questions to the machine.",
+      "URL": "https://doi.org/10.1145/1045283.1045290",
+      "DOI": "10.1145/1045283.1045290",
+      "shortTitle": "Semantic grammar",
+      "journalAbbreviation": "SIGART Bull.",
+      "language": "en",
+      "author": [
+        {
+          "family": "Burton",
+          "given": "Richard R."
+        }
+      ],
+      "issued": {
+        "date-parts": [
+          [
+            "1977",
+            2,
+            1
+          ]
+        ]
+      },
+      "accessed": {
+        "date-parts": [
+          [
+            2021,
+            6,
+            2
+          ]
+        ]
+      }
+    },
+    {
+      "id": "9296070/S82MS337",
+      "type": "report",
+      "title": "INTERLISP DISPLAY PRIMITIVES",
+      "publisher-place": "Xerox Palo Alto Research Center3333 Coyote H iII RoadPalo Altot California 94304",
+      "event-place": "Xerox Palo Alto Research Center3333 Coyote H iII RoadPalo Altot California 94304",
+      "abstract": "This report describes briefly a set of display primitives that we have developed at PARC toextend the capabilities of InterLisp[l]. These primitives are designed to operate araster-scanned displaYt and concentrate on facilities for placing text carefully on the displayand for moving chunks of an already-created display.",
+      "URL": "http://scholar.googleusercontent.com/scholar?q=cache:fAjwtL8R9ogJ:scholar.google.com/+INTERLISP+DISPLAY+PRIl%5ClITIVES&hl=en&as_sdt=0,5",
+      "language": "en-US",
+      "author": [
+        {
+          "family": "Sproull",
+          "given": "Robert F."
+        }
+      ],
+      "issued": {
+        "date-parts": [
+          [
+            "1977",
+            7
+          ]
+        ]
+      }
+    }
+  ],
+  "1989": [
+    {
+      "id": "9296070/GPMCN5XC",
+      "type": "paper-conference",
+      "title": "The PepPro™ Peptide Synthesis Expert System",
+      "container-title": "PROCEEDINGS OF THE FIRST ANNUAL CONFERENCE ON INNOVATIVE APPLICATIONS OF ARTIFICIAL INTELLIGENCE",
+      "publisher": "The AAAI Press, Menlo Park, California",
+      "publisher-place": "Stanford, California",
+      "event": "THE FIRST ANNUAL CONFERENCE ON INNOVATIVE APPLICATIONS OF ARTIFICIAL INTELLIGENCE",
+      "event-place": "Stanford, California",
+      "abstract": "Peptide synthesis is an important research tool. However, successful syntheses require considerable effort from the scientist. We have produced an expert System, the PepPro™ Peptide Synthesis Expert System, that helps the scientist improve peptide syntheses. To use PepPro the scientist enters the peptide to be synthesized. PepPro then applies its synthesis rules to analyze the peptide, to predict coupling. problems, and to recommend solutions. PepPro produces a synthesis report that summarizes the analysis and recommendations. The program includes a capability that allows the scientist to write new synthesis rules and add them to the PepPro knowledge base. PepPro was developed on Xerox 11xx series workstations using Beckman’s proprietary development environment MP). We then compiled PepPro to run on the IBM PC. PepPro has limitations that derive from unpredictable events during a synthesis. Despite the limitations, PepPro provides several important benefits. The major one is that it makes peptide syntheses easier, less time-consuming, and more efficient.",
+      "URL": "https://www.aaai.org/Papers/IAAI/1989/IAAI89-010.pdf",
+      "author": [
+        {
+          "family": "Martz",
+          "given": "Philip R."
+        },
+        {
+          "family": "Heffron",
+          "given": "Matt"
+        },
+        {
+          "family": "Kalbag",
+          "given": "Suresh"
+        },
+        {
+          "family": "Dyckes",
+          "given": "Douglas F."
+        },
+        {
+          "family": "Voelker",
+          "given": "Paul"
+        }
+      ],
+      "issued": {
+        "date-parts": [
+          [
+            "1989",
+            3,
+            28
+          ]
+        ]
+      }
+    }
+  ],
+  "1996": [
+    {
+      "id": "9296070/CHD59QIJ",
+      "type": "article-journal",
+      "title": "Cyberethics and the future of computing",
+      "container-title": "ACM SIGCAS Computers and Society",
+      "page": "22-29",
+      "volume": "26",
+      "issue": "2",
+      "URL": "https://doi.org/10.1145/236394.236396",
+      "DOI": "10.1145/236394.236396",
+      "journalAbbreviation": "SIGCAS Comput. Soc.",
+      "author": [
+        {
+          "family": "Tavani",
+          "given": "Herman T."
+        }
+      ],
+      "issued": {
+        "date-parts": [
+          [
+            "1996",
+            5,
+            1
+          ]
+        ]
+      },
+      "accessed": {
+        "date-parts": [
+          [
+            2021,
+            4,
+            25
+          ]
+        ]
+      }
+    }
+  ],
+  "2007": [
+    {
+      "id": "9296070/4QGNIKFU",
+      "type": "article-journal",
+      "title": "Word play",
+      "container-title": "Computational Linguistics",
+      "page": "443–467",
+      "volume": "33",
+      "issue": "4",
+      "abstract": "This article is a perspective on some important developments in semantics and in computational linguistics over the past forty years. It reviews two lines of research that lie at opposite ends of the field: semantics and morphology. The semantic part deals with issues from the 1970s such as discourse referents, implicative verbs, presuppositions, and questions. The second part presents a brief history of the application of finite-state transducers to linguistic analysis starting with the advent of two-level morphology in the early 1980s and culminating in successful commercial applications in the 1990s. It offers some commentary on the relationship, or the lack thereof, between computational and paper-and-pencil linguistics. The final section returns to the semantic issues and their application to currently popular tasks such as textual inference and question answering.",
+      "URL": "https://doi.org/10.1162/coli.2007.33.4.443",
+      "DOI": "10.1162/coli.2007.33.4.443",
+      "journalAbbreviation": "Comput. Linguist.",
+      "author": [
+        {
+          "family": "Karttunen",
+          "given": "Lauri"
+        }
+      ],
+      "issued": {
+        "date-parts": [
+          [
+            "2007",
+            12,
+            1
+          ]
+        ]
+      },
+      "accessed": {
+        "date-parts": [
+          [
+            2021,
+            4,
+            15
+          ]
+        ]
+      }
+    }
+  ],
+  "2010": [
+    {
+      "id": "9296070/IKAJUF8S",
+      "type": "webpage",
+      "title": "Medley",
+      "container-title": "VENUE",
+      "URL": "https://web.archive.org/web/20100304002925/http://top2bottom.net:80/medley.html",
+      "author": [
+        {
+          "family": "Jill Marci Sybalsky",
+          "given": ""
+        }
+      ],
+      "issued": {
+        "date-parts": [
+          [
+            "2010",
+            3,
+            4
+          ]
+        ]
+      },
+      "accessed": {
+        "date-parts": [
+          [
+            2021,
+            4,
+            21
+          ]
+        ]
+      }
+    }
+  ],
+  "2015": [
+    {
+      "id": "9296070/23ZCTJ9Z",
+      "type": "article-journal",
+      "title": "TENEX and TOPS-20",
+      "container-title": "Annals of the History of Computing, IEEE",
+      "page": "75-82",
+      "volume": "37",
+      "abstract": "In the late 1960s, a small group of developers at Bolt, Beranek, and Newman (BBN) in Cambridge, Massachusetts, began work on a new computer operating system, including a kernel, system call API, and user command interface (shell). While such an undertaking, particularly with a small group, became rare in subsequent decades, it was not uncommon in the 1960s. During development, this OS was given the name TENEX. A few years later, TENEX was adopted by Digital Equipment Corporation (DEC) for its new line of large machines to be known as the DECSYSTEM-20, and the operating system was renamed to TOPS-20. The author followed TENEX (or vice versa) on this journey, and these are some reflections and observations from that journey. He touches on some of the technical aspects that made TENEX notable in its day and an influence on operating systems that followed as well as on some of the people and other facets involved in the various steps along the way.",
+      "URL": "https://www.researchgate.net/publication/273523084_TENEX_and_TOPS-20",
+      "DOI": "10.1109/MAHC.2015.15",
+      "note": "Publisher: IEEE",
+      "journalAbbreviation": "Annals of the History of Computing",
+      "author": [
+        {
+          "family": "Murphy",
+          "given": "Dan"
+        }
+      ],
+      "issued": {
+        "date-parts": [
+          [
+            "2015",
+            1,
+            1
+          ]
+        ]
+      }
+    },
+    {
+      "id": "9296070/THLV47EY",
+      "type": "report",
+      "title": "Emulation & Virtualization as Preservation Strategies",
+      "publisher": "The Andrew W. Mellon Foundation",
+      "author": [
+        {
+          "family": "Rosenthal",
+          "given": "David S.H."
+        }
+      ],
+      "issued": {
+        "date-parts": [
+          [
+            "2015",
+            10
+          ]
+        ]
+      },
+      "accessed": {
+        "date-parts": [
+          [
+            2016,
+            1,
+            23
+          ]
+        ]
+      }
+    }
+  ],
+  "2019": [
+    {
+      "id": "9296070/IRKEPIAR",
+      "type": "post-weblog",
+      "title": "Introducing Darkstar: A Xerox Star Emulator",
+      "container-title": "Adafruit Industries - Makers, hackers, artists, designers and engineers!",
+      "abstract": "Via libingcomputers.org: Josh Dersch writes about research into the Xerox 8010 Information System (codenamed “Dandelion” during development) and commonly referred to as the Star. The Star was envisioned as center point of the office of the future, combining high-resolution graphics with the now-familiar mouse, Ethernet networking for sharing and collaborating, and Xerox’s Laser Printer technology for faithful “WYSIWYG” document reproduction. A revolutionary system when most everyone else was using text based systems.",
+      "URL": "https://blog.adafruit.com/2019/01/23/introducing-darkstar-a-xerox-star-emulator-vintagecomputing-xerox-emulation/",
+      "shortTitle": "Introducing Darkstar",
+      "language": "en-US",
+      "author": [
+        {
+          "family": "Barela",
+          "given": "Anne"
+        }
+      ],
+      "issued": {
+        "date-parts": [
+          [
+            "2019",
+            1,
+            23
+          ]
+        ]
+      },
+      "accessed": {
+        "date-parts": [
+          [
+            2021,
+            4,
+            21
+          ]
+        ]
+      }
+    },
+    {
+      "id": "9296070/ETMY665Q",
+      "type": "paper-conference",
+      "title": "From NoteCards to Notebooks: There and Back Again",
+      "container-title": "Proceedings of the 30th ACM Conference on Hypertext and Social Media",
+      "collection-title": "HT '19",
+      "publisher": "Association for Computing Machinery",
+      "publisher-place": "New York, NY, USA",
+      "page": "19–28",
+      "event-place": "New York, NY, USA",
+      "abstract": "Fifty years since the beginning of the Internet, and three decades of the Dexter Hypertext Reference Model and the World Wide Web mark an opportune time to take stock and consider how hypermedia has developed, and in which direction it might be headed. The modern Web has on one hand turned into a place where very few, very large companies control all major platforms with some highly unfortunately consequences. On the other hand, it has also led to the creation of a highly flexible and nigh ubiquitous set of technologies and practices, which can be used as the basis for future hypermedia research with the rise of computational notebooks as a prime example of a new kind of collaborative and highly malleable applications.",
+      "URL": "https://doi.org/10.1145/3342220.3343666",
+      "DOI": "10.1145/3342220.3343666",
+      "ISBN": "978-1-4503-6885-8",
+      "shortTitle": "From NoteCards to Notebooks",
+      "author": [
+        {
+          "family": "Bouvin",
+          "given": "Niels Olof"
+        }
+      ],
+      "issued": {
+        "date-parts": [
+          [
+            "2019",
+            9,
+            12
+          ]
+        ]
+      },
+      "accessed": {
+        "date-parts": [
+          [
+            2021,
+            4,
+            15
+          ]
+        ]
+      }
+    },
+    {
+      "id": "9296070/ETMY665Q",
+      "type": "paper-conference",
+      "title": "From NoteCards to Notebooks: There and Back Again",
+      "container-title": "Proceedings of the 30th ACM Conference on Hypertext and Social Media",
+      "collection-title": "HT '19",
+      "publisher": "Association for Computing Machinery",
+      "publisher-place": "New York, NY, USA",
+      "page": "19–28",
+      "event-place": "New York, NY, USA",
+      "abstract": "Fifty years since the beginning of the Internet, and three decades of the Dexter Hypertext Reference Model and the World Wide Web mark an opportune time to take stock and consider how hypermedia has developed, and in which direction it might be headed. The modern Web has on one hand turned into a place where very few, very large companies control all major platforms with some highly unfortunately consequences. On the other hand, it has also led to the creation of a highly flexible and nigh ubiquitous set of technologies and practices, which can be used as the basis for future hypermedia research with the rise of computational notebooks as a prime example of a new kind of collaborative and highly malleable applications.",
+      "URL": "https://doi.org/10.1145/3342220.3343666",
+      "DOI": "10.1145/3342220.3343666",
+      "ISBN": "978-1-4503-6885-8",
+      "shortTitle": "From NoteCards to Notebooks",
+      "author": [
+        {
+          "family": "Bouvin",
+          "given": "Niels Olof"
+        }
+      ],
+      "issued": {
+        "date-parts": [
+          [
+            "2019",
+            9,
+            12
+          ]
+        ]
+      },
+      "accessed": {
+        "date-parts": [
+          [
+            2021,
+            4,
+            15
+          ]
+        ]
+      }
+    }
+  ]
+}

--- a/layouts/shortcodes/bibTable.html
+++ b/layouts/shortcodes/bibTable.html
@@ -1,5 +1,5 @@
 
-<table>
+<table style="max-width: 100%">
     <thead>
         <tr>
           <th>Author</th>
@@ -8,18 +8,31 @@
         </tr>
       </thead>
       <tbody>
-{{ $bibliographies := getJSON "data/bibliography.json" }}
-        {{ range $bibliographies }}
+        {{ $years_items := getJSON "data/bibliography.json" }}
+        {{ range $year, $items := $years_items }}
           <tr>
-            <td>
-              {{ range .author }}
-                {{ .family }}, {{ .given }} <br>
-              {{ end }}
-
-            </td>
-            <td><a href="{{ .URL }}">{{ .title }}</a></td>
-            <td>{{ .note }}</td>
+            <th colspan="3">
+              {{ $year }}
+            </th>
           </tr>
+          {{ range $items }}
+            <tr>
+              <td>
+                {{ range .author }}
+                  {{ if .literal }}
+                    {{ .literal }}
+                  {{ else if and .family .given }}
+                    {{ .family }}, {{ .given }}
+                  {{ else }}
+                    {{ .family }}{{ .given }}
+                  {{ end }}<br>
+                {{ end }}
+
+              </td>
+              <td>{{ if .URL }}<a href="{{ .URL }}">{{ .title }}</a>{{ else }}{{ .title }}{{ end }}</td>
+              <td>{{ .note }}</td>
+            </tr>
+          {{ end }}
         {{ end }}
       </tbody>
   

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 
-  "name": "hugo",
+  "name": "Interlisp.github.io",
 
   "lockfileVersion": 2,
 

--- a/scripts/update_bibliography.sh
+++ b/scripts/update_bibliography.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+set -e
+
+GROUP_ID=2914042
+
+items=""
+
+function add_items_from_collection () {
+    local collection_key="$1"
+    echo "Getting collection $collection_key"
+    local start=0
+    local limit=100
+    while :; do
+        local this_page=$(curl -s "https://api.zotero.org/groups/$GROUP_ID/collections/$collection_key/items/top?include=data,csljson&start=$start&limit=$limit&v=3")
+        items=$(jq -s 'add' <<< "$this_page$items")
+        start=$(($start + $limit))
+
+        # Break when we don't get any more items
+        [[ $(jq '. | length' <<< "$this_page") > 0 ]] || break
+    done
+
+    # Recurse into subcollections
+    while read subcollection_key; do
+        add_items_from_collection $subcollection_key
+    done < <(curl -s "https://api.zotero.org/groups/$GROUP_ID/collections/$collection_key/collections" | jq -r '.[].key')
+}
+
+root_collection="FSK5IX4F"
+add_items_from_collection $root_collection
+
+echo "Got $(jq '. | length' <<< "$items") items"
+
+items=$(jq '
+    sort_by(.data.date)
+    | map(.csljson)
+    | group_by(.issued."date-parts"[0][0])
+    | map({ (.[0].issued."date-parts"[0][0] // "Undated" | tostring): . })
+    | add' <<< "$items")
+
+echo "Outputting CSL JSON"
+echo "$items" > "$(dirname "$0")/../data/bibliography.json"


### PR DESCRIPTION
- Only link titles if we have a URL to link to
- Display institutional/single-field names ("Xerox PARC") correctly

Writing the generator script in Bash was probably not the best choice, but it works fine. It requires `jq`, available through your package manager of choice.