### PR TITLE
Move credits to about, leave in-memoriam as part of history.

### DIFF
--- a/content/en/medley/about/credits.md
+++ b/content/en/medley/about/credits.md
@@ -30,4 +30,4 @@ with recent additions from
 * Eric Kaltman
 * Morgan McMurray
 
-For information about past contributors who are no longer with us, go to [In Memoriam](in-memoriam).
+For information about past contributors who are no longer with us, go to [In Memoriam](/medley/history/in-memoriam).

--- a/content/en/medley/history/in-memoriam.md
+++ b/content/en/medley/history/in-memoriam.md
@@ -1,6 +1,6 @@
 ---
 title: In Memoriam
-weight: 10
+weight: 100
 type: docs
 ---
 The following individuals were a part of the Interlisp Medley project during their lives. We appreciate them and the contributions they made to Interlisp.


### PR DESCRIPTION
Addresses [Who is involved](https://github.com/Interlisp/medley/issues/1092)

Moves credits to the about section and leaves the in-memoriam section within history.  In may be appropriate as a future task to further embellish the information on the individuals there.  