### PR TITLE
Switch to Custom Google Search to search both the website and github.

### DIFF
--- a/content/en/search.md
+++ b/content/en/search.md
@@ -1,0 +1,4 @@
++++
+title = "Search Results"
+layout = "search"
++++

--- a/hugo.toml
+++ b/hugo.toml
@@ -177,13 +177,13 @@ github_project_repo = "https://github.com/interlisp/medley"
 github_branch= "main"
 
 # Google Custom Search Engine ID. Remove or comment out to disable search.
-# gcs_engine_id = "d72aa9b2712488cc3"
+gcs_engine_id = "33ef4cbe0703b4f3a"
 
 # Enable Algolia DocSearch
-algolia_docsearch = false
+#algolia_docsearch = false
 
 # Enable Lunr.js offline search
-offlineSearch = true
+# offlineSearch = true
 
 # Enable syntax highlighting and copy buttons on code blocks with Prism
 # Default "Chroma" syntax highlighter has no dot support, so use Prism instead


### PR DESCRIPTION
Merge once we get the Custom Search registered as being a non-profit with Google.  That will allow us to do searches without adds in the returned results.