### PR TITLE
In Memoriam: links to Wikipedia entries and obituaries

### DIFF
--- a/content/en/credits/in-memoriam.md
+++ b/content/en/credits/in-memoriam.md
@@ -4,10 +4,14 @@ weight: 10
 type: docs
 ---
 
-#### Warren Teitelman
+#### [Warren Teitelman](https://en.wikipedia.org/wiki/Warren_Teitelman)
 
-#### Danny Bobrow
+[Obituary](http://warrenteitelman.com)
 
-#### John Sybalsky 
+#### [Danny Bobrow](https://en.wikipedia.org/wiki/Daniel_G._Bobrow)
 
-#### Steve Purcell
+[Obituary](https://www.paloaltoonline.com/obituaries/memorials/daniel-danny-g-bobrow-phd?o=4957)
+
+#### [John Sybalsky](http://www.sybalsky.net)
+
+#### [Steve Purcell](https://www.paloaltoonline.com/obituaries/memorials/steve-purcell?o=5822)


### PR DESCRIPTION
As suggested in issue #67 I added links to the obituaries of the people listed on page [In Memoriam](https://interlisp.org/credits/in-memoriam), and to their Wikipedia bios when available.