### PR TITLE
Fix warning about duplicate menu entry

### DIFF
--- a/content/en/publications/_index.md
+++ b/content/en/publications/_index.md
@@ -4,10 +4,6 @@ url: /publications
 weight: 70
 aliases:
 no_list: true
-menu:
-  main:
-    weight: 10
-    pre: "<i class='fas fa-download'></i>"
 type: docs
 ---
 We are using [Zotero](https://www.zotero.org/) to create a detailed bibliography of works documenting Lisp, Interlisp and the results of projects and related activities.


### PR DESCRIPTION
This PR fixes the warning given when running the site preview via `hugo server`:

```
WARN 2023/04/15 21:02:54 "/home/user/Interlisp.github.io/content/en/publications/_index.md:1:1": duplicate menu entry with identifier "Publications" in menu "main"
```