### PR TITLE
Included the Abstract information in the Bibliography, using an "expa…

### DIFF
--- a/data/bibliography.json
+++ b/data/bibliography.json
@@ -35,7 +35,45 @@
             25
           ]
         ]
-      }
+      },
+      "key": "EIATQTVR",
+      "version": 1978,
+      "itemType": "journalArticle",
+      "creators": [
+        {
+          "creatorType": "author",
+          "firstName": "James R.",
+          "lastName": "Slagle"
+        }
+      ],
+      "abstractNote": "A large high-speed general-purpose digital computer (IBM 7090) was programmed to solve elementary symbolic integration problems at approximately the level of a good college freshman. The program is called SAINT, an acronym for \"Symbolic Automatic INTegrator.\" This paper discusses the SAINT program and its performance. SAINT performs indefinite integration. It also performs definite and multiple integration when these are trivial extensions of indefinite integration. It uses many of the methods and heuristics of students attacking the same prombles. SAINT took an average of two minutes each to solve 52 of the 54 attempted problems taken from the Massachusetts Institute of Technology freshman calculus final examinations. Based on this and other experiments with SAINT, some conclusions coneering computer solution of such problems are: (1) Pattern recognition is of fundamental importance. (2) Great benefit would have been derived from a large memory and more convenient symbol manipulating facilities. (3) The solution of a symbolic integration problem by a commercially available computer is far cheaper and faster than by man.",
+      "publicationTitle": "Journal of the ACM",
+      "pages": "413-581",
+      "date": "October 1963",
+      "series": "",
+      "seriesTitle": "",
+      "seriesText": "",
+      "ISSN": "0004-5411, 1557-735X",
+      "shortTitle": "",
+      "url": "https://dl.acm.org/doi/10.1145/321186.321193",
+      "accessDate": "2021-04-25T16:29:37Z",
+      "archive": "",
+      "archiveLocation": "",
+      "libraryCatalog": "DOI.org (Crossref)",
+      "callNumber": "",
+      "rights": "",
+      "extra": "",
+      "tags": [
+        {
+          "tag": "sz"
+        }
+      ],
+      "collections": [
+        "HVGVBYYB"
+      ],
+      "relations": {},
+      "dateAdded": "2021-04-25T21:00:55Z",
+      "dateModified": "2021-05-29T19:59:29Z"
     }
   ],
   "1965": [
@@ -63,7 +101,48 @@
             5
           ]
         ]
-      }
+      },
+      "key": "RTRAYUTG",
+      "version": 1994,
+      "itemType": "document",
+      "creators": [
+        {
+          "creatorType": "author",
+          "firstName": "L. Peter",
+          "lastName": "Deutsch"
+        },
+        {
+          "creatorType": "author",
+          "firstName": "Butler W.",
+          "lastName": "Lampson"
+        }
+      ],
+      "abstractNote": "",
+      "publisher": "",
+      "date": "June 5, 1965",
+      "shortTitle": "",
+      "url": "http://bitsavers.org/pdf/sds/9xx/940/ucbProjectGenie/30.50.40_930_LISP_Reference_Feb66.pdf",
+      "accessDate": "",
+      "archive": "",
+      "archiveLocation": "",
+      "libraryCatalog": "",
+      "callNumber": "",
+      "rights": "",
+      "extra": "",
+      "tags": [
+        {
+          "tag": "SDS 930 LISP"
+        },
+        {
+          "tag": "s2z"
+        }
+      ],
+      "collections": [
+        "TVX6WEZX"
+      ],
+      "relations": {},
+      "dateAdded": "2021-05-31T19:26:21Z",
+      "dateModified": "2021-06-01T18:51:06Z"
     }
   ],
   "1966": [
@@ -91,7 +170,54 @@
             1966
           ]
         ]
-      }
+      },
+      "key": "M6869X84",
+      "version": 2255,
+      "itemType": "book",
+      "creators": [
+        {
+          "creatorType": "author",
+          "firstName": "Edmund Callis",
+          "lastName": "Berkeley"
+        },
+        {
+          "creatorType": "author",
+          "firstName": "Daniel Gureasko",
+          "lastName": "Bobrow"
+        }
+      ],
+      "abstractNote": "",
+      "series": "",
+      "seriesNumber": "",
+      "volume": "",
+      "numberOfVolumes": "",
+      "edition": "",
+      "place": "",
+      "date": "1966",
+      "numPages": "",
+      "language": "",
+      "url": "http://www.softwarepreservation.org/projects/LISP/book/III_LispBook_Apr66.pdf",
+      "accessDate": "",
+      "archive": "",
+      "archiveLocation": "",
+      "libraryCatalog": "Google Scholar",
+      "callNumber": "",
+      "rights": "",
+      "extra": "",
+      "tags": [
+        {
+          "tag": "sz"
+        }
+      ],
+      "collections": [
+        "TVX6WEZX",
+        "MV55NAER"
+      ],
+      "relations": {
+        "dc:replaces": "http://zotero.org/groups/2914042/items/J6V82TJX"
+      },
+      "dateAdded": "2021-04-22T04:57:15Z",
+      "dateModified": "2021-08-28T00:04:16Z"
     },
     {
       "id": "9296070/6RAE6DBF",
@@ -131,7 +257,53 @@
             1
           ]
         ]
-      }
+      },
+      "key": "6RAE6DBF",
+      "version": 2165,
+      "itemType": "report",
+      "creators": [
+        {
+          "creatorType": "author",
+          "firstName": "Daniel G.",
+          "lastName": "Bobrow"
+        },
+        {
+          "creatorType": "author",
+          "firstName": "Daniel L.",
+          "lastName": "Murphy"
+        }
+      ],
+      "abstractNote": "In an ideal list-processing system there would be enough core memory to contain all the data and programs. The paper describes a number of techniques used to build a LISP system which utilizes a drum for its principal storage medium, with a surprisingly low time-penalty for use of this slow storage device. The techniques include careful segmentation of system programs, allocation of virtual memory to allow address arithmetic for type determination, and a special algorithm for building reasonably linearized lists. A scheme is described for binding variables which is good in this environment and allows for complete compatibility between compiled and interpreted programs with no special declarations.",
+      "reportNumber": "",
+      "reportType": "",
+      "seriesTitle": "",
+      "place": "Cambridge, MA",
+      "institution": "BOLT BERANEK AND NEWMAN INC",
+      "date": "1966-11-04",
+      "pages": "",
+      "shortTitle": "",
+      "url": "https://apps.dtic.mil/sti/citations/AD0647601",
+      "accessDate": "2021-06-01T14:43:36Z",
+      "archive": "",
+      "archiveLocation": "",
+      "libraryCatalog": "apps.dtic.mil",
+      "callNumber": "",
+      "rights": "",
+      "extra": "Section: Technical Reports",
+      "tags": [
+        {
+          "tag": "BBN-LISP"
+        },
+        {
+          "tag": "s2z"
+        }
+      ],
+      "collections": [
+        "TVX6WEZX"
+      ],
+      "relations": {},
+      "dateAdded": "2021-06-01T14:43:36Z",
+      "dateModified": "2021-07-26T02:35:03Z"
     },
     {
       "id": "9296070/LQQWKMEZ",
@@ -174,7 +346,54 @@
             31
           ]
         ]
-      }
+      },
+      "key": "LQQWKMEZ",
+      "version": 2026,
+      "itemType": "conferencePaper",
+      "creators": [
+        {
+          "creatorType": "author",
+          "firstName": "Daniel G.",
+          "lastName": "Bobrow"
+        },
+        {
+          "creatorType": "author",
+          "firstName": "Warren",
+          "lastName": "Teitelman"
+        }
+      ],
+      "abstractNote": "This article describes a notation and a programming language for expressing, from within a LISP system, string transformations such as those performed in COMIT or SNOBOL. A simple transformation (or transformation rule) is specified by providing a pattern which must match the structure to be transformed and a format which specifies how to construct a new structure according to the segmentation specified by the pattern. The patterns and formats are greatly generalized versions of the left-half and right-half rules of COMIT and SNOBOL. For example, elementary patterns and formats can be variable names, results of computations, disjunctive sets, or repeating subpatterns; predicates can be associated with elementary patterns which check relationships among separated elements of the match; it is no longer necessary to restrict the operations to linear strings since elementary patterns can themselves match structures. The FLIP language has been implemented in LISP 1.5, and has been successfully used in such disparate tasks as editing LISP functions and parsing Kleene regular expressions.",
+      "date": "January 1, 1966",
+      "proceedingsTitle": "Proceedings of the first ACM symposium on Symbolic and algebraic manipulation",
+      "conferenceName": "",
+      "place": "New York, NY, USA",
+      "volume": "",
+      "pages": "0301–0329",
+      "series": "SYMSAC '66",
+      "language": "",
+      "shortTitle": "",
+      "url": "https://doi.org/10.1145/800005.807968",
+      "accessDate": "2021-05-31",
+      "archive": "",
+      "archiveLocation": "",
+      "libraryCatalog": "ACM Digital Library",
+      "callNumber": "",
+      "rights": "",
+      "extra": "",
+      "tags": [
+        {
+          "tag": "BBN-LISP"
+        },
+        {
+          "tag": "s2z"
+        }
+      ],
+      "collections": [
+        "MTUXENI8"
+      ],
+      "relations": {},
+      "dateAdded": "2021-05-31T20:22:30Z",
+      "dateModified": "2021-05-31T20:23:33Z"
     },
     {
       "id": "9296070/6M8ISEUL",
@@ -200,10 +419,124 @@
             13
           ]
         ]
-      }
+      },
+      "key": "6M8ISEUL",
+      "version": 2042,
+      "itemType": "document",
+      "creators": [
+        {
+          "creatorType": "author",
+          "name": "Daniel G. Bobrow"
+        },
+        {
+          "creatorType": "author",
+          "name": "Daniel L. Murphy"
+        }
+      ],
+      "abstractNote": "",
+      "publisher": "",
+      "date": "October 13, 1966",
+      "shortTitle": "",
+      "url": "http://www.softwarepreservation.org/projects/LISP/bbnlisp/BBN940LispPrelimSpec_Oct1966.pdf",
+      "accessDate": "",
+      "archive": "",
+      "archiveLocation": "",
+      "libraryCatalog": "",
+      "callNumber": "",
+      "rights": "",
+      "extra": "",
+      "tags": [
+        {
+          "tag": "BBN-LISP"
+        },
+        {
+          "tag": "s2z"
+        }
+      ],
+      "collections": [
+        "TVX6WEZX"
+      ],
+      "relations": {},
+      "dateAdded": "2021-05-31T20:26:36Z",
+      "dateModified": "2021-05-31T20:28:41Z"
     }
   ],
   "1967": [
+    {
+      "id": "9296070/6KKLXERD",
+      "type": "report",
+      "title": "DESIGN AND IMPLEMENTATION OF FLIP, A LISP FORMAT DIRECTED LIST PROCESSOR",
+      "publisher": "BOLT BERANEK AND NEWMAN INC CAMBRIDGE MA",
+      "abstract": "The paper discusses some of the considerations involved in designing and implementing a pattern matching or COMIT feature inside of LISP. The programming language FLIP is presented here as a paradigm for such a feature. The design and implementation of FLIP discussed below emphasizes compact notation and efficiency of operation. In addition, FLIP is a modular language and can be readily extended and generalized to include features found in other pattern driven languages such as CONVERT and SNOBOL. This makes it extremely versatile. The development of this paper proceeds from abstract considerations to specific details. The syntax and semantics of FLIP are presented first, followed by a discussion of the implementation with especial attention devoted to techniques used for reducing the number of conses required as well as improving search strategy. Finally FLIP is treated as a working system and viewed from the users standpoint. Here we present some of the additions and extensions to FLIP that have evolved out of almost two years of experimentation. These transform it from a notational system into a practical and useful programming system.",
+      "URL": "https://apps.dtic.mil/sti/citations/AD0660548",
+      "note": "Section: Technical Reports",
+      "language": "en",
+      "author": [
+        {
+          "family": "Teitelman",
+          "given": "Warren"
+        }
+      ],
+      "issued": {
+        "date-parts": [
+          [
+            1967,
+            7,
+            15
+          ]
+        ]
+      },
+      "accessed": {
+        "date-parts": [
+          [
+            2021,
+            6,
+            1
+          ]
+        ]
+      },
+      "key": "6KKLXERD",
+      "version": 2024,
+      "itemType": "report",
+      "creators": [
+        {
+          "creatorType": "author",
+          "firstName": "Warren",
+          "lastName": "Teitelman"
+        }
+      ],
+      "abstractNote": "The paper discusses some of the considerations involved in designing and implementing a pattern matching or COMIT feature inside of LISP. The programming language FLIP is presented here as a paradigm for such a feature. The design and implementation of FLIP discussed below emphasizes compact notation and efficiency of operation. In addition, FLIP is a modular language and can be readily extended and generalized to include features found in other pattern driven languages such as CONVERT and SNOBOL. This makes it extremely versatile. The development of this paper proceeds from abstract considerations to specific details. The syntax and semantics of FLIP are presented first, followed by a discussion of the implementation with especial attention devoted to techniques used for reducing the number of conses required as well as improving search strategy. Finally FLIP is treated as a working system and viewed from the users standpoint. Here we present some of the additions and extensions to FLIP that have evolved out of almost two years of experimentation. These transform it from a notational system into a practical and useful programming system.",
+      "reportNumber": "",
+      "reportType": "",
+      "seriesTitle": "",
+      "place": "",
+      "institution": "BOLT BERANEK AND NEWMAN INC CAMBRIDGE MA",
+      "date": "1967-07-15",
+      "pages": "",
+      "shortTitle": "",
+      "url": "https://apps.dtic.mil/sti/citations/AD0660548",
+      "accessDate": "2021-06-01T14:06:01Z",
+      "archive": "",
+      "archiveLocation": "",
+      "libraryCatalog": "apps.dtic.mil",
+      "callNumber": "",
+      "rights": "",
+      "extra": "Section: Technical Reports",
+      "tags": [
+        {
+          "tag": "BBN-LISP"
+        },
+        {
+          "tag": "s2z"
+        }
+      ],
+      "collections": [
+        "TVX6WEZX"
+      ],
+      "relations": {},
+      "dateAdded": "2021-06-01T14:06:01Z",
+      "dateModified": "2021-06-01T14:33:48Z"
+    },
     {
       "id": "9296070/XSVG2PVI",
       "type": "report",
@@ -252,41 +585,68 @@
             1
           ]
         ]
-      }
-    },
-    {
-      "id": "9296070/6KKLXERD",
-      "type": "report",
-      "title": "DESIGN AND IMPLEMENTATION OF FLIP, A LISP FORMAT DIRECTED LIST PROCESSOR",
-      "publisher": "BOLT BERANEK AND NEWMAN INC CAMBRIDGE MA",
-      "abstract": "The paper discusses some of the considerations involved in designing and implementing a pattern matching or COMIT feature inside of LISP. The programming language FLIP is presented here as a paradigm for such a feature. The design and implementation of FLIP discussed below emphasizes compact notation and efficiency of operation. In addition, FLIP is a modular language and can be readily extended and generalized to include features found in other pattern driven languages such as CONVERT and SNOBOL. This makes it extremely versatile. The development of this paper proceeds from abstract considerations to specific details. The syntax and semantics of FLIP are presented first, followed by a discussion of the implementation with especial attention devoted to techniques used for reducing the number of conses required as well as improving search strategy. Finally FLIP is treated as a working system and viewed from the users standpoint. Here we present some of the additions and extensions to FLIP that have evolved out of almost two years of experimentation. These transform it from a notational system into a practical and useful programming system.",
-      "URL": "https://apps.dtic.mil/sti/citations/AD0660548",
-      "note": "Section: Technical Reports",
-      "language": "en",
-      "author": [
+      },
+      "key": "XSVG2PVI",
+      "version": 2044,
+      "itemType": "report",
+      "creators": [
         {
-          "family": "Teitelman",
-          "given": "Warren"
+          "creatorType": "author",
+          "firstName": "Daniel G.",
+          "lastName": "Bobrow"
+        },
+        {
+          "creatorType": "author",
+          "firstName": "D. Lucille",
+          "lastName": "Darley"
+        },
+        {
+          "creatorType": "author",
+          "firstName": "L. Peter",
+          "lastName": "Deutsch"
+        },
+        {
+          "creatorType": "author",
+          "firstName": "Daniel L.",
+          "lastName": "Murphy"
+        },
+        {
+          "creatorType": "author",
+          "firstName": "Warren",
+          "lastName": "Teitelman"
         }
       ],
-      "issued": {
-        "date-parts": [
-          [
-            1967,
-            7,
-            15
-          ]
-        ]
-      },
-      "accessed": {
-        "date-parts": [
-          [
-            2021,
-            6,
-            1
-          ]
-        ]
-      }
+      "abstractNote": "The report describes the LISP system implemented at BBN on the SDS 940 Computer. This LISP is an upward compatible extension of LISP 1.5 for the IBM 7090, with a number of new features which make it work well as an on-line language. These new features include tracing, and conditional breakpoints in functions for debugging and a sophisticated LISP oriented editor. The BBN 940 LISP SYSTEM has a large memory store approximately 50,000 free words utilizing special paging techniques for a drum to provide reasonable computation times. The system includes both an interpreter, a fully compatible compiler, and an assembly language facility for inserting machine code subroutines.",
+      "reportNumber": "",
+      "reportType": "",
+      "seriesTitle": "",
+      "place": "",
+      "institution": "BOLT BERANEK AND NEWMAN INC CAMBRIDGE MA",
+      "date": "1967-07-15",
+      "pages": "",
+      "shortTitle": "",
+      "url": "https://apps.dtic.mil/sti/citations/AD0656771",
+      "accessDate": "2021-06-01T14:02:18Z",
+      "archive": "",
+      "archiveLocation": "",
+      "libraryCatalog": "apps.dtic.mil",
+      "callNumber": "",
+      "rights": "",
+      "extra": "Section: Technical Reports",
+      "tags": [
+        {
+          "tag": "BBN-LISP"
+        },
+        {
+          "tag": "s2z"
+        }
+      ],
+      "collections": [
+        "TVX6WEZX"
+      ],
+      "relations": {},
+      "dateAdded": "2021-06-01T14:02:18Z",
+      "dateModified": "2021-06-01T14:34:05Z"
     },
     {
       "id": "9296070/G796KZSG",
@@ -326,7 +686,53 @@
             16
           ]
         ]
-      }
+      },
+      "key": "G796KZSG",
+      "version": 1437,
+      "itemType": "journalArticle",
+      "creators": [
+        {
+          "creatorType": "author",
+          "firstName": "Daniel G.",
+          "lastName": "Bobrow"
+        },
+        {
+          "creatorType": "author",
+          "firstName": "Daniel L.",
+          "lastName": "Murphy"
+        }
+      ],
+      "abstractNote": "In an ideal list-processing system there would be enough core memory to contain all the data and programs. Described in this paper are a number of techniques that have been used to build a LISP system utilizing a drum for its principal storage medium, with a surprisingly low time penalty for use of this slow storage device. The techniques include careful segmentation of system programs, allocation of virtual memory to allow address arithmetic for type determination, and a special algorithm for building reasonably linearized lists. A scheme for binding variables is described which is good in this environment and allows for complete compatibility between compiled and interpreted programs with no special declarations.",
+      "publicationTitle": "Communications of the ACM",
+      "pages": "155-159",
+      "date": "03/1967",
+      "series": "",
+      "seriesTitle": "",
+      "seriesText": "",
+      "ISSN": "0001-0782, 1557-7317",
+      "shortTitle": "",
+      "url": "https://dl.acm.org/doi/10.1145/363162.363185",
+      "accessDate": "2021-04-16T02:11:24Z",
+      "archive": "",
+      "archiveLocation": "",
+      "libraryCatalog": "DOI.org (Crossref)",
+      "callNumber": "",
+      "rights": "",
+      "extra": "",
+      "tags": [
+        {
+          "tag": "BBN-LISP"
+        },
+        {
+          "tag": "s2z"
+        }
+      ],
+      "collections": [
+        "TVX6WEZX"
+      ],
+      "relations": {},
+      "dateAdded": "2021-04-16T02:11:24Z",
+      "dateModified": "2021-06-01T14:44:46Z"
     },
     {
       "id": "9296070/PGGC8GAZ",
@@ -356,7 +762,44 @@
             21
           ]
         ]
-      }
+      },
+      "key": "PGGC8GAZ",
+      "version": 2247,
+      "itemType": "document",
+      "creators": [
+        {
+          "creatorType": "author",
+          "firstName": "Warren",
+          "lastName": "Teitelman"
+        }
+      ],
+      "abstractNote": "",
+      "publisher": "",
+      "date": "April 10, 1967",
+      "language": "",
+      "shortTitle": "",
+      "url": "http://bitsavers.org/pdf/sds/9xx/940/ucbProjectGenie/940_LISP_Memo_2_Apr67.pdf",
+      "accessDate": "2021-04-21T15:35:37Z",
+      "archive": "",
+      "archiveLocation": "",
+      "libraryCatalog": "",
+      "callNumber": "",
+      "rights": "",
+      "extra": "",
+      "tags": [
+        {
+          "tag": "BBN-LISP"
+        },
+        {
+          "tag": "s2z"
+        }
+      ],
+      "collections": [
+        "TVX6WEZX"
+      ],
+      "relations": {},
+      "dateAdded": "2021-04-22T03:48:38Z",
+      "dateModified": "2021-08-27T23:41:22Z"
     },
     {
       "id": "9296070/LQAA78HI",
@@ -406,7 +849,63 @@
             23
           ]
         ]
-      }
+      },
+      "key": "LQAA78HI",
+      "version": 1937,
+      "itemType": "report",
+      "creators": [
+        {
+          "creatorType": "author",
+          "name": "Daniel G. Bobrow"
+        },
+        {
+          "creatorType": "author",
+          "name": "D. Lucille Darley"
+        },
+        {
+          "creatorType": "author",
+          "name": "L. Peter Deutsch"
+        },
+        {
+          "creatorType": "author",
+          "name": "Daniel L. Murphy"
+        },
+        {
+          "creatorType": "author",
+          "name": "Warren Teitelman"
+        }
+      ],
+      "abstractNote": "This report describes the LISP system implemented at BBN on the \nSDS 940 Computer. This LISP is an upward compatible extension of \nLISP 1.5 for the IBM 7090, with a number of new features which \nmake it work well as an on-line language. These new features \ninclude tracing, and conditional breakpoints in functions for \ndebugging and a sophisticated LISP oriented editor. The BBN 940 \nLISP SYSTEM has a large memory store (approximately 50,000 free \nwords) utilizing special paging techniques for a drum to provide \nreasonable computation times. The system includes both an \ninterpreter, a fully compatible compiler, and an assembly language \nfacility for inserting machine code subroutines.",
+      "reportNumber": "9",
+      "reportType": "",
+      "seriesTitle": "",
+      "place": "",
+      "institution": "",
+      "date": "July 15, 1967",
+      "pages": "138",
+      "shortTitle": "",
+      "url": "http://www.softwarepreservation.org/projects/LISP/bbnlisp/BBN940Lisp_Jul67.pdf/view",
+      "accessDate": "2021-04-23T15:29:53Z",
+      "archive": "",
+      "archiveLocation": "",
+      "libraryCatalog": "",
+      "callNumber": "",
+      "rights": "",
+      "extra": "",
+      "tags": [
+        {
+          "tag": "BBN-LISP"
+        },
+        {
+          "tag": "s2z"
+        }
+      ],
+      "collections": [
+        "TVX6WEZX"
+      ],
+      "relations": {},
+      "dateAdded": "2021-04-25T18:13:25Z",
+      "dateModified": "2021-06-03T19:53:48Z"
     }
   ],
   "1968": [
@@ -451,7 +950,52 @@
             29
           ]
         ]
-      }
+      },
+      "key": "KZ7FU59I",
+      "version": 2826,
+      "itemType": "conferencePaper",
+      "creators": [
+        {
+          "creatorType": "author",
+          "firstName": "Robert F.",
+          "lastName": "Sproull"
+        },
+        {
+          "creatorType": "author",
+          "firstName": "Ivan E.",
+          "lastName": "Sutherland"
+        }
+      ],
+      "abstractNote": "When compared with a drawing on paper, the pictures presented by today's computer display equipment are sadly lacking in resolution. Most modern display equipment uses 10 bit digital to analog converters, providing for display in a 1024 by 1024 square raster. The actual resolution available is usually somewhat less since adjacent spots or lines will overlap. Even large-screen displays have limited resolution, for although they give a bigger picture, they also draw wider lines so that the amount of material which can appear at one time is still limited. Users of larger paper drawings have become accustomed to having a great deal of material presented at once. The computer display scope alone cannot serve the many tasks which require relatively large drawings with fine details.",
+      "date": "1968",
+      "proceedingsTitle": "Proceedings of the December 9-11, 1968, fall joint computer conference, part I on - AFIPS '68 (Fall, part I)",
+      "conferenceName": "December 9-11, 1968, fall joint computer conference, part I",
+      "place": "San Francisco, California",
+      "pages": "765-775",
+      "series": "",
+      "shortTitle": "",
+      "url": "http://portal.acm.org/citation.cfm?doid=1476589.1476687",
+      "accessDate": "2023-04-29T15:30:13Z",
+      "archive": "",
+      "archiveLocation": "",
+      "libraryCatalog": "DOI.org (Crossref)",
+      "callNumber": "",
+      "rights": "",
+      "extra": "",
+      "tags": [
+        {
+          "tag": "AFIPS Conference Paper"
+        },
+        {
+          "tag": "Reviewed by SHFT - CSUCI (Ron Vincent A.)"
+        }
+      ],
+      "collections": [
+        "3CNYFDHF"
+      ],
+      "relations": {},
+      "dateAdded": "2023-04-29T15:30:13Z",
+      "dateModified": "2023-05-05T13:51:30Z"
     },
     {
       "id": "9296070/DNCVYGJC",
@@ -492,7 +1036,53 @@
             21
           ]
         ]
-      }
+      },
+      "key": "DNCVYGJC",
+      "version": 1439,
+      "itemType": "journalArticle",
+      "creators": [
+        {
+          "creatorType": "author",
+          "firstName": "Daniel G.",
+          "lastName": "Bobrow"
+        },
+        {
+          "creatorType": "author",
+          "firstName": "Daniel L.",
+          "lastName": "Murphy"
+        }
+      ],
+      "abstractNote": "The problem of the use of two levels of storage for programs is explored in the context of a LISP system which uses core memory as a buffer for a large virtual memory stored on a drum. Details of timing are given for one particular problem.",
+      "publicationTitle": "Communications of the ACM",
+      "pages": "558",
+      "date": "August 1968",
+      "series": "",
+      "seriesTitle": "",
+      "seriesText": "",
+      "ISSN": "0001-0782, 1557-7317",
+      "shortTitle": "",
+      "url": "https://dl.acm.org/doi/10.1145/363567.363581",
+      "accessDate": "2021-04-21T14:42:31Z",
+      "archive": "",
+      "archiveLocation": "",
+      "libraryCatalog": "DOI.org (Crossref)",
+      "callNumber": "",
+      "rights": "",
+      "extra": "",
+      "tags": [
+        {
+          "tag": "BBN-LISP"
+        },
+        {
+          "tag": "s2z"
+        }
+      ],
+      "collections": [
+        "TVX6WEZX"
+      ],
+      "relations": {},
+      "dateAdded": "2021-04-25T21:00:11Z",
+      "dateModified": "2021-06-01T14:45:15Z"
     }
   ],
   "1969": [
@@ -529,7 +1119,68 @@
             4
           ]
         ]
-      }
+      },
+      "key": "9SDF3BWD",
+      "version": 2248,
+      "itemType": "book",
+      "creators": [
+        {
+          "creatorType": "editor",
+          "firstName": "Daniel G.",
+          "lastName": "Bobrow"
+        },
+        {
+          "creatorType": "editor",
+          "firstName": "D. L.",
+          "lastName": "Murphy"
+        },
+        {
+          "creatorType": "editor",
+          "firstName": "Warren",
+          "lastName": "Teitelman"
+        }
+      ],
+      "abstractNote": "This document describes the BEN-LISP system currently implemented on the SDS 940. It is a dialect of LISP 1.5 and the differences between IBM 7090 version and this system are described in Appendix\n1 and 2. Principally, this system has been expanded from the LISP 1.5 on the 7090 in a number of different ways. BBN-LISP is\ndesigned to utilize a drum for storage and to provide the user a large virtual memory, with a relatively small penalty in speed (using special paging techniques described in Bobrow and Murphy 1967).",
+      "series": "",
+      "seriesNumber": "",
+      "volume": "",
+      "numberOfVolumes": "",
+      "edition": "",
+      "place": "Cambridge",
+      "date": "April 1969",
+      "numPages": "368",
+      "language": "",
+      "ISBN": "",
+      "url": "http://www.bitsavers.org/pdf/bbn/The_BBN-LISP_System_Apr69.pdf",
+      "accessDate": "",
+      "archive": "",
+      "archiveLocation": "",
+      "libraryCatalog": "Library Catalog (Blacklight)",
+      "callNumber": "Z699.5.L28 B62 1969",
+      "rights": "",
+      "extra": "",
+      "tags": [
+        {
+          "tag": "BBN-LISP"
+        },
+        {
+          "tag": "Information storage and retrieval systems",
+          "type": 1
+        },
+        {
+          "tag": "LISP (Computer program language)",
+          "type": 1
+        },
+        {
+          "tag": "s2z"
+        }
+      ],
+      "collections": [
+        "TVX6WEZX"
+      ],
+      "relations": {},
+      "dateAdded": "2021-06-01T14:29:17Z",
+      "dateModified": "2021-08-27T23:51:44Z"
     },
     {
       "id": "9296070/I2U8XT9Z",
@@ -566,7 +1217,46 @@
             25
           ]
         ]
-      }
+      },
+      "key": "I2U8XT9Z",
+      "version": 1781,
+      "itemType": "journalArticle",
+      "creators": [
+        {
+          "creatorType": "author",
+          "firstName": "D. G.",
+          "lastName": "Bobrow"
+        }
+      ],
+      "abstractNote": "This first (long delayed) LISP Bulletin contains samples of most of those types of items which the editor feels are relevant to this publication. These include announcements of new (i.e. not previously announced here) implementations of LISP (or closely related) systems; quick tricks in LISP; abstracts of LISP related papers; short writeups and listings of useful programs; and longer articles on problems of general interest to the entire LISP community. Printing of these last articles in the Bulletin does not interfere with later publications in formal journals or books. Short write-ups of new features added to LISP are of interest, preferably upward compatible with LISP 1.5, especially if they are illustrated by programming examples.",
+      "publicationTitle": "ACM SIGPLAN Notices",
+      "pages": "17-57",
+      "date": "September 1, 1969",
+      "series": "",
+      "seriesTitle": "",
+      "seriesText": "",
+      "language": "",
+      "ISSN": "0362-1340",
+      "shortTitle": "",
+      "url": "https://doi.org/10.1145/1132291.1132032",
+      "accessDate": "2021-04-25T19:13:30Z",
+      "archive": "",
+      "archiveLocation": "",
+      "libraryCatalog": "September 1969",
+      "callNumber": "",
+      "rights": "",
+      "extra": "",
+      "tags": [
+        {
+          "tag": "sz"
+        }
+      ],
+      "collections": [
+        "TVX6WEZX"
+      ],
+      "relations": {},
+      "dateAdded": "2021-04-25T19:54:39Z",
+      "dateModified": "2021-06-02T19:23:50Z"
     }
   ],
   "1971": [
@@ -610,7 +1300,58 @@
             1
           ]
         ]
-      }
+      },
+      "key": "JCVVQUVD",
+      "version": 2240,
+      "itemType": "document",
+      "creators": [
+        {
+          "creatorType": "author",
+          "firstName": "W.",
+          "lastName": "Teitelman"
+        },
+        {
+          "creatorType": "author",
+          "firstName": "D. G.",
+          "lastName": "Bobrow"
+        },
+        {
+          "creatorType": "author",
+          "firstName": "A. K.",
+          "lastName": "Hartley"
+        },
+        {
+          "creatorType": "author",
+          "firstName": "D. L.",
+          "lastName": "Murphy"
+        }
+      ],
+      "abstractNote": "",
+      "date": "July 1971",
+      "language": "",
+      "shortTitle": "",
+      "url": "http://www.softwarepreservation.org/projects/LISP/bbnlisp/TenexLispRef_Jul71.pdf",
+      "accessDate": "2021-06-01T14:08:20Z",
+      "archive": "",
+      "archiveLocation": "",
+      "libraryCatalog": "",
+      "callNumber": "",
+      "rights": "",
+      "extra": "",
+      "tags": [
+        {
+          "tag": "BBN-LISP"
+        },
+        {
+          "tag": "s2z"
+        }
+      ],
+      "collections": [
+        "TVX6WEZX"
+      ],
+      "relations": {},
+      "dateAdded": "2021-06-01T14:08:20Z",
+      "dateModified": "2021-08-27T22:43:31Z"
     }
   ],
   "1972": [
@@ -628,7 +1369,37 @@
             1972
           ]
         ]
-      }
+      },
+      "key": "5MWT6G4D",
+      "version": 2512,
+      "itemType": "book",
+      "creators": [],
+      "abstractNote": "",
+      "series": "",
+      "seriesNumber": "",
+      "volume": "",
+      "numberOfVolumes": "",
+      "edition": "",
+      "place": "",
+      "date": "1972",
+      "numPages": "",
+      "language": "",
+      "ISBN": "",
+      "shortTitle": "",
+      "url": "",
+      "accessDate": "",
+      "archiveLocation": "X6058.2011",
+      "libraryCatalog": "Computer History Museum Archive",
+      "callNumber": "",
+      "rights": "",
+      "extra": "Catalog Number: 102721861\nCategory: Program Listing\nCollection Title: Gift of Larry Masinter\nCredit: Gift of Larry Masinter",
+      "tags": [],
+      "collections": [
+        "TVX6WEZX"
+      ],
+      "relations": {},
+      "dateAdded": "2022-10-08T18:17:04Z",
+      "dateModified": "2022-10-08T18:17:04Z"
     },
     {
       "id": "9296070/KP33M4DP",
@@ -670,7 +1441,58 @@
             1
           ]
         ]
-      }
+      },
+      "key": "KP33M4DP",
+      "version": 2003,
+      "itemType": "document",
+      "creators": [
+        {
+          "creatorType": "author",
+          "firstName": "W.",
+          "lastName": "Teitelman"
+        },
+        {
+          "creatorType": "author",
+          "firstName": "D. G.",
+          "lastName": "Bobrow"
+        },
+        {
+          "creatorType": "author",
+          "firstName": "A. K.",
+          "lastName": "Hartley"
+        },
+        {
+          "creatorType": "author",
+          "firstName": "D. L.",
+          "lastName": "Murphy"
+        }
+      ],
+      "abstractNote": "",
+      "date": "August 1972",
+      "language": "",
+      "shortTitle": "",
+      "url": "http://www.bitsavers.org/pdf/bbn/tenex/TenexLispRef_Aug72.pdf",
+      "accessDate": "2021-06-01T14:08:20Z",
+      "archive": "",
+      "archiveLocation": "",
+      "libraryCatalog": "",
+      "callNumber": "",
+      "rights": "",
+      "extra": "",
+      "tags": [
+        {
+          "tag": "BBN-LISP"
+        },
+        {
+          "tag": "s2z"
+        }
+      ],
+      "collections": [
+        "TVX6WEZX"
+      ],
+      "relations": {},
+      "dateAdded": "2021-06-01T14:37:38Z",
+      "dateModified": "2021-06-01T14:41:06Z"
     },
     {
       "id": "9296070/QWKIX8DW",
@@ -710,7 +1532,48 @@
             31
           ]
         ]
-      }
+      },
+      "key": "QWKIX8DW",
+      "version": 1984,
+      "itemType": "conferencePaper",
+      "creators": [
+        {
+          "creatorType": "author",
+          "firstName": "Warren",
+          "lastName": "Teitelman"
+        }
+      ],
+      "abstractNote": "This paper describes a research effort and programming system designed to facilitate the production of programs. Unlike automated programming, which focuses on developing systems that write programs, automated programmering involves developing systems which automate (or at least greatly facilitate) those tasks that a programmer performs other than writing programs: e.g., repairing syntactical errors to get programs to run in the first place, generating test cases, making tentative changes, retesting, undoing changes, reconfiguring, massive edits, et al., plus repairing and recovering from mistakes made during the above. When the system in which the programmer is operating is cooperative and helpful with respect to these activities, the programmer can devote more time and energy to the task of programming itself, i.e., to conceptualizing, designing and implementing. Consequently, he can be more ambitious, and more productive.",
+      "date": "December 5, 1972",
+      "proceedingsTitle": "Proceedings of the December 5-7, 1972, fall joint computer conference, part II",
+      "conferenceName": "",
+      "place": "New York, NY, USA",
+      "volume": "",
+      "pages": "917–921",
+      "series": "AFIPS '72 (Fall, part II)",
+      "language": "",
+      "url": "https://doi.org/10.1145/1480083.1480119",
+      "accessDate": "2021-05-31",
+      "archive": "",
+      "archiveLocation": "",
+      "libraryCatalog": "ACM Digital Library",
+      "callNumber": "",
+      "rights": "",
+      "extra": "",
+      "tags": [
+        {
+          "tag": "interlisp"
+        },
+        {
+          "tag": "s2z"
+        }
+      ],
+      "collections": [
+        "TVX6WEZX"
+      ],
+      "relations": {},
+      "dateAdded": "2021-05-31T17:47:02Z",
+      "dateModified": "2021-05-31T18:41:43Z"
     }
   ],
   "1973": [
@@ -751,7 +1614,50 @@
             29
           ]
         ]
-      }
+      },
+      "key": "NPV6XFQB",
+      "version": 2019,
+      "itemType": "report",
+      "creators": [
+        {
+          "creatorType": "author",
+          "firstName": "Rene",
+          "lastName": "Reboh"
+        },
+        {
+          "creatorType": "author",
+          "firstName": "Earl",
+          "lastName": "Sacerdoti"
+        }
+      ],
+      "abstractNote": "A preliminary version of QL1SP is described. QLISP permits free intermingling of QA4-like constructs with INTERLISP code. The preliminary version contains features similar to those of QA4 except for the backtracking of control environments. It provides several new features as well. This preliminary manual presumes a familiarity with both INTERL1SPand the basic concepts of QA4. It is intended to update rather than replace the existing documentation of QA4.",
+      "reportNumber": "",
+      "reportType": "",
+      "seriesTitle": "",
+      "place": "",
+      "institution": "Stanford Research Institute Menlo Park United States",
+      "date": "1973-08-01",
+      "pages": "38",
+      "shortTitle": "",
+      "url": "https://apps.dtic.mil/sti/citations/AD1015722",
+      "accessDate": "2021-05-29T20:23:42Z",
+      "archive": "",
+      "archiveLocation": "",
+      "libraryCatalog": "apps.dtic.mil",
+      "callNumber": "",
+      "rights": "",
+      "extra": "Section: Technical Reports",
+      "tags": [
+        {
+          "tag": "sz"
+        }
+      ],
+      "collections": [
+        "MTUXENI8"
+      ],
+      "relations": {},
+      "dateAdded": "2021-05-29T20:23:42Z",
+      "dateModified": "2021-05-29T20:24:35Z"
     },
     {
       "id": "9296070/EM6WJF9A",
@@ -791,7 +1697,53 @@
             16
           ]
         ]
-      }
+      },
+      "key": "EM6WJF9A",
+      "version": 1346,
+      "itemType": "journalArticle",
+      "creators": [
+        {
+          "creatorType": "author",
+          "firstName": "Daniel G.",
+          "lastName": "Bobrow"
+        },
+        {
+          "creatorType": "author",
+          "firstName": "Ben",
+          "lastName": "Wegbreit"
+        }
+      ],
+      "abstractNote": "Many control and access environment structures require that storage for a procedure activation exist at times when control is not nested within the procedure activated. This is straightforward to implement by dynamic storage allocation with linked blocks for each activation, but rather expensive in both time and space. This paper presents an implementation technique using a single stack to hold procedure activation storage which allows retention of that storage for durations not necessarily tied to control flow. The technique has the property that, in the simple case, it runs identically to the usual automatic stack allocation and deallocation procedure. Applications of this technique to multitasking, coroutines, backtracking, label-valued variables, and functional arguments are discussed. In the initial model, a single real processor is assumed, and the implementation assumes multiple-processes coordinate by passing control explicitly to one another. A multiprocessor implementation requires only a few changes to the basic technique, as described.",
+      "publicationTitle": "Communications of the ACM",
+      "pages": "591-603",
+      "date": "10/1973",
+      "series": "",
+      "seriesTitle": "",
+      "seriesText": "",
+      "ISSN": "0001-0782, 1557-7317",
+      "shortTitle": "",
+      "url": "https://dl.acm.org/doi/10.1145/362375.362379",
+      "accessDate": "2021-04-16T02:11:24Z",
+      "archive": "",
+      "archiveLocation": "",
+      "libraryCatalog": "DOI.org (Crossref)",
+      "callNumber": "",
+      "rights": "",
+      "extra": "",
+      "tags": [
+        {
+          "tag": "interlisp"
+        },
+        {
+          "tag": "s2z"
+        }
+      ],
+      "collections": [
+        "TVX6WEZX"
+      ],
+      "relations": {},
+      "dateAdded": "2021-04-16T02:11:24Z",
+      "dateModified": "2021-05-31T18:41:07Z"
     },
     {
       "id": "9296070/NQXP9QH8",
@@ -828,7 +1780,51 @@
             31
           ]
         ]
-      }
+      },
+      "key": "NQXP9QH8",
+      "version": 1964,
+      "itemType": "conferencePaper",
+      "creators": [
+        {
+          "creatorType": "author",
+          "firstName": "L. Peter",
+          "lastName": "Deutsch"
+        }
+      ],
+      "abstractNote": "This paper presents a machine designed for compact representation and rapid execution of LISP programs. The machine language is a factor of 2 to 5 more compact than S-expressions or conventional compiled code, and the compiler is extremely simple. The encoding scheme is potentially applicable to data as well as program. The machine also provides for user-defined data structures.",
+      "date": "August 20, 1973",
+      "proceedingsTitle": "Proceedings of the 3rd international joint conference on Artificial intelligence",
+      "conferenceName": "",
+      "place": "San Francisco, CA, USA",
+      "volume": "",
+      "pages": "697–703",
+      "series": "IJCAI'73",
+      "language": "",
+      "DOI": "",
+      "ISBN": "",
+      "shortTitle": "",
+      "url": "https://dl.acm.org/doi/abs/10.5555/1624775.1624860",
+      "accessDate": "2021-05-31",
+      "archive": "",
+      "archiveLocation": "",
+      "libraryCatalog": "ACM Digital Library",
+      "callNumber": "",
+      "rights": "",
+      "extra": "",
+      "tags": [
+        {
+          "tag": "Interlisp-D"
+        },
+        {
+          "tag": "s2z"
+        }
+      ],
+      "collections": [
+        "3CNYFDHF"
+      ],
+      "relations": {},
+      "dateAdded": "2021-05-31T15:52:01Z",
+      "dateModified": "2021-05-31T18:28:34Z"
     },
     {
       "id": "9296070/LSJRVJU8",
@@ -864,7 +1860,60 @@
             15
           ]
         ]
-      }
+      },
+      "key": "LSJRVJU8",
+      "version": 1936,
+      "itemType": "journalArticle",
+      "creators": [
+        {
+          "creatorType": "author",
+          "firstName": "Warren",
+          "lastName": "Teitelman"
+        }
+      ],
+      "abstractNote": "INTERLISP (INTERactive LISP) is a LISP system currently implemented on the DEC PDP-10 under the BBN TENEX time sharing system<*R1>. INTERLISP is designed to provide the user access to the large virtual memory allowed by TENEX, with a relatively small penalty in speed (using special paging techniques described in <*R2>). Additional data types have been added, including strings, arrays, and hash association tables (hash links). The system includes a compatible compiler and interpreter. Machine code can be intermixed with INTERLISP expressions via the assemble directive of the compiler. The compiler also contains a facility for \"block compilation\" which allows a group of functions to be compiled as a unit, suppressing internal names. Each successive level of computation, from interpreted through compiled, to block-compiled provides greater speed at a cost of debugging ease.",
+      "publicationTitle": "ACM SIGART Bulletin",
+      "volume": "",
+      "pages": "8-9",
+      "date": "December 1, 1973",
+      "series": "",
+      "seriesTitle": "",
+      "seriesText": "",
+      "language": "",
+      "ISSN": "0163-5719",
+      "shortTitle": "",
+      "url": "https://doi.org/10.1145/1056786.1056787",
+      "accessDate": "2021-04-15T23:17:58Z",
+      "archive": "",
+      "archiveLocation": "",
+      "libraryCatalog": "December 1973",
+      "callNumber": "",
+      "rights": "",
+      "extra": "",
+      "tags": [
+        {
+          "tag": "interlisp"
+        },
+        {
+          "tag": "s2z"
+        }
+      ],
+      "collections": [
+        "TVX6WEZX"
+      ],
+      "relations": {
+        "dc:replaces": [
+          "http://zotero.org/groups/2914042/items/2NB6DSTG",
+          "http://zotero.org/groups/2914042/items/4G8DYBLZ",
+          "http://zotero.org/groups/2914042/items/A62BWT4B",
+          "http://zotero.org/groups/2914042/items/FYH7ZPSM",
+          "http://zotero.org/groups/2914042/items/FSIAMRL5",
+          "http://zotero.org/groups/2914042/items/R5M8NXAU",
+          "http://zotero.org/groups/2914042/items/RRBMED3C"
+        ]
+      },
+      "dateAdded": "2021-04-15T23:18:51Z",
+      "dateModified": "2021-06-03T19:53:25Z"
     },
     {
       "id": "9296070/I5AH4B95",
@@ -887,7 +1936,49 @@
             5
           ]
         ]
-      }
+      },
+      "key": "I5AH4B95",
+      "version": 2017,
+      "itemType": "report",
+      "creators": [
+        {
+          "creatorType": "author",
+          "firstName": "L. Peter",
+          "lastName": "Deutsch"
+        }
+      ],
+      "abstractNote": "Program verification refers to the idea that the intent or effect of a program can be stated in a precise way that is not a simple \"rewording \" of the program itself, and that one can prove (in the mathematical sense) that a program actually conforms to a given statement of intent. This thesis describes a software system which can verify (prove) some non-trivial programs automatically. The system described here is organized in a novel manner compared to most other theorem-proving systems. IL has a great deal of specific knowledge about integers and arrays of integers, yet it is not \"special-purpose\", since this knowledge is represented in procedures which are separate from the underlying structure of the system. It also incorporates some knowledge, gained by the author from both experiment and introspection, about how programs are often constructed, and uses this knowledge to guide the proof process. It uses its knowledge, plus contextual information from the program being verified, to simplify the theorems dramatically as they are being constructed, rather than relying on a super-powerful proof procedure. The system also provides for interactive editing of programs and assertions, and for detailed human control of the proof process when the system cannot produce a proof (or counter-example) on its own.",
+      "reportNumber": "",
+      "reportType": "",
+      "seriesTitle": "",
+      "place": "California",
+      "institution": "",
+      "date": "May 1973",
+      "pages": "",
+      "language": "",
+      "shortTitle": "",
+      "url": "http://citeseerx.ist.psu.edu/viewdoc/summary?doi=10.1.1.696.5498",
+      "accessDate": "",
+      "archive": "",
+      "archiveLocation": "",
+      "libraryCatalog": "CiteSeer",
+      "callNumber": "",
+      "rights": "",
+      "extra": "",
+      "tags": [
+        {
+          "tag": "BBN-LISP"
+        },
+        {
+          "tag": "s2z"
+        }
+      ],
+      "collections": [
+        "HVGVBYYB"
+      ],
+      "relations": {},
+      "dateAdded": "2021-06-01T14:53:11Z",
+      "dateModified": "2021-06-01T15:01:16Z"
     }
   ],
   "1974": [
@@ -925,7 +2016,56 @@
             15
           ]
         ]
-      }
+      },
+      "key": "QQ4WARPF",
+      "version": 1936,
+      "itemType": "journalArticle",
+      "creators": [
+        {
+          "creatorType": "author",
+          "firstName": "Warren",
+          "lastName": "Teitelman"
+        }
+      ],
+      "abstractNote": "Documentation for INTERSLIP in the form of the INTERSLIP Reference Manual is now available and may be obtained from Warren Teitelman, Xerox Palo Alto Research Center. The new manual replaces all existing documentation, and is completely up to date (as to January, 1974). The manual is available in either loose-leaf or bound form. The lose-leaf version (binders not supplied) comes with printed separator tabs between the chapters. The bound version also includes colored divider pages between chapters, and is printed on somewhat thinner paper than the loose-leaf version, in an effort to make it 'portable' (the manual being approximately 700 pages long). Both versions contain a complete master index (approximately 1600 entries), as well as a separate index for each chapter. Although the manual is intended primarily to be used for reference, many chapters, e.g., the programmer's assistant, do-what-I-mean, CLISP, etc., include introductory and tutorial material. The manual is available in machine-readable form, and an on-line question-answering system using the manual as a data base is currently being implemented.",
+      "publicationTitle": "ACM SIGART Bulletin",
+      "volume": "",
+      "pages": "5-22",
+      "date": "February 1, 1974",
+      "series": "",
+      "seriesTitle": "",
+      "seriesText": "",
+      "language": "",
+      "ISSN": "0163-5719",
+      "shortTitle": "",
+      "url": "https://doi.org/10.1145/1045183.1045186",
+      "accessDate": "2021-04-15T23:17:59Z",
+      "archive": "",
+      "archiveLocation": "",
+      "libraryCatalog": "February 1974",
+      "callNumber": "",
+      "rights": "",
+      "extra": "",
+      "tags": [
+        {
+          "tag": "interlisp"
+        },
+        {
+          "tag": "s2z"
+        }
+      ],
+      "collections": [
+        "TVX6WEZX"
+      ],
+      "relations": {
+        "dc:replaces": [
+          "http://zotero.org/groups/2914042/items/75EE9NSJ",
+          "http://zotero.org/groups/2914042/items/IZX4ZJQI",
+          "http://zotero.org/groups/2914042/items/UT9ISQ7D"
+        ]
+      },
+      "dateAdded": "2021-04-15T23:18:51Z",
+      "dateModified": "2021-06-03T19:53:31Z"
     },
     {
       "id": "9296070/K4LSMPDE",
@@ -948,7 +2088,43 @@
             18
           ]
         ]
-      }
+      },
+      "key": "K4LSMPDE",
+      "version": 2241,
+      "itemType": "document",
+      "creators": [
+        {
+          "creatorType": "author",
+          "firstName": "P.",
+          "lastName": "Deutsch"
+        }
+      ],
+      "abstractNote": "Several conflicting goal must be resolved in deciding on a set of display facilities for Lisp: ease of lisp, efficient access to hardware facilities, and device and system independence. Thiss memo suggests a set of facilities constructed in two layers: a lower layer that gives direct access to the Alto\nbitmap capability, while retaining Lisp's tradition of freeing the programmer\nfrom  storage allocation worries and an upper Iayer that uses the lower (on the Alto) or a character-stream protocol (for VTS t on MAXC) to provide for writing strings, scrolling, edting, etc. on the screen,",
+      "date": "November 18, 1974",
+      "language": "",
+      "shortTitle": "",
+      "url": "http://www.bitsavers.org/pdf/xerox/alto/memos_1974/Display_Primitives_in_Lisp_Nov74.pdf",
+      "accessDate": "",
+      "archive": "",
+      "archiveLocation": "",
+      "libraryCatalog": "",
+      "callNumber": "",
+      "rights": "",
+      "extra": "",
+      "tags": [
+        {
+          "tag": "interlisp"
+        },
+        {
+          "tag": "s2z"
+        }
+      ],
+      "collections": [
+        "TVX6WEZX"
+      ],
+      "relations": {},
+      "dateAdded": "2021-05-31T19:04:25Z",
+      "dateModified": "2021-08-27T22:44:57Z"
     }
   ],
   "1975": [
@@ -973,7 +2149,51 @@
             1975
           ]
         ]
-      }
+      },
+      "key": "VCQ8JN33",
+      "version": 1984,
+      "itemType": "journalArticle",
+      "creators": [
+        {
+          "creatorType": "author",
+          "name": "Anders Haraidson"
+        }
+      ],
+      "abstractNote": "This paper gives a tutorial introduction to INTERLISP/360-370, a subset of INTERLISP, which can be implemented on IBM/360 and\nsimilar systems. oe·scriptions of a large number of functions in INTERLISP with numerous examples, exercises and solutions are contained. The use of edit, break, advice, file handling and compiler are given and both interactive and batch use of the system is taken care of.",
+      "publicationTitle": "Oatalogi1aboratoriet, Sturegatan 1. S-752 23 Uppsala, -Sweden",
+      "volume": "",
+      "issue": "",
+      "pages": "217",
+      "date": "1975",
+      "series": "",
+      "seriesTitle": "",
+      "seriesText": "",
+      "journalAbbreviation": "",
+      "DOI": "",
+      "ISSN": "9150600346",
+      "shortTitle": "",
+      "url": "http://www.softwarepreservation.org/projects/LISP/uppsala/Haraldson-LISP_details.pdf",
+      "accessDate": "",
+      "archive": "",
+      "archiveLocation": "",
+      "libraryCatalog": "",
+      "callNumber": "",
+      "rights": "",
+      "extra": "",
+      "tags": [
+        {
+          "tag": "INTERLISP/360-370"
+        },
+        {
+          "tag": "s2z"
+        }
+      ],
+      "collections": [
+        "TVX6WEZX"
+      ],
+      "relations": {},
+      "dateAdded": "2021-05-31T17:07:38Z",
+      "dateModified": "2021-05-31T18:38:09Z"
     },
     {
       "id": "9296070/FW3Z9TSW",
@@ -1007,7 +2227,45 @@
             29
           ]
         ]
-      }
+      },
+      "key": "FW3Z9TSW",
+      "version": 1794,
+      "itemType": "report",
+      "creators": [
+        {
+          "creatorType": "author",
+          "firstName": "Stephen",
+          "lastName": "Weyl"
+        }
+      ],
+      "abstractNote": "This report describes the file system for the experimental large file management support system currently being implemented at SRI. INTERLISP, an interactive, development-oriented computer programming system, has been augmented to support applications requiring large data bases maintained on secondary store.  The data base support programs are separated into two levels  an advanced file system and relational data base management procedures. The file system allows programmers to make full use of the capabilities of on-line random access devices using problem related symbolic primitives rather than page and word numbers.  It also performs several useful data storage functions such as data compression, sequencing, and generation of symbols which are unique for a file.",
+      "reportNumber": "",
+      "reportType": "",
+      "seriesTitle": "",
+      "place": "",
+      "institution": "STANFORD RESEARCH INST MENLO PARK CALIF",
+      "date": "1975-11-01",
+      "pages": "",
+      "shortTitle": "",
+      "url": "https://apps.dtic.mil/sti/citations/ADA018962",
+      "accessDate": "2021-05-29T20:22:56Z",
+      "archive": "",
+      "archiveLocation": "",
+      "libraryCatalog": "apps.dtic.mil",
+      "callNumber": "",
+      "rights": "",
+      "extra": "Section: Technical Reports",
+      "tags": [
+        {
+          "tag": "sz"
+        }
+      ],
+      "collections": [
+        "MTUXENI8"
+      ],
+      "relations": {},
+      "dateAdded": "2021-05-29T20:22:56Z",
+      "dateModified": "2021-05-29T20:24:48Z"
     },
     {
       "id": "9296070/QFBSW8AZ",
@@ -1043,7 +2301,48 @@
             16
           ]
         ]
-      }
+      },
+      "key": "QFBSW8AZ",
+      "version": 1345,
+      "itemType": "journalArticle",
+      "creators": [
+        {
+          "creatorType": "author",
+          "firstName": "Daniel G.",
+          "lastName": "Bobrow"
+        }
+      ],
+      "abstractNote": "In current machine designs, a machine address gives the user direct access to a single piece of information, namely the contents of that machine word. This note is based on the observation that it is often useful to associate additional information, with some (relatively few) address locations determined at run time, without the necessity of preallocating the storage at all possible such addresses. That is, it can be useful to have an effective extra bit, field, or address in some words without every word having to contain a bit (or bits) to mark this as a special case. The key idea is that this extra associated information can be found by a table search. Although it could be found by any search technique (e.g. linear, binary sorted, etc.), we suggest that an appropriate low overhead mechanism is to use hash search on a table in which the key is the address of the cell to be augmented.",
+      "publicationTitle": "Communications of the ACM",
+      "pages": "413-415",
+      "date": "07/1975",
+      "series": "",
+      "seriesTitle": "",
+      "seriesText": "",
+      "ISSN": "0001-0782, 1557-7317",
+      "shortTitle": "",
+      "url": "https://dl.acm.org/doi/10.1145/360881.360920",
+      "accessDate": "2021-04-16T02:11:24Z",
+      "archive": "",
+      "archiveLocation": "",
+      "libraryCatalog": "DOI.org (Crossref)",
+      "callNumber": "",
+      "rights": "",
+      "extra": "",
+      "tags": [
+        {
+          "tag": "interlisp"
+        },
+        {
+          "tag": "s2z"
+        }
+      ],
+      "collections": [
+        "TVX6WEZX"
+      ],
+      "relations": {},
+      "dateAdded": "2021-04-16T02:11:24Z",
+      "dateModified": "2021-05-31T18:40:14Z"
     },
     {
       "id": "9296070/KQM2N5FW",
@@ -1067,7 +2366,49 @@
             19
           ]
         ]
-      }
+      },
+      "key": "KQM2N5FW",
+      "version": 2011,
+      "itemType": "report",
+      "creators": [
+        {
+          "creatorType": "author",
+          "firstName": "L. Peter",
+          "lastName": "Deutsch"
+        }
+      ],
+      "abstractNote": "Program verification refers to the idea that the intent or effect of a program can be stated in a precise way that is not a simple \"rewording \" of the program itself, and that one can prove (in the mathematical sense) that a program actually conforms to a given statement of intent. This thesis describes a software system which can verify (prove) some non-trivial programs automatically. The system described here is organized in a novel manner compared to most other theorem-proving systems. IL has a great deal of specific knowledge about integers and arrays of integers, yet it is not \"special-purpose\", since this knowledge is represented in procedures which are separate from the underlying structure of the system. It also incorporates some knowledge, gained by the author from both experiment and introspection, about how programs are often constructed, and uses this knowledge to guide the proof process. It uses its knowledge, plus contextual information from the program being verified, to simplify the theorems dramatically as they are being constructed, rather than relying on a super-powerful proof procedure. The system also provides for interactive editing of programs and assertions, and for detailed human control of the proof process when the system cannot produce a proof (or counter-example) on its own.",
+      "reportNumber": "",
+      "reportType": "",
+      "seriesTitle": "",
+      "place": "California",
+      "institution": "",
+      "date": "19 MAR 1975",
+      "pages": "",
+      "language": "",
+      "shortTitle": "",
+      "url": "http://www.softwarepreservation.org/projects/verification/pivot/Deutsch-Pivot.pdf",
+      "accessDate": "",
+      "archive": "",
+      "archiveLocation": "",
+      "libraryCatalog": "CiteSeer",
+      "callNumber": "",
+      "rights": "",
+      "extra": "",
+      "tags": [
+        {
+          "tag": "BBN-LISP"
+        },
+        {
+          "tag": "s2z"
+        }
+      ],
+      "collections": [
+        "HVGVBYYB"
+      ],
+      "relations": {},
+      "dateAdded": "2021-06-01T15:02:02Z",
+      "dateModified": "2021-06-01T15:02:51Z"
     },
     {
       "id": "9296070/JP52RFKS",
@@ -1103,30 +2444,54 @@
             31
           ]
         ]
-      }
+      },
+      "key": "JP52RFKS",
+      "version": 1963,
+      "itemType": "report",
+      "creators": [
+        {
+          "creatorType": "author",
+          "firstName": "P.",
+          "lastName": "Deutsch"
+        }
+      ],
+      "abstractNote": "",
+      "reportNumber": "",
+      "reportType": "",
+      "seriesTitle": "",
+      "place": "Palo Alto",
+      "institution": "PARC/CSL",
+      "date": "May 14, 1975",
+      "pages": "2",
+      "url": "http://www.bitsavers.org/pdf/xerox/alto/memos_1975/Status_Report_on_Alto_Lisp_May75.pdf",
+      "accessDate": "2021-05-31T15:46:36Z",
+      "archive": "",
+      "archiveLocation": "",
+      "libraryCatalog": "Internet Archive",
+      "callNumber": "",
+      "rights": "",
+      "extra": "",
+      "tags": [
+        {
+          "tag": "Interlisp-D"
+        },
+        {
+          "tag": "lisp",
+          "type": 1
+        },
+        {
+          "tag": "s2z"
+        }
+      ],
+      "collections": [
+        "3CNYFDHF"
+      ],
+      "relations": {},
+      "dateAdded": "2021-05-31T15:46:36Z",
+      "dateModified": "2021-05-31T18:28:20Z"
     }
   ],
   "1976": [
-    {
-      "id": "9296070/ZNK9J6YF",
-      "type": "thesis",
-      "title": "List Structure: Measurements, Algorithms, and Encodings",
-      "publisher": "CMU",
-      "abstract": "This thesis is about list structures: how they are used in practice, how they\ncan be moved and copied efficiently, and how they can be represented by space-saving encodings. The approach taken to these subjects is mainly empirical.\nMeasurement results are based on five large programs written in Interlisp, a\nsophisticated Lisp system that runs on the PDP-10.",
-      "author": [
-        {
-          "family": "Clark",
-          "given": "Douglas W."
-        }
-      ],
-      "issued": {
-        "date-parts": [
-          [
-            1976
-          ]
-        ]
-      }
-    },
     {
       "id": "9296070/V3ECJHJ3",
       "type": "report",
@@ -1146,7 +2511,46 @@
             1976
           ]
         ]
-      }
+      },
+      "key": "V3ECJHJ3",
+      "version": 2249,
+      "itemType": "report",
+      "creators": [
+        {
+          "creatorType": "author",
+          "firstName": "J. Strother",
+          "lastName": "Moore"
+        }
+      ],
+      "abstractNote": "The INTERLISP Virtual Machine is the environment in which the INTERLISP System is implemented. It includes such abstract objects as \"Literal Atoms\", \"List Cells\", \"Integers\", etc., the basic LISP functions for manipulating them, the underlying program control and variable binding mechanisms, the input/output facilities, and interrupt processing facilities. In order to Implement the INTER LISP System (as described in The INTERLISP Reference Manual by W. Teitelman, et. al.) on some physical machine, it is only necessary to implement the INTERLISP Virtual Machine, since Virtual Machine compatible source code for the rest of the INTERLISP System can be obtained from publicly available files. This document specifies the behavior of the INTER LISP Virtual Machine from the implementor's point of view. That is, it is an attempt to make explicit those things which must be implemented to allow the INTERLISP System to run on some machine. KEY WORDS AND PHRASES programming language semantics, LISP, dynamic storage allocation, interpreters, spaghetti stacks, abstract data types, function objects, FUNARGs, applicative programming languages, control structures, interactive systems, DWIM, programmer's assistant, automatic error correction, eval, error handling, interrupt",
+      "reportNumber": "",
+      "reportType": "",
+      "seriesTitle": "",
+      "place": "",
+      "institution": "Xerox Palo Alto Research Center",
+      "date": "1976",
+      "pages": "",
+      "language": "",
+      "shortTitle": "",
+      "url": "http://www.bitsavers.org/pdf/xerox/parc/techReports/CSL-76-5_The_Interlisp_Virtual_Machine_Specification.pdf",
+      "accessDate": "",
+      "archive": "",
+      "archiveLocation": "",
+      "libraryCatalog": "CiteSeer",
+      "callNumber": "",
+      "rights": "",
+      "extra": "",
+      "tags": [
+        {
+          "tag": "sz"
+        }
+      ],
+      "collections": [
+        "TVX6WEZX"
+      ],
+      "relations": {},
+      "dateAdded": "2021-04-16T04:04:12Z",
+      "dateModified": "2021-08-27T23:52:37Z"
     },
     {
       "id": "9296070/WRHC5YI7",
@@ -1187,7 +2591,122 @@
             1976
           ]
         ]
-      }
+      },
+      "key": "WRHC5YI7",
+      "version": 2059,
+      "itemType": "conferencePaper",
+      "creators": [
+        {
+          "creatorType": "author",
+          "firstName": "Earl D.",
+          "lastName": "Sacerdoti"
+        },
+        {
+          "creatorType": "author",
+          "firstName": "Richard E.",
+          "lastName": "Fikes"
+        },
+        {
+          "creatorType": "author",
+          "firstName": "Rene",
+          "lastName": "Reboh"
+        },
+        {
+          "creatorType": "author",
+          "firstName": "Daniel",
+          "lastName": "Sagalowicz"
+        },
+        {
+          "creatorType": "author",
+          "firstName": "Richard J.",
+          "lastName": "Waldinger"
+        },
+        {
+          "creatorType": "author",
+          "firstName": "B. Michael",
+          "lastName": "Wilber"
+        }
+      ],
+      "abstractNote": "",
+      "date": "1976",
+      "proceedingsTitle": "Proceedings of the June 7-10, 1976, national computer conference and exposition",
+      "conferenceName": "",
+      "place": "",
+      "publisher": "",
+      "volume": "",
+      "pages": "349-356",
+      "series": "",
+      "language": "",
+      "DOI": "",
+      "ISBN": "",
+      "url": "",
+      "accessDate": "",
+      "archive": "",
+      "archiveLocation": "",
+      "libraryCatalog": "Google Scholar",
+      "callNumber": "",
+      "rights": "",
+      "extra": "",
+      "tags": [],
+      "collections": [
+        "TVX6WEZX"
+      ],
+      "relations": {},
+      "dateAdded": "2021-06-09T23:36:05Z",
+      "dateModified": "2021-06-09T23:36:05Z"
+    },
+    {
+      "id": "9296070/ZNK9J6YF",
+      "type": "thesis",
+      "title": "List Structure: Measurements, Algorithms, and Encodings",
+      "publisher": "CMU",
+      "abstract": "This thesis is about list structures: how they are used in practice, how they\ncan be moved and copied efficiently, and how they can be represented by space-saving encodings. The approach taken to these subjects is mainly empirical.\nMeasurement results are based on five large programs written in Interlisp, a\nsophisticated Lisp system that runs on the PDP-10.",
+      "author": [
+        {
+          "family": "Clark",
+          "given": "Douglas W."
+        }
+      ],
+      "issued": {
+        "date-parts": [
+          [
+            1976
+          ]
+        ]
+      },
+      "key": "ZNK9J6YF",
+      "version": 2336,
+      "itemType": "thesis",
+      "creators": [
+        {
+          "creatorType": "author",
+          "firstName": "Douglas W.",
+          "lastName": "Clark"
+        }
+      ],
+      "abstractNote": "This thesis is about list structures: how they are used in practice, how they\ncan be moved and copied efficiently, and how they can be represented by space-saving encodings. The approach taken to these subjects is mainly empirical.\nMeasurement results are based on five large programs written in Interlisp, a\nsophisticated Lisp system that runs on the PDP-10.",
+      "thesisType": "",
+      "university": "CMU",
+      "place": "",
+      "date": "1976",
+      "numPages": "",
+      "language": "",
+      "shortTitle": "",
+      "url": "",
+      "accessDate": "",
+      "archive": "",
+      "archiveLocation": "",
+      "libraryCatalog": "",
+      "callNumber": "",
+      "rights": "",
+      "extra": "",
+      "tags": [],
+      "collections": [
+        "TVX6WEZX"
+      ],
+      "relations": {},
+      "dateAdded": "2022-01-23T19:55:47Z",
+      "dateModified": "2022-01-23T19:58:30Z"
     },
     {
       "id": "9296070/B2PF228B",
@@ -1217,7 +2736,50 @@
             1
           ]
         ]
-      }
+      },
+      "key": "B2PF228B",
+      "version": 1856,
+      "itemType": "report",
+      "creators": [
+        {
+          "creatorType": "author",
+          "firstName": "Robert",
+          "lastName": "Bobrow"
+        },
+        {
+          "creatorType": "author",
+          "firstName": "Mario",
+          "lastName": "Grignetti"
+        }
+      ],
+      "abstractNote": "This report describes measurements performed for the purpose of determining areas of potential improvement to the efficiency of INTERLISP running under TENEX.",
+      "reportNumber": "DTIC_ADA1045834",
+      "reportType": "",
+      "seriesTitle": "",
+      "place": "",
+      "institution": "BOLT BERANEK AND NEWMAN INC CAMBRIDGE MA",
+      "date": "1976-06-01",
+      "pages": "61",
+      "shortTitle": "",
+      "url": "https://archive.org/details/DTIC_ADA1045834",
+      "accessDate": "",
+      "archive": "",
+      "archiveLocation": "",
+      "libraryCatalog": "Google Scholar",
+      "callNumber": "",
+      "rights": "",
+      "extra": "",
+      "tags": [
+        {
+          "tag": "sz"
+        }
+      ],
+      "collections": [
+        "TVX6WEZX"
+      ],
+      "relations": {},
+      "dateAdded": "2021-04-25T19:54:39Z",
+      "dateModified": "2021-06-03T18:46:42Z"
     },
     {
       "id": "9296070/GCAQS8MG",
@@ -1251,7 +2813,45 @@
             2
           ]
         ]
-      }
+      },
+      "key": "GCAQS8MG",
+      "version": 1995,
+      "itemType": "report",
+      "creators": [
+        {
+          "creatorType": "author",
+          "firstName": "W.",
+          "lastName": "Teitelman"
+        }
+      ],
+      "abstractNote": "The contract covered by this annual report includes a variety of activities and services centering around the continued growth and well-being of INTERLISP, a large, interactive system widely used in the ARPA community for developing advanced and sophisticated computer-based systems.",
+      "reportNumber": "",
+      "reportType": "",
+      "seriesTitle": "",
+      "place": "",
+      "institution": "XEROX CORP PALO ALTO RESEARCH CENTER CA",
+      "date": "1976-10-26",
+      "pages": "",
+      "shortTitle": "",
+      "url": "https://apps.dtic.mil/sti/citations/ADA033633",
+      "accessDate": "2021-06-02T18:22:28Z",
+      "archive": "",
+      "archiveLocation": "",
+      "libraryCatalog": "apps.dtic.mil",
+      "callNumber": "",
+      "rights": "",
+      "extra": "Section: Technical Reports",
+      "tags": [
+        {
+          "tag": "sz"
+        }
+      ],
+      "collections": [
+        "TVX6WEZX"
+      ],
+      "relations": {},
+      "dateAdded": "2021-06-02T18:22:28Z",
+      "dateModified": "2021-06-03T19:24:38Z"
     },
     {
       "id": "9296070/RAASKHRE",
@@ -1291,7 +2891,53 @@
             16
           ]
         ]
-      }
+      },
+      "key": "RAASKHRE",
+      "version": 1333,
+      "itemType": "journalArticle",
+      "creators": [
+        {
+          "creatorType": "author",
+          "firstName": "L. Peter",
+          "lastName": "Deutsch"
+        },
+        {
+          "creatorType": "author",
+          "firstName": "Daniel G.",
+          "lastName": "Bobrow"
+        }
+      ],
+      "abstractNote": "This paper describes a new way of solving the storage reclamation problem for a system such as Lisp that allocates storage automatically from a heap, and does not require the programmer to give any indication that particular items are no longer useful or accessible. A reference count scheme for reclaiming non-self-referential structures, and a linearizing, compacting, copying scheme to reorganize all storage at the users discretion are proposed. The algorithms are designed to work well in systems which use multiple levels of storage, and large virtual address space. They depend on the fact that most cells are referenced exactly once, and that reference counts need only be accurate when storage is about to be reclaimed. A transaction file stores changes to reference counts, and a multiple reference table stores the count for items which are referenced more than once.",
+      "publicationTitle": "Communications of the ACM",
+      "pages": "522-526",
+      "date": "09/1976",
+      "series": "",
+      "seriesTitle": "",
+      "seriesText": "",
+      "ISSN": "0001-0782, 1557-7317",
+      "shortTitle": "",
+      "url": "https://dl.acm.org/doi/10.1145/360336.360345",
+      "accessDate": "2021-04-16T02:11:24Z",
+      "archive": "",
+      "archiveLocation": "",
+      "libraryCatalog": "DOI.org (Crossref)",
+      "callNumber": "",
+      "rights": "",
+      "extra": "",
+      "tags": [
+        {
+          "tag": "Interlisp-D"
+        },
+        {
+          "tag": "s2z"
+        }
+      ],
+      "collections": [
+        "3CNYFDHF"
+      ],
+      "relations": {},
+      "dateAdded": "2021-04-16T02:11:24Z",
+      "dateModified": "2021-05-31T18:27:54Z"
     },
     {
       "id": "9296070/QBBQSH3V",
@@ -1319,7 +2965,53 @@
             4
           ]
         ]
-      }
+      },
+      "key": "QBBQSH3V",
+      "version": 1996,
+      "itemType": "journalArticle",
+      "creators": [
+        {
+          "creatorType": "author",
+          "firstName": "Warren",
+          "lastName": "Teitelman"
+        }
+      ],
+      "abstractNote": "Clisp is an attempt to make Lisp programs easier to read and write by extending the syntax of Lisp to include infix operators, IF-THEN statements, FOR-DO-WHILE statements, and similar Algol-like constructs, without changing the structure or representation of the language. Clisp is implemented through Lisp's error handling machinery, rather than by modifying the interpreter. When an expression is encountered whose evaluation causes an error, the expression is scanned for possible Clisp constructs, which are then converted to the equivalent Lisp expressions. Thus, users can freely intermix Lisp and Clisp without ut having to distinguish which is which. Emphasis in the design and development of Clisp has been on the system aspects of such a facility, with the goal of producing a useful tool, not just another language. To this end, Clisp includes interactive error correction and many \"do-what-I-mean\" features.",
+      "publicationTitle": "IEEE Transactions on Computers",
+      "pages": "354-357",
+      "date": "April 1976",
+      "series": "",
+      "seriesTitle": "",
+      "seriesText": "",
+      "journalAbbreviation": "",
+      "language": "",
+      "ISSN": "0018-9340",
+      "url": "http://www.softwarepreservation.org/projects/LISP/interlisp/Teitelman-3IJCAI.pdf/view",
+      "accessDate": "",
+      "archive": "",
+      "archiveLocation": "",
+      "libraryCatalog": "IEEE Xplore",
+      "callNumber": "",
+      "rights": "",
+      "extra": "Conference Name: IEEE Transactions on Computers",
+      "tags": [
+        {
+          "tag": "Automatic error correction, extensible languages, interactive systems, Lisp, list processing, programming, programming languages.",
+          "type": 1
+        },
+        {
+          "tag": "interlisp"
+        },
+        {
+          "tag": "s2z"
+        }
+      ],
+      "collections": [
+        "TVX6WEZX"
+      ],
+      "relations": {},
+      "dateAdded": "2021-05-31T17:36:23Z",
+      "dateModified": "2021-06-03T19:53:22Z"
     },
     {
       "id": "9296070/P43BUE35",
@@ -1349,7 +3041,43 @@
             23
           ]
         ]
-      }
+      },
+      "key": "P43BUE35",
+      "version": 1999,
+      "itemType": "webpage",
+      "creators": [
+        {
+          "creatorType": "author",
+          "firstName": "Larry",
+          "lastName": "Masinter"
+        }
+      ],
+      "abstractNote": "",
+      "websiteTitle": "Software Preservation Group",
+      "websiteType": "",
+      "date": "January 1976",
+      "shortTitle": "",
+      "url": "http://www.softwarepreservation.org/projects/LISP/interlisp/tenex/twenex.org/PARCMESSAGE.TXT.1/view",
+      "accessDate": "2021-04-23T18:22:13Z",
+      "language": "",
+      "rights": "",
+      "extra": "",
+      "tags": [
+        {
+          "tag": "sz"
+        }
+      ],
+      "collections": [
+        "TVX6WEZX"
+      ],
+      "relations": {
+        "dc:replaces": [
+          "http://zotero.org/groups/2914042/items/BKXXHJSI",
+          "http://zotero.org/groups/2914042/items/5D56GW2J"
+        ]
+      },
+      "dateAdded": "2021-04-25T18:13:25Z",
+      "dateModified": "2021-06-02T18:33:59Z"
     }
   ],
   "1977": [
@@ -1388,7 +3116,51 @@
             31
           ]
         ]
-      }
+      },
+      "key": "3H5F6TBA",
+      "version": 1984,
+      "itemType": "conferencePaper",
+      "creators": [
+        {
+          "creatorType": "author",
+          "firstName": "Warren",
+          "lastName": "Teitelman"
+        }
+      ],
+      "abstractNote": "This paper continues and extends previous work by the author in developing systems which provide the user with various forms of explicit and implicit assistance, and in general cooperate with the user in the development of his programs. The system described in this paper makes extensive use of a bit map display and pointing device (a mouse) to significantly enrich the user's interactions with the system, and to provide capabilities not possible with terminals that essentially emulate hard copy devices. For example, any text that is displayed on the screen can be pointed at and treated as input, exactly as though it were typed, i.e., the user can say use this expression or that value, and then simply point. The user views his programming environment through a collection of display windows, each of which corresponds to a different task or context. The user can manipulate the windows, or the contents of a particular window, by a combination of keyboard inputs or pointing operations. The technique of using different windows for different tasks makes it easy for the user to manage several simultaneous tasks and contexts, e.g., defining programs, testing programs, editing, asking the system for assistance, sending and receiving messages, etc and to switch back and forth between these tasks at his convenience.",
+      "date": "August 22, 1977",
+      "proceedingsTitle": "Proceedings of the 5th international joint conference on Artificial intelligence - Volume 2",
+      "conferenceName": "",
+      "place": "San Francisco, CA, USA",
+      "volume": "",
+      "pages": "905–915",
+      "series": "IJCAI'77",
+      "language": "",
+      "DOI": "",
+      "ISBN": "",
+      "shortTitle": "",
+      "url": "https://dl.acm.org/doi/10.5555/1622943.1623025",
+      "accessDate": "2021-05-31",
+      "archive": "",
+      "archiveLocation": "",
+      "libraryCatalog": "ACM Digital Library",
+      "callNumber": "",
+      "rights": "",
+      "extra": "",
+      "tags": [
+        {
+          "tag": "interlisp"
+        },
+        {
+          "tag": "s2z"
+        }
+      ],
+      "collections": [
+        "3CNYFDHF"
+      ],
+      "relations": {},
+      "dateAdded": "2021-05-31T17:28:06Z",
+      "dateModified": "2021-05-31T18:39:42Z"
     },
     {
       "id": "9296070/P5MUCJX3",
@@ -1426,7 +3198,45 @@
             2
           ]
         ]
-      }
+      },
+      "key": "P5MUCJX3",
+      "version": 2050,
+      "itemType": "journalArticle",
+      "creators": [
+        {
+          "creatorType": "author",
+          "firstName": "Richard R.",
+          "lastName": "Burton"
+        }
+      ],
+      "abstractNote": "One of the major stumbling blocks to more effective used computers by naive users is the lack of natural means of communication between the user and the computer system. This report discusses a paradigm for constructing efficient and friendly man-machine interface systems involving subsets of natural language for limited domains of discourse. As such this work falls somewhere between highly constrained formal language query systems and unrestricted natural language under-standing systems. The primary purpose of this research is not to advance our theoretical under-standing of natural language but rather to put forth a set of techniques for embedding both semantic/conceptual and pragmatic information into a useful natural language interface module. Our intent has been to produce a front end system which enables the user to concentrate on his problem or task rather than making him worry about how to communicate his ideas or questions to the machine.",
+      "publicationTitle": "ACM SIGART Bulletin",
+      "volume": "",
+      "pages": "26",
+      "date": "February 1, 1977",
+      "series": "",
+      "seriesTitle": "",
+      "seriesText": "",
+      "ISSN": "0163-5719",
+      "url": "https://doi.org/10.1145/1045283.1045290",
+      "accessDate": "2021-06-02T18:00:51Z",
+      "archive": "",
+      "archiveLocation": "",
+      "libraryCatalog": "February 1977",
+      "callNumber": "",
+      "rights": "",
+      "extra": "",
+      "tags": [
+        {
+          "tag": "sz"
+        }
+      ],
+      "collections": [
+        "MTUXENI8"
+      ],
+      "relations": {},
+      "dateAdded": "2021-06-02T18:00:51Z",
+      "dateModified": "2021-06-02T18:01:20Z"
     },
     {
       "id": "9296070/S82MS337",
@@ -1450,7 +3260,124 @@
             7
           ]
         ]
-      }
+      },
+      "key": "S82MS337",
+      "version": 1953,
+      "itemType": "report",
+      "creators": [
+        {
+          "creatorType": "author",
+          "firstName": "Robert F.",
+          "lastName": "Sproull"
+        }
+      ],
+      "abstractNote": "This report describes briefly a set of display primitives that we have developed at PARC toextend the capabilities of InterLisp[l]. These primitives are designed to operate araster-scanned displaYt and concentrate on facilities for placing text carefully on the displayand for moving chunks of an already-created display.",
+      "reportNumber": "",
+      "reportType": "",
+      "seriesTitle": "",
+      "place": "Xerox Palo Alto Research Center3333 Coyote H iII RoadPalo Altot California 94304",
+      "institution": "",
+      "date": "July 1977",
+      "pages": "",
+      "shortTitle": "",
+      "url": "http://scholar.googleusercontent.com/scholar?q=cache:fAjwtL8R9ogJ:scholar.google.com/+INTERLISP+DISPLAY+PRIl%5ClITIVES&hl=en&as_sdt=0,5",
+      "accessDate": "",
+      "archive": "",
+      "archiveLocation": "",
+      "libraryCatalog": "CiteSeer",
+      "callNumber": "",
+      "rights": "",
+      "extra": "",
+      "tags": [
+        {
+          "tag": "interlisp"
+        },
+        {
+          "tag": "s2z"
+        }
+      ],
+      "collections": [
+        "3CNYFDHF"
+      ],
+      "relations": {},
+      "dateAdded": "2021-04-16T04:04:12Z",
+      "dateModified": "2021-06-03T19:53:28Z"
+    },
+    {
+      "id": "9296070/FFAKSC38",
+      "type": "report",
+      "title": "A Display Oriented Programmers Assistant",
+      "page": "34",
+      "abstract": "This paper continues and extends previous work by the author in developing systems which provide the user with various forms of explicit and implicit assistance, and in general co-operate with the user in the development of his programs. The system described in this paper makes extensive use of a bit map display and pointing device (a mouse) to significantly enrich the user's interactions with the system, and to provide capabilities not possible with terminals that essentially emulate hard copy devices. For example, any text that is displayed on the screen can be pointed at and treated as input, exactly as though it were typed, i.e. the user can say use this expression or that value, and then simply point. The user views his programming environment through a collection of display windows, each of which corresponds to a different task or context. The user can manipulate the windows, or the contents of a particular window, by a combination of keyboard inputs or pointing operations. The technique of using different windows for different tasks makes it easy for the user to manage several simultaneous tasks and contexts, e.g. defining programs, testing programs, editing, asking the system for assistance, sending and receiving messages, etc. and to switch back and forth between these tasks at his convenience.",
+      "URL": "http://bitsavers.trailing-edge.com/pdf/xerox/parc/techReports/CSL-77-3_A_Display_Oriented_Programmers_Assistant.pdf",
+      "language": "English",
+      "author": [
+        {
+          "family": "Teitelman",
+          "given": "Warren"
+        }
+      ],
+      "issued": {
+        "date-parts": [
+          [
+            "1977",
+            3
+          ]
+        ]
+      },
+      "key": "FFAKSC38",
+      "version": 2889,
+      "itemType": "report",
+      "creators": [
+        {
+          "creatorType": "author",
+          "firstName": "Warren",
+          "lastName": "Teitelman"
+        }
+      ],
+      "abstractNote": "This paper continues and extends previous work by the author in developing systems which provide the user with various forms of explicit and implicit assistance, and in general co-operate with the user in the development of his programs. The system described in this paper makes extensive use of a bit map display and pointing device (a mouse) to significantly enrich the user's interactions with the system, and to provide capabilities not possible with terminals that essentially emulate hard copy devices. For example, any text that is displayed on the screen can be pointed at and treated as input, exactly as though it were typed, i.e. the user can say use this expression or that value, and then simply point. The user views his programming environment through a collection of display windows, each of which corresponds to a different task or context. The user can manipulate the windows, or the contents of a particular window, by a combination of keyboard inputs or pointing operations. The technique of using different windows for different tasks makes it easy for the user to manage several simultaneous tasks and contexts, e.g. defining programs, testing programs, editing, asking the system for assistance, sending and receiving messages, etc. and to switch back and forth between these tasks at his convenience.",
+      "reportNumber": "",
+      "reportType": "",
+      "seriesTitle": "",
+      "place": "",
+      "institution": "",
+      "date": "March 1977",
+      "pages": "34",
+      "shortTitle": "",
+      "url": "http://bitsavers.trailing-edge.com/pdf/xerox/parc/techReports/CSL-77-3_A_Display_Oriented_Programmers_Assistant.pdf",
+      "accessDate": "",
+      "archive": "",
+      "archiveLocation": "",
+      "libraryCatalog": "",
+      "callNumber": "",
+      "rights": "",
+      "extra": "",
+      "tags": [
+        {
+          "tag": "DLISP"
+        },
+        {
+          "tag": "Interlisp"
+        },
+        {
+          "tag": "Reviewed by SHFT - CSUCI (Ron Vincent A.)"
+        },
+        {
+          "tag": "human computer interaction"
+        },
+        {
+          "tag": "interlisp"
+        },
+        {
+          "tag": "s2z"
+        }
+      ],
+      "collections": [
+        "3CNYFDHF"
+      ],
+      "relations": {},
+      "dateAdded": "2023-04-24T20:41:37Z",
+      "dateModified": "2023-05-07T04:59:31Z"
     }
   ],
   "1978": [
@@ -1486,7 +3413,43 @@
             18
           ]
         ]
-      }
+      },
+      "key": "UYMFQ6DW",
+      "version": 2228,
+      "itemType": "journalArticle",
+      "creators": [
+        {
+          "creatorType": "author",
+          "firstName": "E. R.",
+          "lastName": "Fiala"
+        }
+      ],
+      "abstractNote": "",
+      "publicationTitle": "Computer",
+      "issue": "",
+      "pages": "57-67",
+      "date": "1978",
+      "series": "",
+      "seriesTitle": "",
+      "seriesText": "",
+      "journalAbbreviation": "",
+      "ISSN": "0018-9162",
+      "shortTitle": "",
+      "url": "https://web.archive.org/web/2017/https://www.computer.org/web/csdl/index/-/csdl/mags/co/1978/05/01646959.pdf",
+      "accessDate": "2021-07-18T22:55:25Z",
+      "archive": "",
+      "archiveLocation": "",
+      "libraryCatalog": "fatcat.wiki",
+      "callNumber": "",
+      "rights": "",
+      "extra": "Publisher: Institute of Electrical and Electronics Engineers\nReport Number: 11\nFatcat ID: release_q5bn52bkmvgfnfpyj3fa6wfnzy",
+      "tags": [],
+      "collections": [
+        "HVGVBYYB"
+      ],
+      "relations": {},
+      "dateAdded": "2021-07-18T22:55:25Z",
+      "dateModified": "2021-07-18T22:58:17Z"
     },
     {
       "id": "9296070/JNSPBY9L",
@@ -1534,7 +3497,55 @@
             13
           ]
         ]
-      }
+      },
+      "key": "JNSPBY9L",
+      "version": 2111,
+      "itemType": "report",
+      "creators": [
+        {
+          "creatorType": "author",
+          "firstName": "Ronald",
+          "lastName": "Brachman"
+        },
+        {
+          "creatorType": "author",
+          "firstName": "Eugene",
+          "lastName": "Ciccarelli"
+        },
+        {
+          "creatorType": "author",
+          "firstName": "Norton",
+          "lastName": "Greenfeld"
+        },
+        {
+          "creatorType": "author",
+          "firstName": "Martin",
+          "lastName": "Yonke"
+        }
+      ],
+      "abstractNote": "",
+      "reportNumber": "",
+      "reportType": "",
+      "seriesTitle": "",
+      "place": "Fort Belvoir, VA",
+      "institution": "Defense Technical Information Center",
+      "date": "1978-7-1",
+      "pages": "",
+      "url": "http://www.dtic.mil/docs/citations/ADA122437",
+      "accessDate": "2021-07-13T19:57:01Z",
+      "archive": "",
+      "archiveLocation": "",
+      "libraryCatalog": "DOI.org (Crossref)",
+      "callNumber": "",
+      "rights": "",
+      "extra": "DOI: 10.21236/ADA122437",
+      "tags": [],
+      "collections": [
+        "MTUXENI8"
+      ],
+      "relations": {},
+      "dateAdded": "2021-07-13T19:57:01Z",
+      "dateModified": "2021-07-13T19:57:01Z"
     },
     {
       "id": "9296070/QXZFUW4U",
@@ -1571,7 +3582,49 @@
             31
           ]
         ]
-      }
+      },
+      "key": "QXZFUW4U",
+      "version": 1975,
+      "itemType": "journalArticle",
+      "creators": [
+        {
+          "creatorType": "author",
+          "firstName": "L. Peter",
+          "lastName": "Deutsch"
+        }
+      ],
+      "abstractNote": "This paper presents the design of an Interlisp system running on a microprogrammed minicomputer. We discuss the constraints imposed by compatibility requirements and by the hardware, the important design decisions, and the most prominent successes and failures of our design, and offer some suggestions for future designers of small Lisp systems. This extended abstract contains only qualitative results. Supporting measurement data will be presented at MICRO-11.",
+      "publicationTitle": "ACM SIGMICRO Newsletter",
+      "pages": "128–129",
+      "date": "November 19, 1978",
+      "series": "",
+      "seriesTitle": "",
+      "seriesText": "",
+      "language": "",
+      "ISSN": "1050-916X",
+      "shortTitle": "",
+      "url": "https://doi.org/10.1145/1014198.804321",
+      "accessDate": "2021-05-31T15:01:20Z",
+      "archive": "",
+      "archiveLocation": "",
+      "libraryCatalog": "Dec. 1978",
+      "callNumber": "",
+      "rights": "",
+      "extra": "",
+      "tags": [
+        {
+          "tag": "Interlisp-D"
+        },
+        {
+          "tag": "s2z"
+        }
+      ],
+      "collections": [
+        "3CNYFDHF"
+      ],
+      "relations": {},
+      "dateAdded": "2021-05-31T15:01:20Z",
+      "dateModified": "2021-05-31T18:26:02Z"
     },
     {
       "id": "9296070/JEW9IHTC",
@@ -1594,7 +3647,39 @@
             26
           ]
         ]
-      }
+      },
+      "key": "JEW9IHTC",
+      "version": 2242,
+      "itemType": "document",
+      "creators": [
+        {
+          "creatorType": "author",
+          "firstName": "L. Peter",
+          "lastName": "Deutsch"
+        }
+      ],
+      "abstractNote": "",
+      "date": "November 26, 1978",
+      "shortTitle": "",
+      "url": "http://www.softwarepreservation.org/projects/LISP/interlisp/Deutsch-Inside_Interlisp-1978.pdf",
+      "accessDate": "",
+      "archive": "",
+      "archiveLocation": "",
+      "libraryCatalog": "",
+      "callNumber": "",
+      "rights": "",
+      "extra": "",
+      "tags": [
+        {
+          "tag": "s2z"
+        }
+      ],
+      "collections": [
+        "TVX6WEZX"
+      ],
+      "relations": {},
+      "dateAdded": "2021-05-31T15:55:43Z",
+      "dateModified": "2021-08-27T23:01:57Z"
     }
   ],
   "1979": [
@@ -1629,7 +3714,48 @@
             23
           ]
         ]
-      }
+      },
+      "key": "398X5WQZ",
+      "version": 1999,
+      "itemType": "webpage",
+      "creators": [
+        {
+          "creatorType": "author",
+          "firstName": "Warren",
+          "lastName": "Teitelman"
+        },
+        {
+          "creatorType": "author",
+          "firstName": "Ron",
+          "lastName": "Kaplan"
+        }
+      ],
+      "abstractNote": "",
+      "websiteTitle": "Software Preservation Group",
+      "websiteType": "",
+      "date": "1979",
+      "shortTitle": "",
+      "url": "http://www.softwarepreservation.org/projects/LISP/interlisp/tenex/sumex-aim/new-lisp-messages.txt.1/view",
+      "accessDate": "2021-04-23T17:51:42Z",
+      "language": "",
+      "rights": "",
+      "extra": "",
+      "tags": [
+        {
+          "tag": "sz"
+        }
+      ],
+      "collections": [
+        "TVX6WEZX"
+      ],
+      "relations": {
+        "dc:replaces": [
+          "http://zotero.org/groups/2914042/items/7XZP5C7W",
+          "http://zotero.org/groups/2914042/items/47AC2GGA"
+        ]
+      },
+      "dateAdded": "2021-04-25T18:13:25Z",
+      "dateModified": "2021-06-02T18:45:08Z"
     },
     {
       "id": "9296070/PE98QZ2L",
@@ -1668,7 +3794,74 @@
             15
           ]
         ]
-      }
+      },
+      "key": "PE98QZ2L",
+      "version": 1969,
+      "itemType": "conferencePaper",
+      "creators": [
+        {
+          "creatorType": "author",
+          "firstName": "Robert F.",
+          "lastName": "Sproull"
+        }
+      ],
+      "abstractNote": "Raster-scan display terminals can significantly improve the quality of interaction with conventional computer systems. The design of a graphics package to provide a “window” into the extensive programming environment of interlisp is presented. Two aspects of the package are described: first, the functional view of display output and interactive input facilities as seen by the programmer, and second, the methods used to link the display terminal to the main computer via a packet-switched computer network. Recommendations are presented for designing operating systems and programming languages so as to simplify attaching display terminals.",
+      "date": "August 1, 1979",
+      "proceedingsTitle": "Proceedings of the 6th annual conference on Computer graphics and interactive techniques",
+      "conferenceName": "",
+      "place": "New York, NY, USA",
+      "volume": "",
+      "pages": "83–93",
+      "series": "SIGGRAPH '79",
+      "language": "",
+      "shortTitle": "",
+      "url": "https://doi.org/10.1145/800249.807428",
+      "accessDate": "2021-04-15",
+      "archive": "",
+      "archiveLocation": "",
+      "libraryCatalog": "ACM Digital Library",
+      "callNumber": "",
+      "rights": "",
+      "extra": "",
+      "tags": [
+        {
+          "tag": "Computer graphics",
+          "type": 1
+        },
+        {
+          "tag": "Computer networks",
+          "type": 1
+        },
+        {
+          "tag": "Frame buffer",
+          "type": 1
+        },
+        {
+          "tag": "Network graphics",
+          "type": 1
+        },
+        {
+          "tag": "Raster-scan display",
+          "type": 1
+        },
+        {
+          "tag": "interlisp"
+        },
+        {
+          "tag": "s2z"
+        }
+      ],
+      "collections": [
+        "MTUXENI8"
+      ],
+      "relations": {
+        "dc:replaces": [
+          "http://zotero.org/groups/2914042/items/536IAF2B",
+          "http://zotero.org/groups/2914042/items/WSNA6G5G"
+        ]
+      },
+      "dateAdded": "2021-04-15T23:18:51Z",
+      "dateModified": "2021-06-03T19:32:34Z"
     },
     {
       "id": "9296070/H5Q65H3M",
@@ -1709,7 +3902,52 @@
             3
           ]
         ]
-      }
+      },
+      "key": "H5Q65H3M",
+      "version": 1977,
+      "itemType": "conferencePaper",
+      "creators": [
+        {
+          "creatorType": "author",
+          "firstName": "Daniel G.",
+          "lastName": "Bobrow"
+        },
+        {
+          "creatorType": "author",
+          "firstName": "L. Peter",
+          "lastName": "Deutsch"
+        }
+      ],
+      "abstractNote": "",
+      "date": "June 1, 1979",
+      "proceedingsTitle": "Proceedings of the International Symposiumon on Symbolic and Algebraic Computation",
+      "conferenceName": "",
+      "place": "Berlin, Heidelberg",
+      "volume": "",
+      "pages": "481–489",
+      "series": "EUROSAM '79",
+      "language": "",
+      "DOI": "",
+      "shortTitle": "",
+      "url": "https://dl.acm.org/doi/10.5555/646670.699000",
+      "accessDate": "2021-06-03",
+      "archive": "",
+      "archiveLocation": "",
+      "libraryCatalog": "ACM Digital Library",
+      "callNumber": "",
+      "rights": "",
+      "extra": "",
+      "tags": [
+        {
+          "tag": "sz"
+        }
+      ],
+      "collections": [
+        "3CNYFDHF"
+      ],
+      "relations": {},
+      "dateAdded": "2021-06-03T19:09:59Z",
+      "dateModified": "2021-06-03T19:10:26Z"
     },
     {
       "id": "9296070/KR9MIHRU",
@@ -1746,7 +3984,51 @@
             14
           ]
         ]
-      }
+      },
+      "key": "KR9MIHRU",
+      "version": 2875,
+      "itemType": "report",
+      "creators": [
+        {
+          "creatorType": "author",
+          "firstName": "Robert F.",
+          "lastName": "Sproull"
+        }
+      ],
+      "abstractNote": "Raster-scan display terminals can significantly imrpove the quality of interaction with conventional computer systems. the design of a graphics package to provide a \"window\" into the extensive programming environment of Interlisp is presented. Two aspects of the package are described: first, the functional view of display output and interactive input facilities as seen by the programmer, and second, the methods used to link the display terminal to the main computer via a packet-switched computer network. Recommendations are presented for designing operating systems and programming languages so as to simplifly attaching display terminals. An appendix contains detailed documentation of the graphics package.",
+      "reportNumber": "N/A",
+      "reportType": "N/A",
+      "seriesTitle": "",
+      "place": "6th Annual Conference on Computer Graphics and Interacive Techniques",
+      "institution": "Xerox Palo Alto Research Center",
+      "date": "June 1979",
+      "pages": "36",
+      "shortTitle": "",
+      "url": "http://bitsavers.trailing-edge.com/pdf/xerox/parc/techReports/CSL-79-6_Raster_Graphics_for_Interactive_Programming_Environments.pdf",
+      "accessDate": "2022-06-14",
+      "archive": "",
+      "archiveLocation": "",
+      "libraryCatalog": "Zotero",
+      "callNumber": "",
+      "rights": "",
+      "extra": "",
+      "tags": [
+        {
+          "tag": "DLISP"
+        },
+        {
+          "tag": "Interlisp-D"
+        },
+        {
+          "tag": "Reviewed by SHFT - CSUCI (Ron Vincent A.)"
+        }
+      ],
+      "collections": [
+        "3CNYFDHF"
+      ],
+      "relations": {},
+      "dateAdded": "2023-04-28T05:42:34Z",
+      "dateModified": "2023-05-05T14:46:32Z"
     },
     {
       "id": "9296070/IZ6P44N3",
@@ -1784,7 +4066,48 @@
             31
           ]
         ]
-      }
+      },
+      "key": "IZ6P44N3",
+      "version": 1984,
+      "itemType": "journalArticle",
+      "creators": [
+        {
+          "creatorType": "author",
+          "firstName": "Warren",
+          "lastName": "Teitelman"
+        }
+      ],
+      "abstractNote": "This paper continues and extends previous work by the author in developing systems which provide the user with various forms of explicit and implicit assistance, and in general co-operate with the user in the development of his programs. The system described in this paper makes extensive use of a bit map display and pointing device (a mouse) to significantly enrich the user's interactions with the system, and to provide capabilities not possible with terminals that essentially emulate hard copy devices. For example, any text that is displayed on the screen can be pointed at and treated as input, exactly as though it were typed, i.e. the user can say use this expression or that value, and then simply point. The user views his programming environment through a collection of display windows, each of which corresponds to a different task or context. The user can manipulate the windows, or the contents of a particular window, by a combination of keyboard inputs or pointing operations. The technique of using different windows for different tasks makes it easy for the user to manage several simultaneous tasks and contexts, e.g. defining programs, testing programs, editing, asking the system for assistance, sending and receiving messages, etc. and to switch back and forth between these tasks at his convenience.",
+      "publicationTitle": "International Journal of Man-Machine Studies",
+      "pages": "157-187",
+      "date": "March 1, 1979",
+      "series": "",
+      "seriesTitle": "",
+      "seriesText": "",
+      "ISSN": "0020-7373",
+      "shortTitle": "",
+      "url": "https://www.sciencedirect.com/science/article/pii/S0020737379800152",
+      "accessDate": "2021-05-31T17:24:59Z",
+      "archive": "",
+      "archiveLocation": "",
+      "libraryCatalog": "ScienceDirect",
+      "callNumber": "",
+      "rights": "",
+      "extra": "",
+      "tags": [
+        {
+          "tag": "interlisp"
+        },
+        {
+          "tag": "s2z"
+        }
+      ],
+      "collections": [
+        "3CNYFDHF"
+      ],
+      "relations": {},
+      "dateAdded": "2021-05-31T17:24:59Z",
+      "dateModified": "2021-05-31T18:39:51Z"
     },
     {
       "id": "9296070/59BVIIF8",
@@ -1806,7 +4129,49 @@
             3
           ]
         ]
-      }
+      },
+      "key": "59BVIIF8",
+      "version": 2253,
+      "itemType": "report",
+      "creators": [
+        {
+          "creatorType": "author",
+          "firstName": "J. Strother",
+          "lastName": "Moore"
+        }
+      ],
+      "abstractNote": "The INTERLISP Virtual Machine is the environment in which the INTERLISP System is implemented. It includes such abstract objects as ~Literal Atom s~. List CelIs~, ‘Integers. etc.. the basic LISP functions for manipulating them, the underlying program control, and variable binding mechanisms. the input/output facilities, and interrupt processing facilities. In order to implement the INTERLISP System (as described in The INTERLISP Reference Manual by W. Teitelman. et. al.) on some physical machine, it is only necessary to implement the INTERLISP Virtual Machine. since Virtual Machine compatible source code for the rest of the INTERLISP System can be obtained from publicly available files. This document specifies the behavior of the INTERLISP Virtual Machine from the implementor s point of view. That is. it is an attempt to make explicit those things that must be implemented to allow the INTERLISP System to run on some machine.",
+      "reportNumber": "",
+      "reportType": "",
+      "seriesTitle": "",
+      "place": "",
+      "institution": "",
+      "date": "March 1979",
+      "pages": "126",
+      "language": "",
+      "shortTitle": "",
+      "url": "http://www.cs.utexas.edu/~moore/publications/interlisp-vm.pdf",
+      "accessDate": "",
+      "archive": "",
+      "archiveLocation": "",
+      "libraryCatalog": "CiteSeer",
+      "callNumber": "",
+      "rights": "",
+      "extra": "",
+      "tags": [
+        {
+          "tag": "interlisp"
+        },
+        {
+          "tag": "s2z"
+        }
+      ],
+      "collections": [
+        "TVX6WEZX"
+      ],
+      "relations": {},
+      "dateAdded": "2021-05-31T19:01:10Z",
+      "dateModified": "2021-08-27T23:53:35Z"
     },
     {
       "id": "9296070/BSE5UV9A",
@@ -1847,7 +4212,53 @@
             21
           ]
         ]
-      }
+      },
+      "key": "BSE5UV9A",
+      "version": 1332,
+      "itemType": "journalArticle",
+      "creators": [
+        {
+          "creatorType": "author",
+          "firstName": "Daniel G.",
+          "lastName": "Bobrow"
+        },
+        {
+          "creatorType": "author",
+          "firstName": "Douglas W.",
+          "lastName": "Clark"
+        }
+      ],
+      "abstractNote": "List structures provide a general mechanism for representing easily changed structured data, but can introduce inefficiencies in the use of space when fields of uniform size are used to contain pointers to data and to link the structure. Empirically determined regularity can be exploited to provide more space-efficient encodings without losing the flexibility inherent in list structures. The basic scheme is to provide compact pointer fields big enough to accommodate most values that occur in them and to provide “escape” mechanisms for exceptional cases. Several examples of encoding designs are presented and evaluated, including two designs currently used in Lisp machines. Alternative escape mechanisms are described, and various questions of cost and implementation are discussed. In order to extrapolate our results to larger systems than those measured, we propose a model for the generation of list pointers and we test the model against data from two programs. We show that according to our model, list structures with compact cdr fields will, as address space grows, continue to be compacted well with a fixed-width small field. Our conclusion is that with a microcodable processor, about a factor of two gain in space efficiency for list structure can be had for little or no cost in processing time.",
+      "publicationTitle": "ACM Transactions on Programming Languages and Systems",
+      "pages": "266-286",
+      "date": "October 1979",
+      "series": "",
+      "seriesTitle": "",
+      "seriesText": "",
+      "ISSN": "0164-0925, 1558-4593",
+      "shortTitle": "",
+      "url": "https://dl.acm.org/doi/10.1145/357073.357081",
+      "accessDate": "2021-04-21T14:42:31Z",
+      "archive": "",
+      "archiveLocation": "",
+      "libraryCatalog": "DOI.org (Crossref)",
+      "callNumber": "",
+      "rights": "",
+      "extra": "",
+      "tags": [
+        {
+          "tag": "Interlisp-D"
+        },
+        {
+          "tag": "s2z"
+        }
+      ],
+      "collections": [
+        "TVX6WEZX"
+      ],
+      "relations": {},
+      "dateAdded": "2021-04-25T21:00:12Z",
+      "dateModified": "2021-05-31T18:25:51Z"
     }
   ],
   "1980": [
@@ -1873,40 +4284,50 @@
             1980
           ]
         ]
-      }
-    },
-    {
-      "id": "9296070/RV6K2EVG",
-      "type": "thesis",
-      "title": "The interlisp virtual machine: study of its design and its implementation as multilisp",
-      "publisher": "University of British Columbia",
-      "abstract": "Abstract machine definitions have been recognized as convenient and powerful tools for enhancing software portability. One such machine, the Inter lisp Virtual Machine, is examined in this thesis. We present the Multilisp System as an implementation of the Virtual Machine and discuss some of the design criteria and difficulties encountered in mapping the Virtual Machine onto a particular environment. On the basis of our experience with Multilisp we indicate several weaknesses of the Virtual Machine which impair its adequacy as a basis for a portable Interlisp System.",
-      "URL": "https://open.library.ubc.ca/cIRcle/collections/ubctheses/831/items/1.0051801",
-      "note": "DOI: 10.14288/1.0051801",
-      "shortTitle": "The interlisp virtual machine",
-      "language": "eng",
-      "author": [
+      },
+      "key": "6IR4DI6L",
+      "version": 2236,
+      "itemType": "conferencePaper",
+      "creators": [
         {
-          "family": "Koomen",
-          "given": "Johannes A. G. M."
+          "creatorType": "author",
+          "firstName": "Ronald M.",
+          "lastName": "Kaplan"
+        },
+        {
+          "creatorType": "author",
+          "firstName": "B. A.",
+          "lastName": "Sheil"
         }
       ],
-      "issued": {
-        "date-parts": [
-          [
-            1980
-          ]
-        ]
-      },
-      "accessed": {
-        "date-parts": [
-          [
-            2021,
-            6,
-            2
-          ]
-        ]
-      }
+      "abstractNote": "",
+      "date": "1980",
+      "proceedingsTitle": "IFIP Congress",
+      "conferenceName": "",
+      "place": "",
+      "publisher": "",
+      "volume": "",
+      "pages": "355–360",
+      "series": "",
+      "language": "",
+      "DOI": "",
+      "ISBN": "",
+      "shortTitle": "",
+      "url": "",
+      "accessDate": "",
+      "archive": "",
+      "archiveLocation": "",
+      "libraryCatalog": "Google Scholar",
+      "callNumber": "",
+      "rights": "",
+      "extra": "",
+      "tags": [],
+      "collections": [
+        "TVX6WEZX"
+      ],
+      "relations": {},
+      "dateAdded": "2021-08-24T03:41:17Z",
+      "dateModified": "2021-08-24T03:41:17Z"
     },
     {
       "id": "9296070/IWAVJBR2",
@@ -1941,7 +4362,116 @@
             18
           ]
         ]
-      }
+      },
+      "key": "IWAVJBR2",
+      "version": 1957,
+      "itemType": "thesis",
+      "creators": [
+        {
+          "creatorType": "author",
+          "firstName": "Larry Melvin",
+          "lastName": "Masinter"
+        }
+      ],
+      "abstractNote": "This disscrttion dcscribes a programming tool. implemented in Lisp. callcd SCOPE. The basic\nidea behind ScoPE can be stated simply: SCOPE analyzes a user's programs. rcmembers what it\nsees. is able to answer questions based on the facts it remembers. and is able to incrcmentay\nupdate thc data basc when a picce of thc program changes. A varicty of program infonnation\nis available about cross rcfcrences. data flow and program organi7.aticil. Facts about programs\nare stored in a data bas: to answer a question. SCOPE rctrieves and makes inferences basd on\ninfonnation in the data base. SCOPE is interactive because it keeps track of which par of the\nprograms have changed during the course of an editing and debugging sesion. and is able to\nautomatically and incrementally update its data bas. Because SCOPE perfonns whatever re\nanalysis is necesry to answer the question when the question is asked. SCOPE maintans the\nilusion that the data bas is always up to date-ther than the additional wait tie. it is as if\nSCOPE knew the answer al along.\nSCOPE'S foundation is a representauon system in which propertes of pieces of progras ca be\nexpred. The objects of SCOPE'S language are pieces of progrs, and in par.\ndefinitions of symbols-.g.. the definition of a proedure or a data strcture. SCOPE doe not\nmodel propertes of individua statements or expreions in the program: SCOPE knows only\nindividual facts about procedures varables data strctures and other pieces of a progr\nwhich ca be asigned as the definiuon of symbols. The facts are relauons between the name\nof a definiuon and other symbols. For example. one of the relauons that SCOPE keeps trk of\nis Call: Call(FNl'FNil holds if the definiùon whose nae is FNi contans a ca to a\nprocedure named FNi\"\nSCOPE has two interfaces: one to the user and one to other progras. The user interface is an\nEnglish-like command language which allows for a unifonn command strcture and convenient\ndefaults: the most frequently used commands are the easiest to type. All of the power avaiable\nwith the command language is accesible Jirough the progra interface as well. The\ncompiler and varouš other uulities use the progra interf~\"",
+      "thesisType": "Doctor of Philosophy",
+      "university": "PALO ALTO RESEARCH CENTER",
+      "place": "3333 Coyote Hil Road I Palo Alto I Caliornia 94304",
+      "date": "1980",
+      "numPages": "114",
+      "shortTitle": "",
+      "url": "https://larrymasinter.net/thesis.pdf",
+      "accessDate": "2021-04-18T01:14:36Z",
+      "archive": "",
+      "archiveLocation": "",
+      "libraryCatalog": "",
+      "callNumber": "",
+      "rights": "",
+      "extra": "",
+      "tags": [
+        {
+          "tag": "sz"
+        }
+      ],
+      "collections": [
+        "TVX6WEZX"
+      ],
+      "relations": {
+        "dc:replaces": [
+          "http://zotero.org/groups/2914042/items/RP8DVUVU",
+          "http://zotero.org/groups/2914042/items/96BFDTPT"
+        ]
+      },
+      "dateAdded": "2021-04-25T18:13:25Z",
+      "dateModified": "2021-05-31T10:21:50Z"
+    },
+    {
+      "id": "9296070/RV6K2EVG",
+      "type": "thesis",
+      "title": "The interlisp virtual machine: study of its design and its implementation as multilisp",
+      "publisher": "University of British Columbia",
+      "abstract": "Abstract machine definitions have been recognized as convenient and powerful tools for enhancing software portability. One such machine, the Inter lisp Virtual Machine, is examined in this thesis. We present the Multilisp System as an implementation of the Virtual Machine and discuss some of the design criteria and difficulties encountered in mapping the Virtual Machine onto a particular environment. On the basis of our experience with Multilisp we indicate several weaknesses of the Virtual Machine which impair its adequacy as a basis for a portable Interlisp System.",
+      "URL": "https://open.library.ubc.ca/cIRcle/collections/ubctheses/831/items/1.0051801",
+      "note": "DOI: 10.14288/1.0051801",
+      "shortTitle": "The interlisp virtual machine",
+      "language": "eng",
+      "author": [
+        {
+          "family": "Koomen",
+          "given": "Johannes A. G. M."
+        }
+      ],
+      "issued": {
+        "date-parts": [
+          [
+            1980
+          ]
+        ]
+      },
+      "accessed": {
+        "date-parts": [
+          [
+            2021,
+            6,
+            2
+          ]
+        ]
+      },
+      "key": "RV6K2EVG",
+      "version": 2164,
+      "itemType": "thesis",
+      "creators": [
+        {
+          "creatorType": "author",
+          "firstName": "Johannes A. G. M.",
+          "lastName": "Koomen"
+        }
+      ],
+      "abstractNote": "Abstract machine definitions have been recognized as convenient and powerful tools for enhancing software portability. One such machine, the Inter lisp Virtual Machine, is examined in this thesis. We present the Multilisp System as an implementation of the Virtual Machine and discuss some of the design criteria and difficulties encountered in mapping the Virtual Machine onto a particular environment. On the basis of our experience with Multilisp we indicate several weaknesses of the Virtual Machine which impair its adequacy as a basis for a portable Interlisp System.",
+      "thesisType": "",
+      "university": "University of British Columbia",
+      "place": "",
+      "date": "1980",
+      "numPages": "",
+      "url": "https://open.library.ubc.ca/cIRcle/collections/ubctheses/831/items/1.0051801",
+      "accessDate": "2021-06-02T17:17:08Z",
+      "archive": "",
+      "archiveLocation": "",
+      "libraryCatalog": "open.library.ubc.ca",
+      "callNumber": "",
+      "rights": "",
+      "extra": "DOI: 10.14288/1.0051801",
+      "tags": [
+        {
+          "tag": "sz"
+        }
+      ],
+      "collections": [
+        "TVX6WEZX"
+      ],
+      "relations": {},
+      "dateAdded": "2021-06-02T17:17:08Z",
+      "dateModified": "2021-07-26T02:34:45Z"
     },
     {
       "id": "9296070/4EDHAKDB",
@@ -1984,7 +4514,53 @@
             26
           ]
         ]
-      }
+      },
+      "key": "4EDHAKDB",
+      "version": 2064,
+      "itemType": "conferencePaper",
+      "creators": [
+        {
+          "creatorType": "author",
+          "firstName": "Larry M.",
+          "lastName": "Masinter"
+        },
+        {
+          "creatorType": "author",
+          "firstName": "L. Peter",
+          "lastName": "Deutsch"
+        }
+      ],
+      "abstractNote": "We describe the local optimization phase of a compiler for translating the INTERLISP dialect of LISP into stack-architecture (0-address) instruction sets. We discuss the general organization of the compiler, and then describe the set of optimization techniques found most useful, based on empirical results gathered by compiling a large set of programs. The compiler and optimization phase are machine independent, in that they generate a stream of instructions for an abstract stack machine, which an assembler subsequently turns into the actual machine instructions. The compiler has been in successful use for several years, producing code for two different instruction sets.",
+      "date": "August 25, 1980",
+      "proceedingsTitle": "Proceedings of the 1980 ACM conference on LISP and functional programming",
+      "conferenceName": "",
+      "place": "New York, NY, USA",
+      "volume": "",
+      "pages": "223–230",
+      "series": "LFP '80",
+      "language": "",
+      "shortTitle": "",
+      "url": "https://doi.org/10.1145/800087.802810",
+      "accessDate": "2021-04-26",
+      "archive": "",
+      "archiveLocation": "",
+      "libraryCatalog": "ACM Digital Library",
+      "callNumber": "",
+      "rights": "",
+      "extra": "",
+      "tags": [
+        {
+          "tag": "Interlisp-D"
+        }
+      ],
+      "collections": [
+        "3CNYFDHF"
+      ],
+      "relations": {
+        "dc:replaces": "http://zotero.org/groups/2914042/items/9BS48CMP"
+      },
+      "dateAdded": "2021-04-25T21:00:13Z",
+      "dateModified": "2021-06-14T02:24:24Z"
     },
     {
       "id": "9296070/8SMP58AA",
@@ -2023,7 +4599,49 @@
             31
           ]
         ]
-      }
+      },
+      "key": "8SMP58AA",
+      "version": 1962,
+      "itemType": "conferencePaper",
+      "creators": [
+        {
+          "creatorType": "author",
+          "firstName": "L. Peter",
+          "lastName": "Deutsch"
+        }
+      ],
+      "abstractNote": "This paper describes in detail the most interesting aspects of ByteLisp, a transportable Lisp system architecture which implements the Interlisp dialect of Lisp, and its first implementation, on a microprogrammed minicomputer called the Alto. Two forthcoming related papers will deal with general questions of Lisp machine and system architecture, and detailed measurements of the Alto ByteLisp system described here. A highly condensed summary of the series was published at MICRO-11 in November 197815.",
+      "date": "August 25, 1980",
+      "proceedingsTitle": "Proceedings of the 1980 ACM conference on LISP and functional programming",
+      "conferenceName": "",
+      "place": "New York, NY, USA",
+      "volume": "",
+      "pages": "231–242",
+      "series": "LFP '80",
+      "language": "",
+      "shortTitle": "",
+      "url": "https://doi.org/10.1145/800087.802811",
+      "accessDate": "2021-05-31",
+      "archive": "",
+      "archiveLocation": "",
+      "libraryCatalog": "ACM Digital Library",
+      "callNumber": "",
+      "rights": "",
+      "extra": "",
+      "tags": [
+        {
+          "tag": "Interlisp-D"
+        },
+        {
+          "tag": "s2z"
+        }
+      ],
+      "collections": [
+        "3CNYFDHF"
+      ],
+      "relations": {},
+      "dateAdded": "2021-05-31T14:55:59Z",
+      "dateModified": "2021-05-31T18:25:11Z"
     },
     {
       "id": "9296070/WPDGQV37",
@@ -2082,7 +4700,94 @@
             25
           ]
         ]
-      }
+      },
+      "key": "WPDGQV37",
+      "version": 1330,
+      "itemType": "conferencePaper",
+      "creators": [
+        {
+          "creatorType": "author",
+          "firstName": "Richard R.",
+          "lastName": "Burton"
+        },
+        {
+          "creatorType": "author",
+          "firstName": "L. M.",
+          "lastName": "Masinter"
+        },
+        {
+          "creatorType": "author",
+          "firstName": "Daniel G.",
+          "lastName": "Bobrow"
+        },
+        {
+          "creatorType": "author",
+          "firstName": "Willie Sue",
+          "lastName": "Haugeland"
+        },
+        {
+          "creatorType": "author",
+          "firstName": "Ronald M.",
+          "lastName": "Kaplan"
+        },
+        {
+          "creatorType": "author",
+          "firstName": "B. A.",
+          "lastName": "Sheil"
+        }
+      ],
+      "abstractNote": "DoradoLisp is an implementation of the Interlisp programming system on a large personal computer. It has evolved from AltoLisp, an implementation on a less powerful machine. The major goal of the Dorado implementation was to eliminate the performance deficiencies of the previous system. This paper describes the current status of the system and discusses some of the issues that arose during its implementation. Among the techniques that helped us meet our performance goal were transferring much of the kernel software into Lisp, intensive use of performance measurement tools to determine the areas of worst performance, and use of the Interlisp programming environment to allow rapid and widespread improvements to the system code. The paper lists some areas in which performance was critical and offers some observations on how our experience might be useful to other implementations of Interlisp.",
+      "date": "August 25, 1980",
+      "proceedingsTitle": "Proceedings of the 1980 ACM conference on LISP and functional programming",
+      "conferenceName": "",
+      "place": "New York, NY, USA",
+      "volume": "",
+      "pages": "243-247",
+      "series": "LFP '80",
+      "language": "",
+      "shortTitle": "",
+      "url": "https://doi.org/10.1145/800087.802812",
+      "accessDate": "2021-04-25",
+      "archive": "",
+      "archiveLocation": "",
+      "libraryCatalog": "ACM Digital Library",
+      "callNumber": "",
+      "rights": "",
+      "extra": "",
+      "tags": [
+        {
+          "tag": "Interlisp-D"
+        },
+        {
+          "tag": "s2z"
+        }
+      ],
+      "collections": [
+        "3CNYFDHF"
+      ],
+      "relations": {
+        "dc:replaces": [
+          "http://zotero.org/groups/2914042/items/RPCJEWWW",
+          "http://zotero.org/groups/2914042/items/VM7HNYEQ",
+          "http://zotero.org/groups/2914042/items/XDWXH6E5",
+          "http://zotero.org/groups/2914042/items/XPSERCHW",
+          "http://zotero.org/groups/2914042/items/2G7DCQ6H",
+          "http://zotero.org/groups/2914042/items/3D6N2IRZ",
+          "http://zotero.org/groups/2914042/items/49J73NSV",
+          "http://zotero.org/groups/2914042/items/9LZV9XQ8",
+          "http://zotero.org/groups/2914042/items/ACGFJVHK",
+          "http://zotero.org/groups/2914042/items/AU9LGDLG",
+          "http://zotero.org/groups/2914042/items/BP4THIN8",
+          "http://zotero.org/groups/2914042/items/FNKFL6XC",
+          "http://zotero.org/groups/2914042/items/HXHAY3Q6",
+          "http://zotero.org/groups/2914042/items/IVFAJYSW",
+          "http://zotero.org/groups/2914042/items/PYPKSCT4",
+          "http://zotero.org/groups/2914042/items/QSZ2FPL4",
+          "http://zotero.org/groups/2914042/items/VPSPRKDC"
+        ]
+      },
+      "dateAdded": "2021-04-15T23:18:51Z",
+      "dateModified": "2021-05-31T18:24:55Z"
     },
     {
       "id": "9296070/L6DXES8K",
@@ -2122,7 +4827,52 @@
             25
           ]
         ]
-      }
+      },
+      "key": "L6DXES8K",
+      "version": 1683,
+      "itemType": "journalArticle",
+      "creators": [
+        {
+          "creatorType": "author",
+          "firstName": "Ronald J.",
+          "lastName": "Brachman"
+        },
+        {
+          "creatorType": "author",
+          "firstName": "Brian C.",
+          "lastName": "Smith"
+        }
+      ],
+      "abstractNote": "In the fall of 1978 we decided to produce a special issue of the SIGART Newsletter devoted to a survey of current knowledge representation research. We felt that there were twe useful functions such an issue could serve. First, we hoped to elicit a clear picture of how people working in this subdiscipline understand knowledge representation research, to illuminate the issues on which current research is focused, and to catalogue what approaches and techniques are currently being developed. Second -- and this is why we envisaged the issue as a survey of many different groups and projects -- we wanted to provide a document that would enable the reader to acquire at least an approximate sense of how each of the many different research endesvours around the world fit into the field as a whole.It would of course be impossible to produce a final or definitive document accomplishing these goals: rather, we hoped that this survey could initiate a continuing dialogue on issues in representation, a project for which this newsletter seems the ideal forum. It has been many months since our original decision was made, but we are finally able to present the results of that survey. Perhaps more than anything else, it has emerged as a testament to an astounding range and variety of opinions held by many different people in many different places.The following few pages are intended as an introduction to the survey as a whole, and to this issue of the newsletter. We will briefly summarize the form that the survey took, discuss the strategies we followed in analyzing and tabulating responses, briefly review the overall sense we received from the answers that were submitted, and discuss various criticisms which were submitted along with the responses. The remainder of the volume has been designed to be roughly self-explanatory at each point, so that one may dip into it at different places at will. Certain conventions, however, particularly regarding indexing and tabulating, will also be explained in the remainder of this introduction.As editors, we are enormously grateful to the many people who devoted substantial effort to responding to our survey. It is our hope that the material presented here will be interesting and helpful to our readers, and that fruitful discussion of these and other issues will continue energetically and enthusiastically into the future.",
+      "publicationTitle": "ACM SIGART Bulletin",
+      "volume": "",
+      "pages": "1-138",
+      "date": "February 1, 1980",
+      "series": "",
+      "seriesTitle": "",
+      "seriesText": "",
+      "language": "",
+      "ISSN": "0163-5719",
+      "shortTitle": "",
+      "url": "https://doi.org/10.1145/1056751.1056752",
+      "accessDate": "2021-04-25T15:51:14Z",
+      "archive": "",
+      "archiveLocation": "",
+      "libraryCatalog": "February 1980",
+      "callNumber": "",
+      "rights": "",
+      "extra": "",
+      "tags": [
+        {
+          "tag": "sz"
+        }
+      ],
+      "collections": [
+        "MTUXENI8"
+      ],
+      "relations": {},
+      "dateAdded": "2021-04-25T19:54:39Z",
+      "dateModified": "2021-06-02T17:52:16Z"
     },
     {
       "id": "9296070/9B3ESHMP",
@@ -2173,7 +4923,84 @@
             9
           ]
         ]
-      }
+      },
+      "key": "9B3ESHMP",
+      "version": 1726,
+      "itemType": "report",
+      "creators": [
+        {
+          "creatorType": "author",
+          "firstName": "Richard R.",
+          "lastName": "Burton"
+        },
+        {
+          "creatorType": "author",
+          "firstName": "Ronald M.",
+          "lastName": "Kaplan"
+        },
+        {
+          "creatorType": "author",
+          "firstName": "B.",
+          "lastName": "Masinter"
+        },
+        {
+          "creatorType": "author",
+          "firstName": "B. A.",
+          "lastName": "Sheil"
+        },
+        {
+          "creatorType": "author",
+          "firstName": "A.",
+          "lastName": "Bell"
+        },
+        {
+          "creatorType": "author",
+          "firstName": "D. G.",
+          "lastName": "Bobrow"
+        },
+        {
+          "creatorType": "author",
+          "firstName": "L. P.",
+          "lastName": "Deutsch"
+        },
+        {
+          "creatorType": "author",
+          "firstName": "W. S.",
+          "lastName": "Haugeland"
+        }
+      ],
+      "abstractNote": "This report consists of five papers on Interlisp-0, a refinement and implementation of the\nI[ tnterlisp virtual machine [Moore, 761 which supports the interlisp programming system\n[Teitelman et at., 781 on the Dolphin and Dorado personal computers",
+      "reportNumber": "",
+      "reportType": "",
+      "seriesTitle": "COGNITIVE AND INSTRUCTIONAL SCIENCES SERIES CIS.5 (SSL-80-4",
+      "place": "",
+      "institution": "",
+      "date": "September 1980",
+      "pages": "52",
+      "language": "",
+      "shortTitle": "",
+      "url": "http://www.softwarepreservation.net/projects/LISP/interlisp-d/Papers_On_Interlisp-D.pdf",
+      "accessDate": "",
+      "archive": "",
+      "archiveLocation": "",
+      "libraryCatalog": "Google Scholar",
+      "callNumber": "",
+      "rights": "",
+      "extra": "",
+      "tags": [
+        {
+          "tag": "Interlisp-D"
+        },
+        {
+          "tag": "s2z"
+        }
+      ],
+      "collections": [
+        "3CNYFDHF"
+      ],
+      "relations": {},
+      "dateAdded": "2021-04-22T03:48:38Z",
+      "dateModified": "2021-06-02T18:38:25Z"
     }
   ],
   "1981": [
@@ -2199,7 +5026,46 @@
             1981
           ]
         ]
-      }
+      },
+      "key": "THYZ7UPH",
+      "version": 1792,
+      "itemType": "report",
+      "creators": [
+        {
+          "creatorType": "author",
+          "firstName": "J. Strother",
+          "lastName": "Moore"
+        }
+      ],
+      "abstractNote": "The TXDT package is a collection of INTERLISP programs designed for those who wish to build text editors in INTERLISP. TXDT provides a new INTERLISP data type, called a buffer, and programs for efficiently inserting, deleting, searching and manipulating text in buffers. Modifications may be made undoable. A unique feature of TXDT is that an address may be \"stuck\" to a character occurrence so as to follow that character wherever it Is subsequently moved. TXDT also has provisions for fonts.",
+      "reportNumber": "",
+      "reportType": "",
+      "seriesTitle": "",
+      "place": "California",
+      "institution": "Xerox. Palo Alto Research Center",
+      "date": "1981",
+      "pages": "34",
+      "language": "",
+      "shortTitle": "",
+      "url": "http://129.69.211.95/pdf/xerox/parc/techReports/CSL-81-2_The_TXDT_Package.pdf",
+      "accessDate": "",
+      "archive": "",
+      "archiveLocation": "",
+      "libraryCatalog": "Google Scholar",
+      "callNumber": "",
+      "rights": "",
+      "extra": "",
+      "tags": [
+        {
+          "tag": "sz"
+        }
+      ],
+      "collections": [
+        "MTUXENI8"
+      ],
+      "relations": {},
+      "dateAdded": "2021-04-25T19:54:45Z",
+      "dateModified": "2021-06-01T16:08:16Z"
     },
     {
       "id": "9296070/A94JY5AD",
@@ -2247,7 +5113,74 @@
             1
           ]
         ]
-      }
+      },
+      "key": "A94JY5AD",
+      "version": 2374,
+      "itemType": "conferencePaper",
+      "creators": [
+        {
+          "creatorType": "author",
+          "firstName": "Randall",
+          "lastName": "Davis"
+        },
+        {
+          "creatorType": "author",
+          "firstName": "Howard",
+          "lastName": "Austin"
+        },
+        {
+          "creatorType": "author",
+          "firstName": "Ingrid",
+          "lastName": "Carlbom"
+        },
+        {
+          "creatorType": "author",
+          "firstName": "Bud",
+          "lastName": "Frawley"
+        },
+        {
+          "creatorType": "author",
+          "firstName": "Paul",
+          "lastName": "Pruchnik"
+        },
+        {
+          "creatorType": "author",
+          "firstName": "Rich",
+          "lastName": "Sneiderman"
+        },
+        {
+          "creatorType": "author",
+          "firstName": "J.",
+          "lastName": "Gilreath"
+        }
+      ],
+      "abstractNote": "The DIPMETER ADVISOR program is an application of Al and Expert System techniques to the problem of inferring subsurface geologic structure. It synthesizes techniques developed in two previous lines of work, rulte-based systems and signal understanding programs. This report on the prototype system has four main concerns. First, we describe the task and characterize the various bodies of knowledge required. Second, we describe the design of the system we have built and the level of performance it has currently reached. Third, we use this task as a case study and examine it in the light of other, related efforts, showing how particular characteristics of this problem have dictated a number of design decisions. We consider the character of the interpretation hypotheses generated and the sources of the expertise involved. Finally, we discuss future directions of this early effort. We describe the problem of \"shallow knowledge\" in expert systems and explain why this task appears to provide an attractive setting for exploring the use of deeper models.",
+      "date": "1981-01-01",
+      "proceedingsTitle": "",
+      "conferenceName": "[No source information available]",
+      "place": "",
+      "publisher": "",
+      "volume": "",
+      "pages": "846-849",
+      "series": "",
+      "language": "",
+      "DOI": "",
+      "ISBN": "",
+      "url": "",
+      "accessDate": "",
+      "archive": "",
+      "archiveLocation": "",
+      "libraryCatalog": "ResearchGate",
+      "callNumber": "",
+      "rights": "",
+      "extra": "",
+      "tags": [],
+      "collections": [
+        "MTUXENI8"
+      ],
+      "relations": {},
+      "dateAdded": "2022-06-27T01:46:53Z",
+      "dateModified": "2022-06-27T01:46:53Z"
     },
     {
       "id": "9296070/7T3AV4PM",
@@ -2289,7 +5222,51 @@
             5
           ]
         ]
-      }
+      },
+      "key": "7T3AV4PM",
+      "version": 2066,
+      "itemType": "journalArticle",
+      "creators": [
+        {
+          "creatorType": "author",
+          "firstName": "W.",
+          "lastName": "Teitelman"
+        },
+        {
+          "creatorType": "author",
+          "firstName": "L.",
+          "lastName": "Masinter"
+        }
+      ],
+      "abstractNote": "Integration, extensibility, and ease of modification made Interlisp unique and powerful. Its adaptations will enhance the power of the coming world of personal computing and advanced displays.",
+      "publicationTitle": "Computer",
+      "pages": "25-33",
+      "date": "1981/04/01",
+      "series": "",
+      "seriesTitle": "",
+      "seriesText": "",
+      "journalAbbreviation": "",
+      "ISSN": "0018-9162",
+      "shortTitle": "",
+      "url": "https://www.computer.org/csdl/magazine/co/1981/04/01667317/13rRUyv53Ic",
+      "accessDate": "2021-05-05T15:43:12Z",
+      "archive": "",
+      "archiveLocation": "",
+      "libraryCatalog": "www.computer.org",
+      "callNumber": "",
+      "rights": "",
+      "extra": "Publisher: IEEE Computer Society",
+      "tags": [
+        {
+          "tag": "interlisp"
+        }
+      ],
+      "collections": [
+        "TVX6WEZX"
+      ],
+      "relations": {},
+      "dateAdded": "2021-05-05T15:43:12Z",
+      "dateModified": "2021-06-14T02:25:22Z"
     },
     {
       "id": "9296070/6BCFJ639",
@@ -2324,7 +5301,51 @@
             23
           ]
         ]
-      }
+      },
+      "key": "6BCFJ639",
+      "version": 2533,
+      "itemType": "report",
+      "creators": [
+        {
+          "creatorType": "author",
+          "firstName": "Larry M.",
+          "lastName": "Masinter"
+        }
+      ],
+      "abstractNote": "",
+      "reportNumber": "SUN-CS-81-879",
+      "reportType": "",
+      "seriesTitle": "",
+      "place": "Stanford University Stanford, CA 94305",
+      "institution": "Department of Computer Science, Stanford University",
+      "date": "August 1,1981",
+      "pages": "13",
+      "language": "",
+      "shortTitle": "",
+      "url": "http://www.softwarepreservation.org/projects/LISP/interlisp/Interlisp-VAX_A_Report.pdf/view",
+      "accessDate": "2021-04-23T17:32:32Z",
+      "archive": "",
+      "archiveLocation": "",
+      "libraryCatalog": "",
+      "callNumber": "",
+      "rights": "",
+      "extra": "",
+      "tags": [
+        {
+          "tag": "INTERLISP-VAX"
+        }
+      ],
+      "collections": [
+        "TVX6WEZX"
+      ],
+      "relations": {
+        "dc:replaces": [
+          "http://zotero.org/groups/2914042/items/Q53EEAAL",
+          "http://zotero.org/groups/2914042/items/IVENR923"
+        ]
+      },
+      "dateAdded": "2021-04-25T18:13:25Z",
+      "dateModified": "2022-12-27T21:03:54Z"
     },
     {
       "id": "9296070/W96JCCYH",
@@ -2361,7 +5382,44 @@
             4
           ]
         ]
-      }
+      },
+      "key": "W96JCCYH",
+      "version": 2065,
+      "itemType": "conferencePaper",
+      "creators": [
+        {
+          "creatorType": "author",
+          "firstName": "David R.",
+          "lastName": "Barstow"
+        }
+      ],
+      "abstractNote": "DED is a display-oriented editor that was designed to add the power and convenience of display terminals to INTERLISPs teletype-oriented structure editor. DED divides the display screen into a Prettypnnt Region and an Interaction Region. The Prettypnnt Region gives a prettyprinted view of the structure being edited; the Interaction Region contains the interaction between the user and INTERLISPs standard editor. DEDs prettyprinter allows ellision, and the user may zoom in or out to see the expression being edited with more or less detail. There are several arrow keys which allow the user to change quite easily the locus of attention in certain structural ways, as well as a menu-like facility for common command sequences. Together, these features provide a display-facility that considerably augments INTERLISPs otherwise quite sophisticated user interface.",
+      "date": "August 24, 1981",
+      "proceedingsTitle": "Proceedings of the 7th international joint conference on Artificial intelligence - Volume 2",
+      "conferenceName": "",
+      "place": "San Francisco, CA, USA",
+      "volume": "",
+      "pages": "927–929",
+      "series": "IJCAI'81",
+      "language": "",
+      "DOI": "",
+      "ISBN": "",
+      "shortTitle": "",
+      "url": "https://dl.acm.org/doi/abs/10.5555/1623264.1623329",
+      "accessDate": "2021-05-04",
+      "archive": "",
+      "archiveLocation": "",
+      "libraryCatalog": "ACM Digital Library",
+      "callNumber": "",
+      "rights": "",
+      "extra": "",
+      "tags": [],
+      "collections": [
+        "MTUXENI8"
+      ],
+      "relations": {},
+      "dateAdded": "2021-05-04T22:22:53Z",
+      "dateModified": "2021-06-14T02:24:42Z"
     },
     {
       "id": "9296070/C6TTQVYB",
@@ -2398,7 +5456,51 @@
             15
           ]
         ]
-      }
+      },
+      "key": "C6TTQVYB",
+      "version": 2705,
+      "itemType": "journalArticle",
+      "creators": [
+        {
+          "creatorType": "author",
+          "firstName": "Beau",
+          "lastName": "Sheil"
+        }
+      ],
+      "abstractNote": "The Interslip-D project was formed to develop a personal machine implementation of Interlisp for use as an environment for research in artificial intelligence and cognitive science [Burton et al., 80b]. This note describes the principal developments since our last report almost a year ago [Burton et al., 80a].",
+      "publicationTitle": "ACM SIGART Bulletin",
+      "volume": "",
+      "pages": "31–32",
+      "date": "July 1, 1981",
+      "series": "",
+      "seriesTitle": "",
+      "seriesText": "",
+      "language": "",
+      "ISSN": "0163-5719",
+      "url": "https://doi.org/10.1145/1056743.1056745",
+      "accessDate": "2021-04-15T23:17:52Z",
+      "archive": "",
+      "archiveLocation": "",
+      "libraryCatalog": "July 1981",
+      "callNumber": "",
+      "rights": "",
+      "extra": "",
+      "tags": [
+        {
+          "tag": "Interlisp-D"
+        },
+        {
+          "tag": "s2z"
+        }
+      ],
+      "collections": [
+        "3CNYFDHF"
+      ],
+      "relations": {
+        "dc:replaces": "http://zotero.org/groups/2914042/items/FYL8IT5W"
+      },
+      "dateAdded": "2021-04-15T23:18:51Z",
+      "dateModified": "2023-04-20T02:49:35Z"
     }
   ],
   "1982": [
@@ -2435,7 +5537,47 @@
             1
           ]
         ]
-      }
+      },
+      "key": "RNAZ2XUW",
+      "version": 1976,
+      "itemType": "conferencePaper",
+      "creators": [
+        {
+          "creatorType": "author",
+          "firstName": "Tim",
+          "lastName": "Finin"
+        }
+      ],
+      "abstractNote": "We describe an effort to translate the Interlisp KL-ONE system into Franzlisp to enable it to be run on a VAX . This effort has involved Tim Finin, Richard Duncan and Hassan Ait-Kaci from the University of Pennsylvania, Judy Weiner from Temple University, Jane Barnett from Computer Corporation of America and Jim Schmolze from Bolt Beranek and Newman. The primary motivation for this project was to make a version of KL-ONE available on a PDP 1 1/780 VAX . A VAX Interlisp is not yet available, although one is being written and will soon be available . Currently, the only substantial Lisp for a Vax is the Berkeley FranzLisp system. As a secondary motivation, we are interested in making KL-ONE more available in general - on a variety of Lisp dialects and machines.",
+      "date": "1982/06/01",
+      "proceedingsTitle": "Proceedings of the Second KL-One Workshop",
+      "conferenceName": "",
+      "place": "",
+      "volume": "",
+      "pages": "106-114",
+      "series": "",
+      "DOI": "",
+      "ISBN": "",
+      "shortTitle": "",
+      "url": "https://ebiquity.umbc.edu/paper/html/id/738/Translating-KL-One-from-interlisp-to-Franzlisp",
+      "accessDate": "2021-06-01T16:00:24Z",
+      "archive": "",
+      "archiveLocation": "",
+      "libraryCatalog": "ebiquity.umbc.edu",
+      "callNumber": "",
+      "rights": "",
+      "extra": "",
+      "tags": [
+        {
+          "tag": "sz"
+        }
+      ],
+      "collections": [
+        "MTUXENI8"
+      ],
+      "relations": {},
+      "dateAdded": "2021-06-01T16:00:24Z",
+      "dateModified": "2021-06-03T19:23:29Z"
     },
     {
       "id": "9296070/G4F5FZND",
@@ -2482,7 +5624,58 @@
             16
           ]
         ]
-      }
+      },
+      "key": "G4F5FZND",
+      "version": 2706,
+      "itemType": "conferencePaper",
+      "creators": [
+        {
+          "creatorType": "author",
+          "firstName": "Raymond L.",
+          "lastName": "Bates"
+        },
+        {
+          "creatorType": "author",
+          "firstName": "David",
+          "lastName": "Dyer"
+        },
+        {
+          "creatorType": "author",
+          "firstName": "Johannes A. G. M.",
+          "lastName": "Koomen"
+        }
+      ],
+      "abstractNote": "This paper presents some of the issues involved in implementing Interlisp [19] on a VAX computer [24] with the goal of producing a version that runs under UNIX[17], specifically Berkeley VM/UNIX. This implementation has the following goals:\n• To be compatible with and functionally equivalent to Interlisp-10.\n\n• To serve as a basis for future Interlisp implementations on other mainframe computers. This goal requires that the implementation to be portable.\n\n• To support a large virtual address space.\n\n• To achieve a reasonable speed.\n\nThe implementation draws directly from three sources, Interlisp-10 [19], Interlisp-D [5], and Multilisp [12]. Interlisp-10, the progenitor of all Interlisps, runs on the PDP-10 under the TENEX [2] and TOPS-20 operating systems. Interlisp-D, developed at Xerox Palo Alto Research Center, runs on personal computers also developed at PARC. Multilisp, developed at the University of British Columbia, is a portable interpreter containing a kernel of Interlisp, written in Pascal [9] and running on the IBM Series/370 and the VAX. The Interlisp-VAX implementation relies heavily on these implementations. In turn, Interlisp-D and Multilisp were developed from The Interlisp Virtual Machine Specification [15] by J Moore (subsequently referred to as the VM specification), which discusses what is needed to implement an Interlisp by describing an Interlisp Virtual Machine from the implementors' point of view. Approximately six man-years of effort have been spent exclusively in developing Interlisp-VAX, plus the benefit of many years of development for the previous Interlisp implementations.",
+      "date": "August 1982",
+      "proceedingsTitle": "Proceedings of the 1982 ACM symposium on LISP and functional programming  - LFP '82",
+      "conferenceName": "the 1982 ACM symposium",
+      "place": "Pittsburgh, Pennsylvania, United States",
+      "volume": "",
+      "pages": "81-87",
+      "series": "",
+      "shortTitle": "",
+      "url": "http://portal.acm.org/citation.cfm?doid=800068.802138",
+      "accessDate": "2021-04-16T02:11:24Z",
+      "archive": "",
+      "archiveLocation": "",
+      "libraryCatalog": "DOI.org (Crossref)",
+      "callNumber": "",
+      "rights": "",
+      "extra": "",
+      "tags": [
+        {
+          "tag": "INTERLISP-VAX"
+        },
+        {
+          "tag": "s2z"
+        }
+      ],
+      "collections": [
+        "TVX6WEZX"
+      ],
+      "relations": {},
+      "dateAdded": "2021-04-16T02:11:24Z",
+      "dateModified": "2023-04-20T02:56:47Z"
     },
     {
       "id": "9296070/8AB9NPK7",
@@ -2534,7 +5727,69 @@
             23
           ]
         ]
-      }
+      },
+      "key": "8AB9NPK7",
+      "version": 2078,
+      "itemType": "book",
+      "creators": [
+        {
+          "creatorType": "author",
+          "firstName": "Raymond",
+          "lastName": "Bates"
+        },
+        {
+          "creatorType": "author",
+          "firstName": "Dayer",
+          "lastName": "David"
+        },
+        {
+          "creatorType": "author",
+          "firstName": "Johannes",
+          "lastName": "Koomen"
+        },
+        {
+          "creatorType": "author",
+          "firstName": "Steven",
+          "lastName": "Saunders"
+        },
+        {
+          "creatorType": "author",
+          "firstName": "Donald",
+          "lastName": "Voreck"
+        }
+      ],
+      "abstractNote": "",
+      "series": "",
+      "seriesNumber": "",
+      "volume": "",
+      "numberOfVolumes": "",
+      "place": "300 N. Halstead St. Pasadena CA 91107 USA",
+      "date": "December 5, 1982",
+      "numPages": "57",
+      "ISBN": "",
+      "shortTitle": "",
+      "url": "http://www.softwarepreservation.org/projects/LISP/interlisp/Interlisp-VAX-Users_Manual.pdf/view",
+      "accessDate": "2021-04-23T17:25:31Z",
+      "archive": "",
+      "archiveLocation": "",
+      "libraryCatalog": "",
+      "callNumber": "",
+      "rights": "",
+      "extra": "",
+      "tags": [
+        {
+          "tag": "INTERLISP-VAX"
+        },
+        {
+          "tag": "s2z"
+        }
+      ],
+      "collections": [
+        "TVX6WEZX"
+      ],
+      "relations": {},
+      "dateAdded": "2021-04-25T18:13:25Z",
+      "dateModified": "2021-05-31T18:37:37Z"
     }
   ],
   "1983": [
@@ -2562,7 +5817,266 @@
             1
           ]
         ]
-      }
+      },
+      "key": "X8JE697I",
+      "version": 2454,
+      "itemType": "journalArticle",
+      "creators": [
+        {
+          "creatorType": "author",
+          "firstName": "Mark",
+          "lastName": "Stefik"
+        },
+        {
+          "creatorType": "author",
+          "firstName": "Daniel G",
+          "lastName": "Bobrow"
+        }
+      ],
+      "abstractNote": "",
+      "publicationTitle": "",
+      "volume": "",
+      "issue": "",
+      "pages": "50",
+      "date": "12/1/1983",
+      "series": "",
+      "seriesTitle": "",
+      "seriesText": "",
+      "journalAbbreviation": "",
+      "DOI": "",
+      "ISSN": "",
+      "shortTitle": "",
+      "url": "",
+      "accessDate": "",
+      "archive": "",
+      "archiveLocation": "",
+      "libraryCatalog": "Zotero",
+      "callNumber": "",
+      "rights": "",
+      "extra": "",
+      "tags": [],
+      "collections": [
+        "8MSYRKQA"
+      ],
+      "relations": {},
+      "dateAdded": "2022-07-04T20:11:05Z",
+      "dateModified": "2022-07-04T20:15:10Z"
+    },
+    {
+      "id": "9296070/A7ZZFYKB",
+      "type": "article-journal",
+      "title": "KNOWLEDGE PROGRAMMING IN LOOPS:",
+      "page": "11",
+      "abstract": "Early this year fifty people took an experimental course at Xerox PARC on knowledge programming in Loops During the course, they extended and debugged small knowledge systems in a simulated economics domain called Truckin Everyone learned how to use the Loops environment, formulated the knowledge for their own program, and represented it in Loops At the end of the course a knowledge competition was run so that the strategies used in the different systems could be compared The punchline to this story is that almost everyone learned enough about Loops to complete a small knowledge system in only three days. Although one must exercise caution in extrapolating from small experiments, the results suggest that there is substantial power in integrating multiple programming paradigms.",
+      "language": "en",
+      "author": [
+        {
+          "family": "Stefik",
+          "given": "Mark"
+        },
+        {
+          "family": "Bobrow",
+          "given": "Daniel G"
+        },
+        {
+          "family": "Mittal",
+          "given": "Sanjay"
+        },
+        {
+          "family": "Conway",
+          "given": "Lynn"
+        }
+      ],
+      "issued": {
+        "date-parts": [
+          [
+            1983
+          ]
+        ]
+      },
+      "key": "A7ZZFYKB",
+      "version": 2611,
+      "itemType": "journalArticle",
+      "creators": [
+        {
+          "creatorType": "author",
+          "firstName": "Mark",
+          "lastName": "Stefik"
+        },
+        {
+          "creatorType": "author",
+          "firstName": "Daniel G",
+          "lastName": "Bobrow"
+        },
+        {
+          "creatorType": "author",
+          "firstName": "Sanjay",
+          "lastName": "Mittal"
+        },
+        {
+          "creatorType": "author",
+          "firstName": "Lynn",
+          "lastName": "Conway"
+        }
+      ],
+      "abstractNote": "Early this year fifty people took an experimental course at Xerox PARC on knowledge programming in Loops During the course, they extended and debugged small knowledge systems in a simulated economics domain called Truckin Everyone learned how to use the Loops environment, formulated the knowledge for their own program, and represented it in Loops At the end of the course a knowledge competition was run so that the strategies used in the different systems could be compared The punchline to this story is that almost everyone learned enough about Loops to complete a small knowledge system in only three days. Although one must exercise caution in extrapolating from small experiments, the results suggest that there is substantial power in integrating multiple programming paradigms.",
+      "publicationTitle": "",
+      "volume": "",
+      "issue": "",
+      "pages": "11",
+      "date": "1983",
+      "series": "",
+      "seriesTitle": "",
+      "seriesText": "",
+      "journalAbbreviation": "",
+      "DOI": "",
+      "ISSN": "",
+      "shortTitle": "",
+      "url": "",
+      "accessDate": "",
+      "archive": "",
+      "archiveLocation": "",
+      "libraryCatalog": "Zotero",
+      "callNumber": "",
+      "rights": "",
+      "extra": "",
+      "tags": [],
+      "collections": [
+        "FSK5IX4F",
+        "8MSYRKQA"
+      ],
+      "relations": {},
+      "dateAdded": "2022-06-27T03:05:03Z",
+      "dateModified": "2022-06-27T03:05:03Z"
+    },
+    {
+      "id": "9296070/H8QEYLT7",
+      "type": "article-journal",
+      "title": "GLISP: A Lisp-based Programming System with Data Abstraction",
+      "URL": "https://www.cs.utexas.edu/users/ai-lab/?novak:aimag83",
+      "shortTitle": "GLISP",
+      "author": [
+        {
+          "family": "Novak, Jr",
+          "given": "Gordon S."
+        }
+      ],
+      "issued": {
+        "date-parts": [
+          [
+            1983
+          ]
+        ]
+      },
+      "accessed": {
+        "date-parts": [
+          [
+            2022,
+            8,
+            5
+          ]
+        ]
+      },
+      "key": "H8QEYLT7",
+      "version": 2506,
+      "itemType": "journalArticle",
+      "creators": [
+        {
+          "creatorType": "author",
+          "firstName": "Gordon S.",
+          "lastName": "Novak, Jr"
+        }
+      ],
+      "abstractNote": "",
+      "publicationTitle": "",
+      "volume": "",
+      "issue": "",
+      "pages": "",
+      "date": "1983",
+      "series": "",
+      "seriesTitle": "",
+      "seriesText": "",
+      "journalAbbreviation": "",
+      "language": "",
+      "DOI": "",
+      "ISSN": "",
+      "url": "https://www.cs.utexas.edu/users/ai-lab/?novak:aimag83",
+      "accessDate": "2022-08-05T00:09:07Z",
+      "archive": "",
+      "archiveLocation": "",
+      "libraryCatalog": "www.cs.utexas.edu",
+      "callNumber": "",
+      "rights": "",
+      "extra": "",
+      "tags": [],
+      "collections": [
+        "MTUXENI8"
+      ],
+      "relations": {},
+      "dateAdded": "2022-08-05T00:09:07Z",
+      "dateModified": "2022-09-11T06:31:34Z"
+    },
+    {
+      "id": "9296070/L378BFRQ",
+      "type": "book",
+      "title": "Interlisp reference manual: Revised",
+      "publisher": "Xerox Corp.",
+      "publisher-place": "Palo Alto Research Center, Pasadena, Calif.",
+      "event-place": "Palo Alto Research Center, Pasadena, Calif.",
+      "note": "OCLC: 11098633",
+      "language": "English",
+      "author": [
+        {
+          "family": "Michael Sannella",
+          "given": ""
+        }
+      ],
+      "issued": {
+        "date-parts": [
+          [
+            1983
+          ]
+        ]
+      },
+      "key": "L378BFRQ",
+      "version": 2063,
+      "itemType": "book",
+      "creators": [
+        {
+          "creatorType": "author",
+          "name": "Michael Sannella"
+        }
+      ],
+      "abstractNote": "",
+      "series": "",
+      "seriesNumber": "",
+      "volume": "",
+      "numberOfVolumes": "",
+      "edition": "",
+      "place": "Palo Alto Research Center, Pasadena, Calif.",
+      "date": "1983",
+      "numPages": "",
+      "ISBN": "",
+      "shortTitle": "",
+      "url": "",
+      "accessDate": "",
+      "archive": "",
+      "archiveLocation": "",
+      "libraryCatalog": "Open WorldCat",
+      "callNumber": "",
+      "rights": "",
+      "extra": "OCLC: 11098633",
+      "tags": [
+        {
+          "tag": "sz"
+        }
+      ],
+      "collections": [
+        "TVX6WEZX"
+      ],
+      "relations": {},
+      "dateAdded": "2021-05-31T10:16:58Z",
+      "dateModified": "2021-06-12T14:59:01Z"
     },
     {
       "id": "9296070/MKX86XFD",
@@ -2595,15 +6109,69 @@
             1983
           ]
         ]
-      }
+      },
+      "key": "MKX86XFD",
+      "version": 2470,
+      "itemType": "journalArticle",
+      "creators": [
+        {
+          "creatorType": "author",
+          "firstName": "Mark",
+          "lastName": "Stefik"
+        },
+        {
+          "creatorType": "author",
+          "firstName": "Daniel G",
+          "lastName": "Bobrow"
+        },
+        {
+          "creatorType": "author",
+          "firstName": "Sanjay",
+          "lastName": "Mittal"
+        },
+        {
+          "creatorType": "author",
+          "firstName": "Lynn",
+          "lastName": "Conway"
+        }
+      ],
+      "abstractNote": "Early this year fifty people took an experimental course at Xerox PARC on knowledge programming in Loops During the course, they extended and debugged small knowledge systems in a simulated economics domain called Truckin Everyone learned how to use the Loops environment, formulated the knowledge for their own program, and represented it in Loops At the end of the course a knowledge competition was run so that the strategies used in the different systems could be compared The punchline to this story is that almost everyone learned enough about Loops to complete a small knowledge system in only three days. Although one must exercise caution in extrapolating from small experiments, the results suggest that there is substantial power in integrating multiple programming paradigms.",
+      "publicationTitle": "",
+      "volume": "",
+      "issue": "",
+      "pages": "11",
+      "date": "1983",
+      "series": "",
+      "seriesTitle": "",
+      "seriesText": "",
+      "journalAbbreviation": "",
+      "DOI": "",
+      "ISSN": "",
+      "shortTitle": "",
+      "url": "",
+      "accessDate": "",
+      "archive": "",
+      "archiveLocation": "",
+      "libraryCatalog": "Zotero",
+      "callNumber": "",
+      "rights": "",
+      "extra": "",
+      "tags": [],
+      "collections": [
+        "8MSYRKQA"
+      ],
+      "relations": {},
+      "dateAdded": "2022-07-17T17:18:45Z",
+      "dateModified": "2022-07-17T17:18:45Z"
     },
     {
-      "id": "9296070/A7ZZFYKB",
-      "type": "article-journal",
-      "title": "KNOWLEDGE PROGRAMMING IN LOOPS:",
-      "page": "11",
-      "abstract": "Early this year fifty people took an experimental course at Xerox PARC on knowledge programming in Loops During the course, they extended and debugged small knowledge systems in a simulated economics domain called Truckin Everyone learned how to use the Loops environment, formulated the knowledge for their own program, and represented it in Loops At the end of the course a knowledge competition was run so that the strategies used in the different systems could be compared The punchline to this story is that almost everyone learned enough about Loops to complete a small knowledge system in only three days. Although one must exercise caution in extrapolating from small experiments, the results suggest that there is substantial power in integrating multiple programming paradigms.",
-      "language": "en",
+      "id": "9296070/V3AS6UR5",
+      "type": "post-weblog",
+      "title": "Truckin’ and the Knowledge Competitions | MJSBlog",
+      "genre": "Blog",
+      "abstract": "MJSBlog - Workin on it",
+      "URL": "https://www.markstefik.com/?page_id=359",
+      "language": "en-US",
       "author": [
         {
           "family": "Stefik",
@@ -2611,7 +6179,7 @@
         },
         {
           "family": "Bobrow",
-          "given": "Daniel G"
+          "given": "Daniel"
         },
         {
           "family": "Mittal",
@@ -2622,50 +6190,6 @@
           "given": "Lynn"
         }
       ],
-      "issued": {
-        "date-parts": [
-          [
-            1983
-          ]
-        ]
-      }
-    },
-    {
-      "id": "9296070/H8QEYLT7",
-      "type": "article-journal",
-      "title": "GLISP: A Lisp-based Programming System with Data Abstraction",
-      "URL": "https://www.cs.utexas.edu/users/ai-lab/?novak:aimag83",
-      "shortTitle": "GLISP",
-      "author": [
-        {
-          "family": "Novak, Jr",
-          "given": "Gordon S."
-        }
-      ],
-      "issued": {
-        "date-parts": [
-          [
-            1983
-          ]
-        ]
-      },
-      "accessed": {
-        "date-parts": [
-          [
-            2022,
-            8,
-            5
-          ]
-        ]
-      }
-    },
-    {
-      "id": "9296070/V3AS6UR5",
-      "type": "post-weblog",
-      "title": "Truckin’ and the Knowledge Competitions | MJSBlog",
-      "abstract": "MJSBlog - Workin on it",
-      "URL": "https://www.markstefik.com/?page_id=359",
-      "language": "en-US",
       "issued": {
         "date-parts": [
           [
@@ -2681,63 +6205,52 @@
             25
           ]
         ]
-      }
-    },
-    {
-      "id": "9296070/L378BFRQ",
-      "type": "book",
-      "title": "Interlisp reference manual: Revised",
-      "publisher": "Xerox Corp.",
-      "publisher-place": "Palo Alto Research Center, Pasadena, Calif.",
-      "event-place": "Palo Alto Research Center, Pasadena, Calif.",
-      "note": "OCLC: 11098633",
-      "language": "English",
-      "author": [
+      },
+      "key": "V3AS6UR5",
+      "version": 2981,
+      "itemType": "blogPost",
+      "creators": [
         {
-          "family": "Michael Sannella",
-          "given": ""
+          "creatorType": "author",
+          "firstName": "Mark",
+          "lastName": "Stefik"
+        },
+        {
+          "creatorType": "author",
+          "firstName": "Daniel",
+          "lastName": "Bobrow"
+        },
+        {
+          "creatorType": "author",
+          "firstName": "Sanjay",
+          "lastName": "Mittal"
+        },
+        {
+          "creatorType": "author",
+          "firstName": "Lynn",
+          "lastName": "Conway"
         }
       ],
-      "issued": {
-        "date-parts": [
-          [
-            1983
-          ]
-        ]
-      }
-    },
-    {
-      "id": "9296070/A7ZZFYKB",
-      "type": "article-journal",
-      "title": "KNOWLEDGE PROGRAMMING IN LOOPS:",
-      "page": "11",
-      "abstract": "Early this year fifty people took an experimental course at Xerox PARC on knowledge programming in Loops During the course, they extended and debugged small knowledge systems in a simulated economics domain called Truckin Everyone learned how to use the Loops environment, formulated the knowledge for their own program, and represented it in Loops At the end of the course a knowledge competition was run so that the strategies used in the different systems could be compared The punchline to this story is that almost everyone learned enough about Loops to complete a small knowledge system in only three days. Although one must exercise caution in extrapolating from small experiments, the results suggest that there is substantial power in integrating multiple programming paradigms.",
-      "language": "en",
-      "author": [
+      "abstractNote": "MJSBlog - Workin on it",
+      "blogTitle": "",
+      "websiteType": "Blog",
+      "date": "1983",
+      "url": "https://www.markstefik.com/?page_id=359",
+      "accessDate": "2021-10-25T18:52:55Z",
+      "shortTitle": "",
+      "rights": "",
+      "extra": "",
+      "tags": [
         {
-          "family": "Stefik",
-          "given": "Mark"
-        },
-        {
-          "family": "Bobrow",
-          "given": "Daniel G"
-        },
-        {
-          "family": "Mittal",
-          "given": "Sanjay"
-        },
-        {
-          "family": "Conway",
-          "given": "Lynn"
+          "tag": "Reviewed by SHFT - CSUCI (Joseph Moreno)"
         }
       ],
-      "issued": {
-        "date-parts": [
-          [
-            1983
-          ]
-        ]
-      }
+      "collections": [
+        "MTUXENI8"
+      ],
+      "relations": {},
+      "dateAdded": "2021-10-25T18:52:55Z",
+      "dateModified": "2023-05-08T15:19:46Z"
     },
     {
       "id": "9296070/PVEEX4BT",
@@ -2771,7 +6284,45 @@
             2
           ]
         ]
-      }
+      },
+      "key": "PVEEX4BT",
+      "version": 1995,
+      "itemType": "report",
+      "creators": [
+        {
+          "creatorType": "author",
+          "firstName": "Robert C.",
+          "lastName": "Schrag"
+        }
+      ],
+      "abstractNote": "Conversion of the LogLispLogic programming in Lisp Artificial Intelligence programming environment from its original RutgersUCI-Lisp RUCI-Lisp implementation to an InterLisp implementation is described. This report may be useful to researchers wishing to convert LogLisp to yet another Lisp dialect, or to those wishing to convert other RUCI-Lisp programs into InterLisp. It is also intended to help users of the InterLisp version of LogLisp to understand the implementation. The conversion process is described at a level aimed toward potential translators who might benefit from approaches taken and lessons learned. General issues of conversion of Lisp software between dialects are discussed, use of InterLisps dialect translation package is described, and specific issues of non-mechanizable conversion are addressed. The latter include dialect differences in function definitions, arrays, integer arithmetic, io, interrupts, and macros. Subsequent validation, compilation, and efficiency enhancement of the InterLisp version are then described. A brief users guide to the InterLisp version and points of contact for information on LogLisp software distribution are also provided. Author",
+      "reportNumber": "",
+      "reportType": "",
+      "seriesTitle": "",
+      "place": "",
+      "institution": "ROME AIR DEVELOPMENT CENTER GRIFFISS AFB NY",
+      "date": "1983-01-01",
+      "pages": "",
+      "shortTitle": "",
+      "url": "https://apps.dtic.mil/sti/citations/ADA127718",
+      "accessDate": "2021-06-02T18:44:10Z",
+      "archive": "",
+      "archiveLocation": "",
+      "libraryCatalog": "apps.dtic.mil",
+      "callNumber": "",
+      "rights": "",
+      "extra": "Section: Technical Reports",
+      "tags": [
+        {
+          "tag": "sz"
+        }
+      ],
+      "collections": [
+        "MTUXENI8"
+      ],
+      "relations": {},
+      "dateAdded": "2021-06-02T18:44:10Z",
+      "dateModified": "2021-06-03T19:25:52Z"
     },
     {
       "id": "9296070/XR77BB2T",
@@ -2816,7 +6367,58 @@
             3
           ]
         ]
-      }
+      },
+      "key": "XR77BB2T",
+      "version": 2149,
+      "itemType": "conferencePaper",
+      "creators": [
+        {
+          "creatorType": "author",
+          "firstName": "Sanjai",
+          "lastName": "Naraln"
+        },
+        {
+          "creatorType": "author",
+          "firstName": "David",
+          "lastName": "McArthur"
+        },
+        {
+          "creatorType": "author",
+          "firstName": "Philip",
+          "lastName": "Klahr"
+        }
+      ],
+      "abstractNote": "ROSS [7] is an object-oriented language developed for building knowledge-based simulations [4]. SWIRL [5, 6] is a program written in ROSS that embeds knowledge about defensive and offensive air battle strategies. Given an initial configuration of military forces, SWIRL simulates the resulting air battle. We have implemented ROSS and SWIRL in several different Lisp environments. We report upon this experience by comparing the various environments in terms of cpu usage, real-time usage, and various user aids.",
+      "date": "August 8, 1983",
+      "proceedingsTitle": "Proceedings of the Eighth international joint conference on Artificial intelligence - Volume 2",
+      "conferenceName": "",
+      "place": "San Francisco",
+      "volume": "",
+      "pages": "859–861",
+      "series": "IJCAI'83",
+      "language": "",
+      "DOI": "",
+      "ISBN": "",
+      "shortTitle": "",
+      "url": "https://dl.acm.org/doi/10.5555/1623516.1623579",
+      "accessDate": "2021-06-03",
+      "archive": "",
+      "archiveLocation": "",
+      "libraryCatalog": "ACM Digital Library",
+      "callNumber": "",
+      "rights": "",
+      "extra": "",
+      "tags": [
+        {
+          "tag": "sz"
+        }
+      ],
+      "collections": [
+        "MTUXENI8"
+      ],
+      "relations": {},
+      "dateAdded": "2021-06-03T18:16:12Z",
+      "dateModified": "2021-07-26T02:20:48Z"
     },
     {
       "id": "9296070/MSBZ5IMI",
@@ -2841,7 +6443,37 @@
             10
           ]
         ]
-      }
+      },
+      "key": "MSBZ5IMI",
+      "version": 1800,
+      "itemType": "document",
+      "creators": [
+        {
+          "creatorType": "author",
+          "name": "Xerox"
+        }
+      ],
+      "abstractNote": "Interlisp began with an implementation of the Lisp programming language for the PDP-1 at Bolt. Beranek and Newman in 1966. It was followed in 1967 by 940 Lisp, an upward compatible implementation for\nthe SDS-940 computer. 940 Lisp was the first Lisp system to demonstrate the feasibility of using software paging techniques and a large vinual memory in conjunction with a list-processing system [Bobrow & ( -----\\\n) Murphy, 1967]. 940 Lisp was patterned after the Lisp 1.5 ~plementation for CTSS at MIT, with several' ) 1ew facilities added to take advantage of its timeshared. on-line environment. DWIM, the Do-What+\nMean error correction facility, was introduced into this system in 1968 by Warren Teitelman [Teitelman. 1969].",
+      "date": "Octuber 1983",
+      "url": "https://larrymasinter.net/86-interlisp-manual-opt.pdf",
+      "accessDate": "",
+      "archive": "",
+      "archiveLocation": "",
+      "libraryCatalog": "Open WorldCat",
+      "callNumber": "",
+      "rights": "",
+      "extra": "OCLC: 802551877",
+      "tags": [
+        {
+          "tag": "sz"
+        }
+      ],
+      "collections": [
+        "TVX6WEZX"
+      ],
+      "relations": {},
+      "dateAdded": "2021-05-31T10:18:35Z",
+      "dateModified": "2021-06-03T17:26:10Z"
     },
     {
       "id": "9296070/E5NDSA26",
@@ -2864,7 +6496,45 @@
             9
           ]
         ]
-      }
+      },
+      "key": "E5NDSA26",
+      "version": 2163,
+      "itemType": "report",
+      "creators": [
+        {
+          "creatorType": "author",
+          "firstName": "Jeffrey M.",
+          "lastName": "Becker"
+        }
+      ],
+      "abstractNote": "",
+      "reportNumber": "ISG 83-28",
+      "reportType": "",
+      "seriesTitle": "",
+      "place": "",
+      "institution": "University of Illinois Urbana-Champaign",
+      "date": "September 1983",
+      "pages": "",
+      "language": "",
+      "url": "https://www.mli.gmu.edu/papers/81-85/83-28.pdf",
+      "accessDate": "",
+      "archive": "",
+      "archiveLocation": "",
+      "libraryCatalog": "Google Scholar",
+      "callNumber": "",
+      "rights": "",
+      "extra": "",
+      "tags": [
+        {
+          "tag": "sz"
+        }
+      ],
+      "collections": [
+        "MTUXENI8"
+      ],
+      "relations": {},
+      "dateAdded": "2021-04-25T19:54:39Z",
+      "dateModified": "2021-07-26T02:33:57Z"
     }
   ],
   "1984": [
@@ -2918,7 +6588,58 @@
             3
           ]
         ]
-      }
+      },
+      "key": "YK6MRM4K",
+      "version": 1988,
+      "itemType": "bookSection",
+      "creators": [
+        {
+          "creatorType": "author",
+          "firstName": "Alan",
+          "lastName": "Bundy"
+        },
+        {
+          "creatorType": "author",
+          "firstName": "Lincoln",
+          "lastName": "Wallen"
+        },
+        {
+          "creatorType": "editor",
+          "firstName": "Alan",
+          "lastName": "Bundy"
+        },
+        {
+          "creatorType": "editor",
+          "firstName": "Lincoln",
+          "lastName": "Wallen"
+        }
+      ],
+      "abstractNote": "Major dialect of LISP <34>, designed for high-resolution, bit-mapped display, distinguished by (a) use of in-core editor for structures, and thus code, (b) programming environment of tools for automatic error-correction, syntax (sic) extension and structure declaration/access, (c) implementation of almost-compatible dialects (Interlisp <X>) on several machines, (d) extensive usage of display orientated tools and facilities. Emphasis: Personal Lisp workstation, user interface tools.",
+      "bookTitle": "Catalogue of Artificial Intelligence Tools",
+      "series": "Symbolic Computation",
+      "seriesNumber": "",
+      "volume": "",
+      "numberOfVolumes": "",
+      "edition": "",
+      "place": "Berlin, Heidelberg",
+      "date": "1984",
+      "pages": "52-52",
+      "shortTitle": "",
+      "url": "https://doi.org/10.1007/978-3-642-96868-6_103",
+      "accessDate": "2021-06-03T18:33:49Z",
+      "archive": "",
+      "archiveLocation": "",
+      "libraryCatalog": "Springer Link",
+      "callNumber": "",
+      "rights": "",
+      "extra": "DOI: 10.1007/978-3-642-96868-6_103",
+      "tags": [],
+      "collections": [
+        "3CNYFDHF"
+      ],
+      "relations": {},
+      "dateAdded": "2021-06-03T18:33:49Z",
+      "dateModified": "2021-06-05T21:10:55Z"
     },
     {
       "id": "9296070/T4Z3DHWC",
@@ -2956,7 +6677,42 @@
             27
           ]
         ]
-      }
+      },
+      "key": "T4Z3DHWC",
+      "version": 2371,
+      "itemType": "journalArticle",
+      "creators": [
+        {
+          "creatorType": "author",
+          "firstName": "Reid G.",
+          "lastName": "Smith"
+        }
+      ],
+      "abstractNote": "We use our experience with the Dipmeter Advisor system for well-log interpretation as a case study to examine the development of commercial expert system. We discuss the nature of these systems as we see them in the coming decade, characteristics of the evolution process, development methods, and skills required in the development team. We argue that the tools and ideas of rapid prototyping and successive refinement accelerate the development process. We note that different types of people are required at different stages of expert system development: Those who are primarily knowledgeable in the domain, but who can use the framework to expand the domain knowledge; and those who can actually design and build expert systems. Finally, we discuss the problem of technology transfer and compare our experience with some of the traditional wisdom of expert system development.",
+      "publicationTitle": "AI Magazine",
+      "pages": "61-61",
+      "date": "1984-09-15",
+      "series": "",
+      "seriesTitle": "",
+      "seriesText": "",
+      "journalAbbreviation": "",
+      "ISSN": "2371-9621",
+      "shortTitle": "",
+      "url": "https://ojs.aaai.org/index.php/aimagazine/article/view/449",
+      "accessDate": "2022-06-27T01:43:19Z",
+      "archive": "",
+      "archiveLocation": "",
+      "libraryCatalog": "ojs.aaai.org",
+      "callNumber": "",
+      "rights": "Copyright (c)",
+      "extra": "Number: 3",
+      "tags": [],
+      "collections": [
+        "MTUXENI8"
+      ],
+      "relations": {},
+      "dateAdded": "2022-06-27T01:43:19Z",
+      "dateModified": "2022-06-27T01:43:19Z"
     },
     {
       "id": "9296070/BNAYT94G",
@@ -3003,7 +6759,56 @@
             2
           ]
         ]
-      }
+      },
+      "key": "BNAYT94G",
+      "version": 1995,
+      "itemType": "conferencePaper",
+      "creators": [
+        {
+          "creatorType": "author",
+          "firstName": "Raymond L.",
+          "lastName": "Bates"
+        },
+        {
+          "creatorType": "author",
+          "firstName": "David",
+          "lastName": "Dyer"
+        },
+        {
+          "creatorType": "author",
+          "firstName": "Mark",
+          "lastName": "Feber"
+        }
+      ],
+      "abstractNote": "This paper reports on recent developments of the ISI- Interlisp implementation of Interlisp on a VAX computer. ISI-Interlisp currently runs under UNIX, specifically the Berkeley VM/UNIX and VMS operating systems. Particular attention is paid to the current status of the implementation and the growing pains experienced in the last few years. Included is a discussion of the conversion from UNIX to VAX/VMS, recent modifications and improvements, current limitations, and projected goals. Since much of the recent effort has concerned performance tuning, our observations on this activity are included. ISI-Interlisp, formerly known as Interlisp-VAX, was reported in 1982 ACM Symposium on LISP and Functional Programming, August 1982 [1]. Experiences and recommendations since the 1982 LISP conference are presented.",
+      "date": "August 6, 1984",
+      "proceedingsTitle": "Proceedings of the 1984 ACM Symposium on LISP and functional programming",
+      "conferenceName": "",
+      "place": "New York, NY, USA",
+      "volume": "",
+      "pages": "129–139",
+      "series": "LFP '84",
+      "language": "",
+      "shortTitle": "",
+      "url": "https://doi.org/10.1145/800055.802029",
+      "accessDate": "2021-06-02",
+      "archive": "",
+      "archiveLocation": "",
+      "libraryCatalog": "ACM Digital Library",
+      "callNumber": "",
+      "rights": "",
+      "extra": "",
+      "tags": [
+        {
+          "tag": "sz"
+        }
+      ],
+      "collections": [
+        "TVX6WEZX"
+      ],
+      "relations": {},
+      "dateAdded": "2021-06-02T18:13:23Z",
+      "dateModified": "2021-06-03T19:32:08Z"
     }
   ],
   "1985": [
@@ -3032,7 +6837,47 @@
             1
           ]
         ]
-      }
+      },
+      "key": "68LHCGJF",
+      "version": 2080,
+      "itemType": "book",
+      "creators": [
+        {
+          "creatorType": "author",
+          "firstName": "Richard P.",
+          "lastName": "Gabriel"
+        }
+      ],
+      "abstractNote": "The final report of the Stanford Lisp Performance Study, Performance and Evaluation of Lisp Systems is the first book to present descriptions on Lisp implementation techniques actually in use. It provides performance information using the tools of benchmarking to measure the various Lisp systems, and provides an understanding of the technical tradeoffs made during the implementation of a Lisp system. The study is divided into three parts. The first provides the theoretical background, outlining the factors that go into evaluating the performance of a Lisp system. The second part presents the Lisp implementations: MacLisp, MIT CADR, LMI Lambda, S-I Lisp, Franz Lisp, MIL, Spice Lisp, Vax Common Lisp, Portable Standard Lisp, and Xerox D-Machine. A final part describes the benchmark suite that was used during the major portion of the study and the results themselves.",
+      "series": "",
+      "seriesNumber": "",
+      "volume": "",
+      "numberOfVolumes": "",
+      "edition": "",
+      "place": "USA",
+      "date": "1985-01-01",
+      "numPages": "285",
+      "language": "",
+      "shortTitle": "",
+      "url": "https://dreamsongs.com/Files/Timrep.pdf",
+      "accessDate": "",
+      "archive": "",
+      "archiveLocation": "",
+      "libraryCatalog": "ACM Digital Library",
+      "callNumber": "",
+      "rights": "",
+      "extra": "",
+      "tags": [
+        {
+          "tag": "sz"
+        }
+      ],
+      "collections": [
+        "TVX6WEZX"
+      ],
+      "relations": {},
+      "dateAdded": "2021-06-02T17:14:22Z",
+      "dateModified": "2021-06-07T19:08:48Z"
     },
     {
       "id": "9296070/QXTFTCCF",
@@ -3068,7 +6913,56 @@
             15
           ]
         ]
-      }
+      },
+      "key": "QXTFTCCF",
+      "version": 1576,
+      "itemType": "journalArticle",
+      "creators": [
+        {
+          "creatorType": "author",
+          "firstName": "Douglas B.",
+          "lastName": "Lenat"
+        },
+        {
+          "creatorType": "author",
+          "firstName": "Mayank",
+          "lastName": "Prakash"
+        },
+        {
+          "creatorType": "author",
+          "firstName": "Mary",
+          "lastName": "Shepherd"
+        }
+      ],
+      "abstractNote": "The major limitations in building large software have always been (a) its brittleness when confronted by problems that were not foreseen by its builders, and (by the amount of manpower required. The recent history of expert systems, for example highlights how constricting the brittleness and knowledge acquisition bottlenecks are. Moreover, standard software methodology (e.g., working from a detailed \"spec\") has proven of little use in AI, a field which by definition tackles ill- structured problems. How can these bottlenecks be widened? Attractive, elegant answers have included machine learning, automatic programming, and natural language understanding. But decades of work on such systems have convinced us that each of these approaches has difficulty \"scaling up\" for want a substantial base of real world knowledge.",
+      "publicationTitle": "AI magazine",
+      "pages": "65-65",
+      "date": "1985-03-15",
+      "series": "",
+      "seriesTitle": "",
+      "seriesText": "",
+      "journalAbbreviation": "",
+      "language": "",
+      "ISSN": "",
+      "url": "https://ojs.aaai.org/index.php/aimagazine/article/view/510",
+      "accessDate": "",
+      "archive": "",
+      "archiveLocation": "",
+      "libraryCatalog": "Google Scholar",
+      "callNumber": "",
+      "rights": "",
+      "extra": "",
+      "tags": [
+        {
+          "tag": "sz"
+        }
+      ],
+      "collections": [
+        "MTUXENI8"
+      ],
+      "relations": {},
+      "dateAdded": "2021-04-25T21:01:13Z",
+      "dateModified": "2021-06-01T20:34:23Z"
     },
     {
       "id": "9296070/MVHYRDBF",
@@ -3104,7 +6998,40 @@
             4
           ]
         ]
-      }
+      },
+      "key": "MVHYRDBF",
+      "version": 2481,
+      "itemType": "journalArticle",
+      "creators": [
+        {
+          "creatorType": "author",
+          "firstName": "Charles R.",
+          "lastName": "Fletcher"
+        }
+      ],
+      "abstractNote": "",
+      "publicationTitle": "Behavior Research Methods, Instruments, & Computers",
+      "pages": "565-571",
+      "date": "9/1985",
+      "series": "",
+      "seriesTitle": "",
+      "seriesText": "",
+      "ISSN": "0743-3808, 1532-5970",
+      "url": "http://link.springer.com/10.3758/BF03207654",
+      "accessDate": "2022-08-04T23:58:38Z",
+      "archive": "",
+      "archiveLocation": "",
+      "libraryCatalog": "DOI.org (Crossref)",
+      "callNumber": "",
+      "rights": "",
+      "extra": "",
+      "tags": [],
+      "collections": [
+        "MTUXENI8"
+      ],
+      "relations": {},
+      "dateAdded": "2022-08-04T23:58:38Z",
+      "dateModified": "2022-08-04T23:58:38Z"
     },
     {
       "id": "9296070/PMXCAM4Y",
@@ -3134,7 +7061,42 @@
             21
           ]
         ]
-      }
+      },
+      "key": "PMXCAM4Y",
+      "version": 2066,
+      "itemType": "document",
+      "creators": [
+        {
+          "creatorType": "author",
+          "name": "XEROX"
+        }
+      ],
+      "abstractNote": "",
+      "publisher": "",
+      "date": "December 1985",
+      "shortTitle": "",
+      "url": "https://www.google.com/search?client=firefox-b-d&q=1985+Harmony+and+Intermezzo+releases+Koto+release+%28for+Xerox+1186%29%2C+some+bits+of+Common+Lisp",
+      "accessDate": "2021-04-21T16:44:24Z",
+      "archive": "",
+      "archiveLocation": "",
+      "libraryCatalog": "",
+      "callNumber": "",
+      "rights": "",
+      "extra": "",
+      "tags": [],
+      "collections": [
+        "TVX6WEZX"
+      ],
+      "relations": {
+        "dc:replaces": [
+          "http://zotero.org/groups/2914042/items/HHLSNMW7",
+          "http://zotero.org/groups/2914042/items/ND33M2BC",
+          "http://zotero.org/groups/2914042/items/AAXTWK7D",
+          "http://zotero.org/groups/2914042/items/CWEEGITE"
+        ]
+      },
+      "dateAdded": "2021-04-22T03:48:38Z",
+      "dateModified": "2021-06-14T02:25:36Z"
     },
     {
       "id": "9296070/YC65PT77",
@@ -3157,30 +7119,39 @@
             12
           ]
         ]
-      }
-    },
-    {
-      "id": "9296070/YC65PT77",
-      "type": "article",
-      "title": "Koto INTERLISP-D RELEASE NOTES",
-      "publisher": "Xerox Corporation",
-      "abstract": "The Koto release of Interlisp-D provides a wide range of added functionality, increased performance and improved reliability Central among these is that Koto is the first release of Interlisp that supports the new Xerox 1185i1186 artificial intelligence work stations, including the new features of these work stations such as the expanded 19\" display and the PC emulation option. Of course, like previous releases of Interlisp, Koto also supports the other current members of the 1100 series of machines, specifically the 1132 and various models of the 1108.",
-      "URL": "http://www.bitsavers.org/pdf/xerox/interlisp-d/198706_Lyric/3102464_Lyric_Common_Lisp_Implementation_Notes_Jun87.pdf",
-      "language": "English",
-      "author": [
+      },
+      "key": "YC65PT77",
+      "version": 2635,
+      "itemType": "document",
+      "creators": [
         {
-          "family": "Anonymous",
-          "given": ""
+          "creatorType": "author",
+          "name": "Anonymous"
         }
       ],
-      "issued": {
-        "date-parts": [
-          [
-            "1985",
-            12
-          ]
-        ]
-      }
+      "abstractNote": "The Koto release of Interlisp-D provides a wide range of added functionality, increased performance and improved reliability Central among these is that Koto is the first release of Interlisp that supports the new Xerox 1185i1186 artificial intelligence work stations, including the new features of these work stations such as the expanded 19\" display and the PC emulation option. Of course, like previous releases of Interlisp, Koto also supports the other current members of the 1100 series of machines, specifically the 1132 and various models of the 1108.",
+      "date": "December 1985",
+      "shortTitle": "",
+      "url": "http://www.bitsavers.org/pdf/xerox/interlisp-d/198706_Lyric/3102464_Lyric_Common_Lisp_Implementation_Notes_Jun87.pdf",
+      "accessDate": "",
+      "archive": "",
+      "archiveLocation": "",
+      "libraryCatalog": "",
+      "callNumber": "",
+      "rights": "",
+      "extra": "",
+      "tags": [
+        {
+          "tag": "s2z"
+        }
+      ],
+      "collections": [
+        "3CNYFDHF",
+        "ATGZ3WVE"
+      ],
+      "relations": {},
+      "dateAdded": "2021-05-31T16:17:31Z",
+      "dateModified": "2023-03-09T18:55:44Z"
     },
     {
       "id": "9296070/FKDCVZJ5",
@@ -3226,7 +7197,57 @@
             15
           ]
         ]
-      }
+      },
+      "key": "FKDCVZJ5",
+      "version": 1822,
+      "itemType": "conferencePaper",
+      "creators": [
+        {
+          "creatorType": "author",
+          "firstName": "A.",
+          "lastName": "Lehtola"
+        },
+        {
+          "creatorType": "author",
+          "firstName": "H.",
+          "lastName": "Jäppinen"
+        },
+        {
+          "creatorType": "author",
+          "firstName": "E.",
+          "lastName": "Nelimarkka"
+        }
+      ],
+      "abstractNote": "This paper introduces a special programming environment for the definition of grammars and for the implementation of corresponding parsers. In natural language processing systems it is advantageous to have linguistic knowledge and processing mechanisms separated. Our environment accepts grammars consisting of binary dependency relations and grammatical functions. Well-formed expressions of functions and relations provide constituent surroundings for syntactic categories in the form of two-way automata. These relations, functions, and automata are described in a special definition language.In focusing on high level descriptions a linguist may ignore computational details of the parsing process. He writes the grammar into a DPL-description and a compiler translates it into efficient LISP-code. The environment has also a tracing facility for the parsing process, grammar-sensitive lexical maintenance programs, and routines for the interactive graphic display of parse trees and grammar definitions. Translator routines are also available for the transport of compiled code between various LISP-dialects. The environment itself exists currently in INTERLISP and FRANZLISP. This paper focuses on knowledge engineering issues and does not enter linguistic argumentation.",
+      "date": "March 27, 1985",
+      "proceedingsTitle": "Proceedings of the second conference on European chapter of the Association for Computational Linguistics",
+      "conferenceName": "",
+      "place": "USA",
+      "volume": "",
+      "pages": "98–106",
+      "series": "EACL '85",
+      "language": "",
+      "ISBN": "",
+      "shortTitle": "",
+      "url": "https://doi.org/10.3115/976931.976946",
+      "accessDate": "2021-04-15",
+      "archive": "",
+      "archiveLocation": "",
+      "libraryCatalog": "ACM Digital Library",
+      "callNumber": "",
+      "rights": "",
+      "extra": "",
+      "tags": [
+        {
+          "tag": "sz"
+        }
+      ],
+      "collections": [
+        "MTUXENI8"
+      ],
+      "relations": {},
+      "dateAdded": "2021-04-15T23:18:51Z",
+      "dateModified": "2021-06-03T18:17:23Z"
     },
     {
       "id": "9296070/6D2EJDZD",
@@ -3254,119 +7275,46 @@
             10
           ]
         ]
-      }
-    },
-    {
-      "id": "9296070/PUQ8EKTK",
-      "type": "book",
-      "title": "Interlisp-D Reference Manual, Volume II: Environment",
-      "publisher": "Xerox Corporation",
-      "publisher-place": "S.l.",
-      "volume": "2",
-      "number-of-pages": "436",
-      "event-place": "S.l.",
-      "URL": "http://www.bitsavers.org/pdf/xerox/interlisp-d/198510_Koto/3101273_Interlisp-D_Vol_2_Environment_Oct85.pdf",
-      "note": "OCLC: 802551877",
-      "shortTitle": "Volume II: Environment",
-      "language": "English",
-      "editor": [
+      },
+      "key": "6D2EJDZD",
+      "version": 2633,
+      "itemType": "book",
+      "creators": [
         {
-          "family": "Sannella",
-          "given": "Michael"
+          "creatorType": "editor",
+          "firstName": "Michael",
+          "lastName": "Sannella"
         }
       ],
-      "issued": {
-        "date-parts": [
-          [
-            "1985",
-            10
-          ]
-        ]
-      }
-    },
-    {
-      "id": "9296070/DXD65IKD",
-      "type": "book",
-      "title": "Interlisp-D Reference Manual, Volume I: Language",
-      "publisher": "Xerox Corporation",
-      "publisher-place": "S.l.",
-      "volume": "1",
-      "number-of-pages": "296",
-      "event-place": "S.l.",
-      "URL": "http://www.bitsavers.org/pdf/xerox/interlisp-d/198510_Koto/3101272_Interlisp-D_Vol_1_Language_Oct85.pdf",
-      "note": "OCLC: 802551877",
-      "shortTitle": "Volume I: Language",
-      "language": "English",
-      "editor": [
+      "abstractNote": "",
+      "series": "",
+      "seriesNumber": "",
+      "numberOfVolumes": "",
+      "edition": "",
+      "place": "S.l.",
+      "date": "October, 1985",
+      "numPages": "388",
+      "ISBN": "",
+      "url": "http://www.bitsavers.org/pdf/xerox/interlisp-d/198510_Koto/3101274_Interlisp-D_Vol_3_Input_Output_Oct85.pdf",
+      "accessDate": "",
+      "archive": "",
+      "archiveLocation": "",
+      "libraryCatalog": "Open WorldCat",
+      "callNumber": "",
+      "rights": "",
+      "extra": "OCLC: 802551877",
+      "tags": [
         {
-          "family": "Sannella",
-          "given": "Michael"
+          "tag": "Interlisp-D"
         }
       ],
-      "issued": {
-        "date-parts": [
-          [
-            "1985",
-            10
-          ]
-        ]
-      }
-    },
-    {
-      "id": "9296070/6D2EJDZD",
-      "type": "book",
-      "title": "Interlisp-D Reference Manual, Volume III: Input/Output",
-      "publisher": "Xerox Corporation",
-      "publisher-place": "S.l.",
-      "volume": "3",
-      "number-of-pages": "388",
-      "event-place": "S.l.",
-      "URL": "http://www.bitsavers.org/pdf/xerox/interlisp-d/198510_Koto/3101274_Interlisp-D_Vol_3_Input_Output_Oct85.pdf",
-      "note": "OCLC: 802551877",
-      "shortTitle": "Volume III: Input/Output",
-      "language": "English",
-      "editor": [
-        {
-          "family": "Sannella",
-          "given": "Michael"
-        }
+      "collections": [
+        "3CNYFDHF",
+        "ATGZ3WVE"
       ],
-      "issued": {
-        "date-parts": [
-          [
-            "1985",
-            10
-          ]
-        ]
-      }
-    },
-    {
-      "id": "9296070/PUQ8EKTK",
-      "type": "book",
-      "title": "Interlisp-D Reference Manual, Volume II: Environment",
-      "publisher": "Xerox Corporation",
-      "publisher-place": "S.l.",
-      "volume": "2",
-      "number-of-pages": "436",
-      "event-place": "S.l.",
-      "URL": "http://www.bitsavers.org/pdf/xerox/interlisp-d/198510_Koto/3101273_Interlisp-D_Vol_2_Environment_Oct85.pdf",
-      "note": "OCLC: 802551877",
-      "shortTitle": "Volume II: Environment",
-      "language": "English",
-      "editor": [
-        {
-          "family": "Sannella",
-          "given": "Michael"
-        }
-      ],
-      "issued": {
-        "date-parts": [
-          [
-            "1985",
-            10
-          ]
-        ]
-      }
+      "relations": {},
+      "dateAdded": "2021-05-31T16:43:48Z",
+      "dateModified": "2021-06-05T21:10:41Z"
     },
     {
       "id": "9296070/DXD65IKD",
@@ -3394,7 +7342,113 @@
             10
           ]
         ]
-      }
+      },
+      "key": "DXD65IKD",
+      "version": 2631,
+      "itemType": "book",
+      "creators": [
+        {
+          "creatorType": "editor",
+          "firstName": "Michael",
+          "lastName": "Sannella"
+        }
+      ],
+      "abstractNote": "",
+      "series": "",
+      "seriesNumber": "",
+      "numberOfVolumes": "",
+      "edition": "",
+      "place": "S.l.",
+      "date": "October, 1985",
+      "numPages": "296",
+      "ISBN": "",
+      "url": "http://www.bitsavers.org/pdf/xerox/interlisp-d/198510_Koto/3101272_Interlisp-D_Vol_1_Language_Oct85.pdf",
+      "accessDate": "",
+      "archive": "",
+      "archiveLocation": "",
+      "libraryCatalog": "Open WorldCat",
+      "callNumber": "",
+      "rights": "",
+      "extra": "OCLC: 802551877",
+      "tags": [
+        {
+          "tag": "Interlisp-D"
+        }
+      ],
+      "collections": [
+        "3CNYFDHF",
+        "ATGZ3WVE"
+      ],
+      "relations": {},
+      "dateAdded": "2021-05-31T16:40:00Z",
+      "dateModified": "2021-06-05T21:10:21Z"
+    },
+    {
+      "id": "9296070/PUQ8EKTK",
+      "type": "book",
+      "title": "Interlisp-D Reference Manual, Volume II: Environment",
+      "publisher": "Xerox Corporation",
+      "publisher-place": "S.l.",
+      "volume": "2",
+      "number-of-pages": "436",
+      "event-place": "S.l.",
+      "URL": "http://www.bitsavers.org/pdf/xerox/interlisp-d/198510_Koto/3101273_Interlisp-D_Vol_2_Environment_Oct85.pdf",
+      "note": "OCLC: 802551877",
+      "shortTitle": "Volume II: Environment",
+      "language": "English",
+      "editor": [
+        {
+          "family": "Sannella",
+          "given": "Michael"
+        }
+      ],
+      "issued": {
+        "date-parts": [
+          [
+            "1985",
+            10
+          ]
+        ]
+      },
+      "key": "PUQ8EKTK",
+      "version": 2632,
+      "itemType": "book",
+      "creators": [
+        {
+          "creatorType": "editor",
+          "firstName": "Michael",
+          "lastName": "Sannella"
+        }
+      ],
+      "abstractNote": "",
+      "series": "",
+      "seriesNumber": "",
+      "numberOfVolumes": "",
+      "edition": "",
+      "place": "S.l.",
+      "date": "October, 1985",
+      "numPages": "436",
+      "ISBN": "",
+      "url": "http://www.bitsavers.org/pdf/xerox/interlisp-d/198510_Koto/3101273_Interlisp-D_Vol_2_Environment_Oct85.pdf",
+      "accessDate": "",
+      "archive": "",
+      "archiveLocation": "",
+      "libraryCatalog": "Open WorldCat",
+      "callNumber": "",
+      "rights": "",
+      "extra": "OCLC: 802551877",
+      "tags": [
+        {
+          "tag": "Interlisp-D"
+        }
+      ],
+      "collections": [
+        "3CNYFDHF",
+        "ATGZ3WVE"
+      ],
+      "relations": {},
+      "dateAdded": "2021-05-31T16:41:57Z",
+      "dateModified": "2021-06-05T21:10:31Z"
     },
     {
       "id": "9296070/2B4J79N6",
@@ -3432,39 +7486,48 @@
             15
           ]
         ]
-      }
+      },
+      "key": "2B4J79N6",
+      "version": 1568,
+      "itemType": "journalArticle",
+      "creators": [
+        {
+          "creatorType": "author",
+          "firstName": "A. D. M.",
+          "lastName": "Burwell"
+        }
+      ],
+      "abstractNote": "Report of a meeting held by the Geological Information Group at the British Petroleum Research Centre, Sunbury, 24 January 1985\n\nThis meeting, concerned mainly with computer manipulation of petroleum exploration data, attracted c. 95 participants. In addition to eight papers presented, there were two computer demonstrations of log analysis systems and a number of poster displays.\n\nThe morning session, concerned with large-scale, integrated hardware and software systems, was chaired by R. Howarth. R. Till of British Petroleum gave the opening paper concerning BP Exploration’s integrated database system. BP Exploration databases fall into three main groups: those containing largely numerical data; databases specifically concerned with text handling; and well-based databases. The ‘numerical’ databases, implemented under the ULTRA database management system (dbms), include a seismic data system, a generalized cartographic database and an earth constants database. Textual databases include a library information system and a Petroconsultants scout data database, both implemented under the BASIS dbms. The well-based systems include a generalized well-data database, a wireline log archive, storage and retrieval system, and a master well index; all three are implemented under the INGRES dbms. Two related BASIS databases contain geochemical and biostratigraphical data.\n\nG. Baxter (co-author M. Hemingway) described the development of Britoil’s well log database which was prompted by the need to have rapid access to digitized wireline log data for c. 1500 wells on the UKCS. Early work involved both locating log information and digitizing those logs held in sepia form only. Each digitized log occupies approximately 1 Mbyte.",
+      "publicationTitle": "Journal of the Geological Society of London",
+      "pages": "925-926",
+      "date": "September 1, 1985",
+      "series": "",
+      "seriesTitle": "",
+      "seriesText": "",
+      "ISSN": "0016-7649, 2041-479X",
+      "shortTitle": "",
+      "url": "http://jgs.lyellcollection.org/lookup/doi/10.1144/gsjgs.142.5.0925",
+      "accessDate": "2021-04-15T23:03:04Z",
+      "archive": "",
+      "archiveLocation": "",
+      "libraryCatalog": "DOI.org (Crossref)",
+      "callNumber": "",
+      "rights": "",
+      "extra": "",
+      "tags": [
+        {
+          "tag": "sz"
+        }
+      ],
+      "collections": [
+        "MTUXENI8"
+      ],
+      "relations": {},
+      "dateAdded": "2021-04-15T23:03:04Z",
+      "dateModified": "2021-06-01T20:24:03Z"
     }
   ],
   "1986": [
-    {
-      "id": "9296070/PB5L9AVM",
-      "type": "article-journal",
-      "title": "Computer-aided analysis of structures in INTERLISP environment",
-      "container-title": "Computers & structures",
-      "page": "393-407",
-      "volume": "23",
-      "issue": "3",
-      "abstract": "LISP appears to be the language of choice among the developers of knowledge-based expert systems. Analysis of structures in INTERLISP environment is discussed in this paper. An interactive INTERLISP program is presented for analysis of frames which can be used as part of an expert system for computer-aided design of structures. Some of the concepts and characteristics of INTERLISP language are explained by referring to the INTERLISP program.",
-      "URL": "https://www.sciencedirect.com/science/article/abs/pii/0045794986902312",
-      "DOI": "https://doi.org/10.1016/0045-7949(86)90231-2",
-      "author": [
-        {
-          "family": "Adeli",
-          "given": "H."
-        },
-        {
-          "family": "Paek",
-          "given": "Y. J."
-        }
-      ],
-      "issued": {
-        "date-parts": [
-          [
-            1986
-          ]
-        ]
-      }
-    },
     {
       "id": "9296070/48ESB5WE",
       "type": "book",
@@ -3497,7 +7560,322 @@
             25
           ]
         ]
-      }
+      },
+      "key": "48ESB5WE",
+      "version": 2311,
+      "itemType": "book",
+      "creators": [
+        {
+          "creatorType": "author",
+          "name": "Stephen H. Kaisler"
+        }
+      ],
+      "abstractNote": "LISP, as a language, has been around for about 25 years [mcca78]. It was originally developed to support artificial intelligence (AI) research. At first, it seemed\nto be little noticed except by a small band of academics who implemented some\nof the early LISP interpreters and wrote some of the early AI programs. In the\nearly 60’s, LISP began to diverge as various implementations were developed for\ndifferent machines. McCarthy [mcca78] gives a short history of its early days.",
+      "series": "",
+      "seriesNumber": "",
+      "volume": "",
+      "numberOfVolumes": "",
+      "edition": "",
+      "place": "Canada",
+      "date": "1986",
+      "numPages": "1181",
+      "ISBN": "",
+      "shortTitle": "",
+      "url": "https://interlisp.org/docs/1986-Interlisp-language-book-1.pdf",
+      "accessDate": "2021-04-25T23:24:51Z",
+      "archive": "",
+      "archiveLocation": "",
+      "libraryCatalog": "Internet Archive",
+      "callNumber": "",
+      "rights": "",
+      "extra": "",
+      "tags": [
+        {
+          "tag": "lisp",
+          "type": 1
+        },
+        {
+          "tag": "sz"
+        }
+      ],
+      "collections": [
+        "TVX6WEZX"
+      ],
+      "relations": {
+        "dc:replaces": [
+          "http://zotero.org/groups/2914042/items/VTEQEKZ4",
+          "http://zotero.org/groups/2914042/items/UEYWNTDG"
+        ]
+      },
+      "dateAdded": "2021-04-24T06:12:25Z",
+      "dateModified": "2021-12-22T06:27:41Z"
+    },
+    {
+      "id": "9296070/AH85W4DE",
+      "type": "paper-conference",
+      "title": "Ten Years of Window Systems - A Retrospective View",
+      "container-title": "Methodology of Window Management",
+      "collection-title": "EurographicSeminars",
+      "publisher": "Springer",
+      "publisher-place": "Berlin, Heidelberg",
+      "page": "35-46",
+      "event-place": "Berlin, Heidelberg",
+      "abstract": "Both James Gosling and I currently work for SUN and the reason for my wanting to talk before he does is that I am talking about the past and James is talking about the future. I have been connected with eight window systems as a user, or as an implementor, or by being in the same building! I have been asked to give a historical view and my talk looks at window systems over ten years and features: the Smalltalk, DLisp (Interlisp), Interlisp-D, Tajo (Mesa Development Environment), Docs (Cedar), Viewers (Cedar), SunWindows and SunDew systems.",
+      "DOI": "10.1007/978-3-642-70919-7_4",
+      "ISBN": "978-3-642-70919-7",
+      "language": "en",
+      "author": [
+        {
+          "family": "Teitelman",
+          "given": "Warren"
+        }
+      ],
+      "editor": [
+        {
+          "family": "Hopgood",
+          "given": "F. Robert A."
+        },
+        {
+          "family": "Duce",
+          "given": "David A."
+        },
+        {
+          "family": "Fielding",
+          "given": "Elizabeth V. C."
+        },
+        {
+          "family": "Robinson",
+          "given": "Ken"
+        },
+        {
+          "family": "Williams",
+          "given": "Antony S."
+        }
+      ],
+      "issued": {
+        "date-parts": [
+          [
+            1986
+          ]
+        ]
+      },
+      "key": "AH85W4DE",
+      "version": 3019,
+      "itemType": "conferencePaper",
+      "creators": [
+        {
+          "creatorType": "author",
+          "firstName": "Warren",
+          "lastName": "Teitelman"
+        },
+        {
+          "creatorType": "editor",
+          "firstName": "F. Robert A.",
+          "lastName": "Hopgood"
+        },
+        {
+          "creatorType": "editor",
+          "firstName": "David A.",
+          "lastName": "Duce"
+        },
+        {
+          "creatorType": "editor",
+          "firstName": "Elizabeth V. C.",
+          "lastName": "Fielding"
+        },
+        {
+          "creatorType": "editor",
+          "firstName": "Ken",
+          "lastName": "Robinson"
+        },
+        {
+          "creatorType": "editor",
+          "firstName": "Antony S.",
+          "lastName": "Williams"
+        }
+      ],
+      "abstractNote": "Both James Gosling and I currently work for SUN and the reason for my wanting to talk before he does is that I am talking about the past and James is talking about the future. I have been connected with eight window systems as a user, or as an implementor, or by being in the same building! I have been asked to give a historical view and my talk looks at window systems over ten years and features: the Smalltalk, DLisp (Interlisp), Interlisp-D, Tajo (Mesa Development Environment), Docs (Cedar), Viewers (Cedar), SunWindows and SunDew systems.",
+      "date": "1986",
+      "proceedingsTitle": "Methodology of Window Management",
+      "conferenceName": "",
+      "place": "Berlin, Heidelberg",
+      "volume": "",
+      "pages": "35-46",
+      "series": "EurographicSeminars",
+      "shortTitle": "",
+      "url": "",
+      "accessDate": "",
+      "archive": "",
+      "archiveLocation": "",
+      "libraryCatalog": "Springer Link",
+      "callNumber": "",
+      "rights": "",
+      "extra": "",
+      "tags": [],
+      "collections": [
+        "3CNYFDHF"
+      ],
+      "relations": {},
+      "dateAdded": "2023-07-21T18:05:39Z",
+      "dateModified": "2023-07-21T18:05:39Z"
+    },
+    {
+      "id": "9296070/PB5L9AVM",
+      "type": "article-journal",
+      "title": "Computer-aided analysis of structures in INTERLISP environment",
+      "container-title": "Computers & structures",
+      "page": "393-407",
+      "volume": "23",
+      "issue": "3",
+      "abstract": "LISP appears to be the language of choice among the developers of knowledge-based expert systems. Analysis of structures in INTERLISP environment is discussed in this paper. An interactive INTERLISP program is presented for analysis of frames which can be used as part of an expert system for computer-aided design of structures. Some of the concepts and characteristics of INTERLISP language are explained by referring to the INTERLISP program.",
+      "URL": "https://www.sciencedirect.com/science/article/abs/pii/0045794986902312",
+      "DOI": "https://doi.org/10.1016/0045-7949(86)90231-2",
+      "author": [
+        {
+          "family": "Adeli",
+          "given": "H."
+        },
+        {
+          "family": "Paek",
+          "given": "Y. J."
+        }
+      ],
+      "issued": {
+        "date-parts": [
+          [
+            1986
+          ]
+        ]
+      },
+      "key": "PB5L9AVM",
+      "version": 1571,
+      "itemType": "journalArticle",
+      "creators": [
+        {
+          "creatorType": "author",
+          "firstName": "H.",
+          "lastName": "Adeli"
+        },
+        {
+          "creatorType": "author",
+          "firstName": "Y. J.",
+          "lastName": "Paek"
+        }
+      ],
+      "abstractNote": "LISP appears to be the language of choice among the developers of knowledge-based expert systems. Analysis of structures in INTERLISP environment is discussed in this paper. An interactive INTERLISP program is presented for analysis of frames which can be used as part of an expert system for computer-aided design of structures. Some of the concepts and characteristics of INTERLISP language are explained by referring to the INTERLISP program.",
+      "publicationTitle": "Computers & structures",
+      "pages": "393-407",
+      "date": "1986",
+      "series": "",
+      "seriesTitle": "",
+      "seriesText": "",
+      "journalAbbreviation": "",
+      "language": "",
+      "ISSN": "",
+      "shortTitle": "",
+      "url": "https://www.sciencedirect.com/science/article/abs/pii/0045794986902312",
+      "accessDate": "",
+      "archive": "",
+      "archiveLocation": "",
+      "libraryCatalog": "Google Scholar",
+      "callNumber": "",
+      "rights": "",
+      "extra": "",
+      "tags": [
+        {
+          "tag": "sz"
+        }
+      ],
+      "collections": [
+        "MTUXENI8",
+        "JP4FIV7I"
+      ],
+      "relations": {
+        "dc:replaces": "http://zotero.org/groups/2914042/items/K7TBGT8A"
+      },
+      "dateAdded": "2021-04-16T04:08:28Z",
+      "dateModified": "2021-06-01T20:27:19Z"
+    },
+    {
+      "id": "9296070/BTUF3TN2",
+      "type": "article-journal",
+      "title": "Integrating Access-Oriented Programming into a Multiparadigm Environment",
+      "container-title": "Software, IEEE",
+      "page": "10-18",
+      "volume": "3",
+      "abstract": "The Loops knowledge programming system integrates function-oriented, system object-oriented, rule-oriented, and—something notfound in most other systems—access-oriented programming.",
+      "URL": "https://www.researchgate.net/profile/Mark-Stefik-2/publication/3248853_Integrating_Access-Oriented_Programming_into_a_Multiparadigm_Environment/links/02e7e52139c2d9c03f000000/Integrating-Access-Oriented-Programming-into-a-Multiparadigm-Environment.pdf?_sg%5B0%5D=started_experiment_milestone&origin=journalDetail&_rtd=e30%3D",
+      "DOI": "10.1109/MS.1986.232428",
+      "journalAbbreviation": "Software, IEEE",
+      "author": [
+        {
+          "family": "Stefik",
+          "given": "Mark"
+        },
+        {
+          "family": "Bobrow",
+          "given": "Daniel"
+        },
+        {
+          "family": "Kahn",
+          "given": "Kenneth"
+        }
+      ],
+      "issued": {
+        "date-parts": [
+          [
+            1986,
+            2,
+            1
+          ]
+        ]
+      },
+      "key": "BTUF3TN2",
+      "version": 3018,
+      "itemType": "journalArticle",
+      "creators": [
+        {
+          "creatorType": "author",
+          "firstName": "Mark",
+          "lastName": "Stefik"
+        },
+        {
+          "creatorType": "author",
+          "firstName": "Daniel",
+          "lastName": "Bobrow"
+        },
+        {
+          "creatorType": "author",
+          "firstName": "Kenneth",
+          "lastName": "Kahn"
+        }
+      ],
+      "abstractNote": "The Loops knowledge programming system integrates function-oriented, system object-oriented, rule-oriented, and—something notfound in most other systems—access-oriented programming.",
+      "publicationTitle": "Software, IEEE",
+      "issue": "",
+      "pages": "10-18",
+      "date": "1986-02-01",
+      "series": "",
+      "seriesTitle": "",
+      "seriesText": "",
+      "language": "",
+      "ISSN": "",
+      "shortTitle": "",
+      "url": "https://www.researchgate.net/profile/Mark-Stefik-2/publication/3248853_Integrating_Access-Oriented_Programming_into_a_Multiparadigm_Environment/links/02e7e52139c2d9c03f000000/Integrating-Access-Oriented-Programming-into-a-Multiparadigm-Environment.pdf?_sg%5B0%5D=started_experiment_milestone&origin=journalDetail&_rtd=e30%3D",
+      "accessDate": "",
+      "archive": "",
+      "archiveLocation": "",
+      "libraryCatalog": "ResearchGate",
+      "callNumber": "",
+      "rights": "",
+      "extra": "",
+      "tags": [],
+      "collections": [
+        "8MSYRKQA"
+      ],
+      "relations": {},
+      "dateAdded": "2023-06-03T13:24:45Z",
+      "dateModified": "2023-06-03T13:26:02Z"
     },
     {
       "id": "9296070/NJEBFRHB",
@@ -3545,7 +7923,53 @@
             20
           ]
         ]
-      }
+      },
+      "key": "NJEBFRHB",
+      "version": 2423,
+      "itemType": "bookSection",
+      "creators": [
+        {
+          "creatorType": "author",
+          "firstName": "Philip R.",
+          "lastName": "Martz"
+        },
+        {
+          "creatorType": "author",
+          "firstName": "Matt",
+          "lastName": "Heffron"
+        },
+        {
+          "creatorType": "author",
+          "firstName": "Owen Mitch",
+          "lastName": "Griffith"
+        }
+      ],
+      "abstractNote": "The SpinPro™ Ultracentrifugation Expert System is a computer program that designs optimal ultracentrifugation procedures to satisfy the investigator's research requirements. SpinPro runs on the IBM PC/XT. Ultracentrifugation is a common method in the separation of biological materials. Its capabilities, however, are too often under-utilized. SpinPro addresses this problem by employing Artificial Intelligence (AI) techniques to design efficient and accurate ultracentrifugation procedures. To use SpinPro, the investigator describes the centrifugation problem in a question and answer dialogue. SpinPro then offers detailed advice on optimal and alternative procedures for performing the run. This advice results in cleaner and faster separations and improves the efficiency of the ultracentrifugation laboratory.",
+      "bookTitle": "Artificial Intelligence Applications in Chemistry",
+      "series": "ACS Symposium Series",
+      "seriesNumber": "306",
+      "numberOfVolumes": "0",
+      "edition": "",
+      "place": "",
+      "date": "1986-04-30",
+      "pages": "297-311",
+      "language": "",
+      "shortTitle": "",
+      "url": "https://doi.org/10.1021/bk-1986-0306.ch023",
+      "accessDate": "2022-06-20T19:00:59Z",
+      "archive": "",
+      "archiveLocation": "",
+      "libraryCatalog": "ACS Publications",
+      "callNumber": "",
+      "rights": "",
+      "extra": "Section: 23\nDOI: 10.1021/bk-1986-0306.ch023",
+      "tags": [],
+      "collections": [
+        "MTUXENI8"
+      ],
+      "relations": {},
+      "dateAdded": "2022-06-20T19:00:59Z",
+      "dateModified": "2022-06-29T19:40:01Z"
     },
     {
       "id": "9296070/GWU6SW5W",
@@ -3586,7 +8010,45 @@
             14
           ]
         ]
-      }
+      },
+      "key": "GWU6SW5W",
+      "version": 2553,
+      "itemType": "journalArticle",
+      "creators": [
+        {
+          "creatorType": "author",
+          "firstName": "D. Austin Jr.",
+          "lastName": "Henderson"
+        },
+        {
+          "creatorType": "author",
+          "firstName": "Stuart K.",
+          "lastName": "Card"
+        }
+      ],
+      "abstractNote": "A key constraint on the effectiveness of window-based human-computer interfaces is that the display screen is too small for many applications. This results in “window thrashing,” in which the user must expend considerable effort to keep desired windows visible. Rooms is a window manager that overcomes small screen size by exploiting the statistics of window access, dividing the user's workspace into a suite of virtual workspaces with transitions among them. Mechanisms are described for solving the problems of navigation and simultaneous access to separated information that arise from multiple workspaces.",
+      "publicationTitle": "ACM Transactions on Graphics",
+      "pages": "211-243",
+      "date": "07/1986",
+      "series": "",
+      "seriesTitle": "",
+      "seriesText": "",
+      "ISSN": "0730-0301, 1557-7368",
+      "url": "https://dl.acm.org/doi/10.1145/24054.24056",
+      "accessDate": "2023-02-14T11:11:25Z",
+      "archive": "",
+      "archiveLocation": "",
+      "libraryCatalog": "DOI.org (Crossref)",
+      "callNumber": "",
+      "rights": "",
+      "extra": "",
+      "tags": [],
+      "collections": [
+        "JNKHGNYF"
+      ],
+      "relations": {},
+      "dateAdded": "2023-02-14T11:11:25Z",
+      "dateModified": "2023-02-14T11:15:12Z"
     },
     {
       "id": "9296070/4BGHZ32M",
@@ -3624,7 +8086,42 @@
             14
           ]
         ]
-      }
+      },
+      "key": "4BGHZ32M",
+      "version": 2558,
+      "itemType": "conferencePaper",
+      "creators": [
+        {
+          "creatorType": "author",
+          "firstName": "D. A.",
+          "lastName": "Henderson"
+        }
+      ],
+      "abstractNote": "Trillium is a computer-based environment for simulating and experimenting with interfaces for simple machines. For the past four years it has been use by Xerox designers for fast prototyping and testing of interfaces for copiers and printers. This paper defines the class of “functioning frame” interfaces which Trillium is used to design, discusses the major concerns that have driven the design of Trillium, and describes the Trillium mechanisms chosen to satisfy them.",
+      "date": "April, 1986",
+      "proceedingsTitle": "Proceedings of the SIGCHI Conference on Human Factors in Computing Systems",
+      "conferenceName": "",
+      "place": "New York, NY, USA",
+      "volume": "",
+      "pages": "221–227",
+      "series": "CHI '86",
+      "language": "",
+      "shortTitle": "",
+      "url": "https://doi.org/10.1145/22627.22375",
+      "accessDate": "2023-02-14",
+      "archive": "",
+      "archiveLocation": "",
+      "libraryCatalog": "ACM Digital Library",
+      "callNumber": "",
+      "rights": "",
+      "extra": "",
+      "tags": [],
+      "collections": [
+        "SUFS7ZKM"
+      ],
+      "relations": {},
+      "dateAdded": "2023-02-14T19:12:39Z",
+      "dateModified": "2023-02-14T19:13:26Z"
     },
     {
       "id": "9296070/BG9BWBAA",
@@ -3670,7 +8167,52 @@
             3
           ]
         ]
-      }
+      },
+      "key": "BG9BWBAA",
+      "version": 2605,
+      "itemType": "conferencePaper",
+      "creators": [
+        {
+          "creatorType": "author",
+          "firstName": "Randall H.",
+          "lastName": "Trigg"
+        },
+        {
+          "creatorType": "author",
+          "firstName": "Lucy A.",
+          "lastName": "Suchman"
+        },
+        {
+          "creatorType": "author",
+          "firstName": "Frank G.",
+          "lastName": "Halasz"
+        }
+      ],
+      "abstractNote": "This paper describes a project underway to investigate computer support for collaboration. In particular, we focus on experience with and extensions to NoteCards, a hypertext-based idea structuring system. The forms of collaboration discussed include draft-passing, simultaneous sharing and online presentations. The requirement that mutual intelligibility be maintained between collaborators leads to the need for support of annotative and procedural as well as substantive activities.",
+      "date": "Dicembre 3, 1986",
+      "proceedingsTitle": "Proceedings of the 1986 ACM conference on Computer-supported cooperative work",
+      "conferenceName": "",
+      "place": "New York, NY, USA",
+      "volume": "",
+      "pages": "153–162",
+      "series": "CSCW '86",
+      "language": "",
+      "shortTitle": "",
+      "url": "https://doi.org/10.1145/637069.637089",
+      "accessDate": "2023-03-03",
+      "archive": "",
+      "archiveLocation": "",
+      "libraryCatalog": "ACM Digital Library",
+      "callNumber": "",
+      "rights": "",
+      "extra": "",
+      "tags": [],
+      "collections": [
+        "QTUS8XEQ"
+      ],
+      "relations": {},
+      "dateAdded": "2023-03-03T10:48:17Z",
+      "dateModified": "2023-03-03T10:48:17Z"
     },
     {
       "id": "9296070/3QK929A2",
@@ -3718,7 +8260,177 @@
             2
           ]
         ]
-      }
+      },
+      "key": "3QK929A2",
+      "version": 2042,
+      "itemType": "bookSection",
+      "creators": [
+        {
+          "creatorType": "author",
+          "firstName": "Beau",
+          "lastName": "Sheil"
+        },
+        {
+          "creatorType": "editor",
+          "firstName": "Charles",
+          "lastName": "Rich"
+        },
+        {
+          "creatorType": "editor",
+          "firstName": "Richard C.",
+          "lastName": "Waters"
+        }
+      ],
+      "abstractNote": "This chapter discusses the power tools for programmers. Essentially, all of the intelligent programming tools described in this volume are at most experimental prototypes. Given that these tools are still quite far from being commercial realities, it is worthwhile to note that there is a completely different way in which artificial intelligence research has to help programmers. Artificial intelligence researchers are themselves programmers. Creating such programs is more a problem of exploration than implementation and does not conform to conventional software lifecycle models. The artificial intelligence programming community has always been faced with this kind of exploratory programming and has, therefore, had a head start on developing appropriate language, environment, and hardware features. Redundancy protects the design from unintentional change, the conventional programming technology restrains the programmer, and the programming languages used in exploratory systems minimize and defer constraints on the programmer.",
+      "bookTitle": "Readings in Artificial Intelligence and Software Engineering",
+      "series": "",
+      "seriesNumber": "",
+      "volume": "",
+      "numberOfVolumes": "",
+      "edition": "",
+      "place": "",
+      "date": "January 1, 1986",
+      "pages": "573-580",
+      "url": "https://www.sciencedirect.com/science/article/pii/B9780934613125500483",
+      "accessDate": "2021-06-02T17:05:53Z",
+      "archive": "",
+      "archiveLocation": "",
+      "libraryCatalog": "ScienceDirect",
+      "callNumber": "",
+      "rights": "",
+      "extra": "DOI: 10.1016/B978-0-934613-12-5.50048-3",
+      "tags": [
+        {
+          "tag": "sz"
+        }
+      ],
+      "collections": [
+        "3CNYFDHF"
+      ],
+      "relations": {},
+      "dateAdded": "2021-06-02T17:05:53Z",
+      "dateModified": "2021-06-02T17:08:40Z"
+    },
+    {
+      "id": "9296070/HLN62MVN",
+      "type": "article-journal",
+      "title": "CommonLoops: merging Lisp and object-oriented programming",
+      "container-title": "ACM SIGPLAN Notices",
+      "page": "17–29",
+      "volume": "21",
+      "issue": "11",
+      "abstract": "CommonLoops blends object-oriented programming smoothly and tightly with the procedure-oriented design of Lisp. Functions and methods are combined in a more general abstraction. Message passing is invoked via normal Lisp function call. Methods are viewed as partial descriptions of procedures. Lisp data types are integrated with object classes. With these integrations, it is easy to incrementally move a program between the procedure and object-oriented styles. One of the most important properties of CommonLoops is its extensive use of meta-objects. We discuss three kinds of meta-objects: objects for classes, objects for methods, and objects for discriminators. We argue that these meta-objects make practical both efficient implementation and experimentation with new ideas for object-oriented programming. CommonLoops' small kernel is powerful enough to implement the major object-oriented systems in use today.",
+      "URL": "https://doi.org/10.1145/960112.28700",
+      "DOI": "10.1145/960112.28700",
+      "shortTitle": "CommonLoops",
+      "journalAbbreviation": "SIGPLAN Not.",
+      "author": [
+        {
+          "family": "Bobrow",
+          "given": "Daniel G."
+        },
+        {
+          "family": "Kahn",
+          "given": "Kenneth"
+        },
+        {
+          "family": "Kiczales",
+          "given": "Gregor"
+        },
+        {
+          "family": "Masinter",
+          "given": "Larry"
+        },
+        {
+          "family": "Stefik",
+          "given": "Mark"
+        },
+        {
+          "family": "Zdybel",
+          "given": "Frank"
+        }
+      ],
+      "issued": {
+        "date-parts": [
+          [
+            "1986",
+            6,
+            1
+          ]
+        ]
+      },
+      "accessed": {
+        "date-parts": [
+          [
+            2021,
+            6,
+            3
+          ]
+        ]
+      },
+      "key": "HLN62MVN",
+      "version": 2023,
+      "itemType": "journalArticle",
+      "creators": [
+        {
+          "creatorType": "author",
+          "firstName": "Daniel G.",
+          "lastName": "Bobrow"
+        },
+        {
+          "creatorType": "author",
+          "firstName": "Kenneth",
+          "lastName": "Kahn"
+        },
+        {
+          "creatorType": "author",
+          "firstName": "Gregor",
+          "lastName": "Kiczales"
+        },
+        {
+          "creatorType": "author",
+          "firstName": "Larry",
+          "lastName": "Masinter"
+        },
+        {
+          "creatorType": "author",
+          "firstName": "Mark",
+          "lastName": "Stefik"
+        },
+        {
+          "creatorType": "author",
+          "firstName": "Frank",
+          "lastName": "Zdybel"
+        }
+      ],
+      "abstractNote": "CommonLoops blends object-oriented programming smoothly and tightly with the procedure-oriented design of Lisp. Functions and methods are combined in a more general abstraction. Message passing is invoked via normal Lisp function call. Methods are viewed as partial descriptions of procedures. Lisp data types are integrated with object classes. With these integrations, it is easy to incrementally move a program between the procedure and object-oriented styles. One of the most important properties of CommonLoops is its extensive use of meta-objects. We discuss three kinds of meta-objects: objects for classes, objects for methods, and objects for discriminators. We argue that these meta-objects make practical both efficient implementation and experimentation with new ideas for object-oriented programming. CommonLoops' small kernel is powerful enough to implement the major object-oriented systems in use today.",
+      "publicationTitle": "ACM SIGPLAN Notices",
+      "pages": "17–29",
+      "date": "June 1, 1986",
+      "series": "",
+      "seriesTitle": "",
+      "seriesText": "",
+      "language": "",
+      "ISSN": "0362-1340",
+      "url": "https://doi.org/10.1145/960112.28700",
+      "accessDate": "2021-06-03T19:01:38Z",
+      "archive": "",
+      "archiveLocation": "",
+      "libraryCatalog": "Nov. 1986",
+      "callNumber": "",
+      "rights": "",
+      "extra": "",
+      "tags": [
+        {
+          "tag": "sz"
+        }
+      ],
+      "collections": [
+        "MTUXENI8"
+      ],
+      "relations": {},
+      "dateAdded": "2021-06-03T19:01:38Z",
+      "dateModified": "2021-06-03T19:01:44Z"
     },
     {
       "id": "9296070/YR58NY6F",
@@ -3778,65 +8490,70 @@
             25
           ]
         ]
-      }
-    },
-    {
-      "id": "9296070/HLN62MVN",
-      "type": "article-journal",
-      "title": "CommonLoops: merging Lisp and object-oriented programming",
-      "container-title": "ACM SIGPLAN Notices",
-      "page": "17–29",
-      "volume": "21",
-      "issue": "11",
-      "abstract": "CommonLoops blends object-oriented programming smoothly and tightly with the procedure-oriented design of Lisp. Functions and methods are combined in a more general abstraction. Message passing is invoked via normal Lisp function call. Methods are viewed as partial descriptions of procedures. Lisp data types are integrated with object classes. With these integrations, it is easy to incrementally move a program between the procedure and object-oriented styles. One of the most important properties of CommonLoops is its extensive use of meta-objects. We discuss three kinds of meta-objects: objects for classes, objects for methods, and objects for discriminators. We argue that these meta-objects make practical both efficient implementation and experimentation with new ideas for object-oriented programming. CommonLoops' small kernel is powerful enough to implement the major object-oriented systems in use today.",
-      "URL": "https://doi.org/10.1145/960112.28700",
-      "DOI": "10.1145/960112.28700",
-      "shortTitle": "CommonLoops",
-      "journalAbbreviation": "SIGPLAN Not.",
-      "author": [
+      },
+      "key": "YR58NY6F",
+      "version": 2034,
+      "itemType": "conferencePaper",
+      "creators": [
         {
-          "family": "Bobrow",
-          "given": "Daniel G."
+          "creatorType": "author",
+          "firstName": "Daniel G.",
+          "lastName": "Bobrow"
         },
         {
-          "family": "Kahn",
-          "given": "Kenneth"
+          "creatorType": "author",
+          "firstName": "Kenneth",
+          "lastName": "Kahn"
         },
         {
-          "family": "Kiczales",
-          "given": "Gregor"
+          "creatorType": "author",
+          "firstName": "Gregor",
+          "lastName": "Kiczales"
         },
         {
-          "family": "Masinter",
-          "given": "Larry"
+          "creatorType": "author",
+          "firstName": "Larry",
+          "lastName": "Masinter"
         },
         {
-          "family": "Stefik",
-          "given": "Mark"
+          "creatorType": "author",
+          "firstName": "Mark",
+          "lastName": "Stefik"
         },
         {
-          "family": "Zdybel",
-          "given": "Frank"
+          "creatorType": "author",
+          "firstName": "Frank",
+          "lastName": "Zdybel"
         }
       ],
-      "issued": {
-        "date-parts": [
-          [
-            "1986",
-            6,
-            1
-          ]
-        ]
-      },
-      "accessed": {
-        "date-parts": [
-          [
-            2021,
-            6,
-            3
-          ]
-        ]
-      }
+      "abstractNote": "CommonLoops blends object-oriented programming smoothly and tightly with the procedure-oriented design of Lisp. Functions and methods are combined in a more general abstraction. Message passing is invoked via normal Lisp function call. Methods are viewed as partial descriptions of procedures. Lisp data types are integrated with object classes. With these integrations, it is easy to incrementally move a program between the procedure and object-oriented styles. One of the most important properties of CommonLoops is its extensive use of meta-objects. We discuss three kinds of meta-objects: objects for classes, objects for methods, and objects for discriminators. We argue that these meta-objects make practical both efficient implementation and experimentation with new ideas for object-oriented programming. CommonLoops' small kernel is powerful enough to implement the major object-oriented systems in use today.",
+      "date": "June 1, 1986",
+      "proceedingsTitle": "Conference proceedings on Object-oriented programming systems, languages and applications",
+      "conferenceName": "",
+      "place": "New York, NY, USA",
+      "volume": "",
+      "pages": "17-29",
+      "series": "OOPSLA '86",
+      "language": "",
+      "url": "https://doi.org/10.1145/28697.28700",
+      "accessDate": "2021-04-25",
+      "archive": "",
+      "archiveLocation": "",
+      "libraryCatalog": "ACM Digital Library",
+      "callNumber": "",
+      "rights": "",
+      "extra": "",
+      "tags": [
+        {
+          "tag": "sz"
+        }
+      ],
+      "collections": [
+        "MTUXENI8"
+      ],
+      "relations": {},
+      "dateAdded": "2021-04-25T21:01:23Z",
+      "dateModified": "2021-06-03T19:40:14Z"
     },
     {
       "id": "9296070/YEQK68GN",
@@ -3880,7 +8597,52 @@
             3
           ]
         ]
-      }
+      },
+      "key": "YEQK68GN",
+      "version": 2602,
+      "itemType": "journalArticle",
+      "creators": [
+        {
+          "creatorType": "author",
+          "firstName": "Frank G.",
+          "lastName": "Halasz"
+        },
+        {
+          "creatorType": "author",
+          "firstName": "Thomas P.",
+          "lastName": "Moran"
+        },
+        {
+          "creatorType": "author",
+          "firstName": "Randall H.",
+          "lastName": "Trigg"
+        }
+      ],
+      "abstractNote": "NoteCards is an extensible environment designed to help people formulate, structure, compare, and manage ideas. NoteCards provides the user with a “semantic network” of electronic notecards interconnected by typed links. The system provides tools to organize, manage, and display the structure of the network, as well as a set of methods and protocols for creating programs to manipulate the information in the network. NoteCards is currently being used by more than 50 people engaged in idea processing tasks ranging from writing research papers through designing parts for photocopiers. In this paper we briefly describe NoteCards and the conceptualization of idea processing tasks that underlies its design. We then describe the NoteCards user community and several prototypical NoteCards applications. Finally, we discuss what we have learned about the system's strengths and weaknesses from our observations of the NoteCards user community.",
+      "publicationTitle": "ACM SIGCHI Bulletin",
+      "pages": "45–52",
+      "date": "Maggio 1, 1986",
+      "series": "",
+      "seriesTitle": "",
+      "seriesText": "",
+      "language": "",
+      "ISSN": "0736-6906",
+      "shortTitle": "",
+      "url": "https://doi.org/10.1145/30851.30859",
+      "accessDate": "2023-03-03T10:47:31Z",
+      "archive": "",
+      "archiveLocation": "",
+      "libraryCatalog": "May 1987",
+      "callNumber": "",
+      "rights": "",
+      "extra": "",
+      "tags": [],
+      "collections": [
+        "QTUS8XEQ"
+      ],
+      "relations": {},
+      "dateAdded": "2023-03-03T10:47:32Z",
+      "dateModified": "2023-03-03T10:47:32Z"
     },
     {
       "id": "9296070/YEUXRBGZ",
@@ -3911,7 +8673,41 @@
             23
           ]
         ]
-      }
+      },
+      "key": "YEUXRBGZ",
+      "version": 1964,
+      "itemType": "document",
+      "creators": [
+        {
+          "creatorType": "author",
+          "name": "Xerox"
+        }
+      ],
+      "abstractNote": "",
+      "date": "November, 1986",
+      "shortTitle": "",
+      "url": "http://www.bitsavers.org/pdf/xerox/interlisp-d/198510_Koto/3102300_Interlisp-D_A_Friendly_Primer_Nov86.pdf",
+      "accessDate": "2021-04-23T17:08:36Z",
+      "archive": "",
+      "archiveLocation": "",
+      "libraryCatalog": "",
+      "callNumber": "",
+      "rights": "",
+      "extra": "",
+      "tags": [
+        {
+          "tag": "Interlisp-D"
+        },
+        {
+          "tag": "s2z"
+        }
+      ],
+      "collections": [
+        "3CNYFDHF"
+      ],
+      "relations": {},
+      "dateAdded": "2021-05-31T16:14:54Z",
+      "dateModified": "2021-05-31T18:33:09Z"
     }
   ],
   "1987": [
@@ -3944,7 +8740,44 @@
             29
           ]
         ]
-      }
+      },
+      "key": "3W2WQS2B",
+      "version": 2507,
+      "itemType": "journalArticle",
+      "creators": [
+        {
+          "creatorType": "author",
+          "firstName": "Jeffrey",
+          "lastName": "Stone"
+        }
+      ],
+      "abstractNote": "",
+      "publicationTitle": "The AI Magazine",
+      "volume": "",
+      "issue": "",
+      "pages": "",
+      "date": "1987",
+      "series": "",
+      "seriesTitle": "",
+      "seriesText": "",
+      "journalAbbreviation": "",
+      "DOI": "",
+      "ISSN": "",
+      "url": "https://scholar.archive.org/work/sbbswzyqmbgwlpxikdxm7pfife",
+      "accessDate": "2022-09-29T00:23:37Z",
+      "archive": "",
+      "archiveLocation": "",
+      "libraryCatalog": "scholar.archive.org",
+      "callNumber": "",
+      "rights": "",
+      "extra": "",
+      "tags": [],
+      "collections": [
+        "3CNYFDHF"
+      ],
+      "relations": {},
+      "dateAdded": "2022-09-29T00:23:37Z",
+      "dateModified": "2022-09-29T00:23:37Z"
     },
     {
       "id": "9296070/CGTUSD9T",
@@ -3987,7 +8820,47 @@
             12
           ]
         ]
-      }
+      },
+      "key": "CGTUSD9T",
+      "version": 2704,
+      "itemType": "report",
+      "creators": [
+        {
+          "creatorType": "author",
+          "name": "Cunningham, Robert E."
+        },
+        {
+          "creatorType": "author",
+          "name": "Corbett, John D."
+        },
+        {
+          "creatorType": "author",
+          "name": "Bonar, Jeffrey G."
+        }
+      ],
+      "abstractNote": "Chips is an interactive tool for developing software employing graphical humancomputer interfaces on Xerox Lisp machines. For the programmer, It provides a rich graphical interface for the creation of rich graphical interfaces. In the service of an end user, It provides classes for modeling the graphical relationships of objects on the screen and maintaining constraints between them. Several large applications have been developed with Chips including intelligent tutors for programming and electricity. Chips is implemented as a collection of customizable classes in the LOOPS object-oriented extensions to Interlisp-D. The three fundamental classes are 1 DomainObject which defines objects of the application domain - the domain for which the interface is being built - and ties together the various functionalities provided by the Chips system 2 DisplayObject which defines mouse-sensitive graphical objects and 3 Substrate which defines specialized windows for displaying and storing collections of instances of DisplayObject. A programmer creates an interface by specializing existing DomainObjects and drawing new Displayobjects with a graphics editor. Instances of DispalyObject and Substrate are assembled on screen to form the interface. Once the interface has been sketched in this manner, the programmer can build inward, creating all other parts of the application through the objects on the screen.",
+      "reportNumber": "",
+      "reportType": "",
+      "seriesTitle": "",
+      "place": "",
+      "institution": "",
+      "date": "1987-10-01",
+      "pages": "71.0",
+      "url": "https://apps.dtic.mil/sti/citations/ADA187499",
+      "accessDate": "2023-04-12T19:02:22Z",
+      "archive": "",
+      "archiveLocation": "",
+      "libraryCatalog": "apps.dtic.mil",
+      "callNumber": "",
+      "rights": "",
+      "extra": "Section: Technical Reports",
+      "tags": [],
+      "collections": [
+        "MTUXENI8"
+      ],
+      "relations": {},
+      "dateAdded": "2023-04-12T19:02:22Z",
+      "dateModified": "2023-04-12T19:08:29Z"
     },
     {
       "id": "9296070/8CFC7VH5",
@@ -4023,7 +8896,47 @@
             15
           ]
         ]
-      }
+      },
+      "key": "8CFC7VH5",
+      "version": 1663,
+      "itemType": "journalArticle",
+      "creators": [
+        {
+          "creatorType": "author",
+          "firstName": "Gordy G.",
+          "lastName": "Shanor"
+        }
+      ],
+      "abstractNote": "The Dipmeter Advisor is a knowledge-base system, linked to a computer work-station, designed to aid in the interpretation of dipmeter results through interaction between the interpreter and the \"expert\" system.\n\nThe system utilizes dipmeter results, other wireline log data, computer processed results such as LITHO*, and user-input local geological knowledge as the framework for the interpretation. A work session proceeds through a number of phases, which leads to first a structural, then a stratigraphic interpretation of the well data.\n\nConclusions made by the Dipmeter Advisor can be accepted, modified, or rejected by the interpreter at any stage of the work session. The user may also make his own conclusions and comments, which are stored as part of the final interpretation and become part of an updated knowledge-base for input to further field studies.",
+      "publicationTitle": "Bulletin of the Geological Society of Malaysia",
+      "issue": "",
+      "pages": "37-54",
+      "date": "1987-12-30",
+      "series": "",
+      "seriesTitle": "",
+      "seriesText": "",
+      "language": "",
+      "ISSN": "01266187, 2637109X",
+      "shortTitle": "",
+      "url": "https://gsm.org.my/content.php?id=54&pid=702001-101136",
+      "accessDate": "2021-04-15T23:03:04Z",
+      "archive": "",
+      "archiveLocation": "",
+      "libraryCatalog": "DOI.org (Crossref)",
+      "callNumber": "",
+      "rights": "",
+      "extra": "",
+      "tags": [
+        {
+          "tag": "sz"
+        }
+      ],
+      "collections": [
+        "MTUXENI8"
+      ],
+      "relations": {},
+      "dateAdded": "2021-04-15T23:03:04Z",
+      "dateModified": "2021-06-02T17:37:02Z"
     },
     {
       "id": "9296070/Y73ECKA4",
@@ -4061,7 +8974,48 @@
             31
           ]
         ]
-      }
+      },
+      "key": "Y73ECKA4",
+      "version": 2244,
+      "itemType": "journalArticle",
+      "creators": [
+        {
+          "creatorType": "author",
+          "firstName": "Lee A.",
+          "lastName": "Gladwin"
+        }
+      ],
+      "abstractNote": "",
+      "publicationTitle": "IEEE Intelligent Systems",
+      "pages": "94-94",
+      "date": "1987/07/01",
+      "series": "",
+      "seriesTitle": "",
+      "seriesText": "",
+      "journalAbbreviation": "",
+      "ISSN": "1541-1672",
+      "url": "https://www.computer.org/csdl/magazine/ex/1987/03/04307102/1e7uj6wTMVG",
+      "accessDate": "2021-05-31T18:46:00Z",
+      "archive": "",
+      "archiveLocation": "",
+      "libraryCatalog": "www.computer.org",
+      "callNumber": "",
+      "rights": "",
+      "extra": "Publisher: IEEE Computer Society",
+      "tags": [
+        {
+          "tag": "interlisp"
+        },
+        {
+          "tag": "s2z"
+        }
+      ],
+      "collections": [
+        "TVX6WEZX"
+      ],
+      "relations": {},
+      "dateAdded": "2021-05-31T18:46:00Z",
+      "dateModified": "2021-08-27T23:18:27Z"
     },
     {
       "id": "9296070/EFHC285D",
@@ -4100,7 +9054,46 @@
             15
           ]
         ]
-      }
+      },
+      "key": "EFHC285D",
+      "version": 1673,
+      "itemType": "conferencePaper",
+      "creators": [
+        {
+          "creatorType": "author",
+          "firstName": "J. D.",
+          "lastName": "Myers"
+        }
+      ],
+      "abstractNote": "During my tenure as Chairman of the Department of Medicine at the University of Pittsburgh, 1955 to 1970, two points became clear in regard to diagnosis in internal medicine. The first was that the knowledge base in that field had become vastly too large for any single person to encompass it. The second point was that the busy practitioner, even though he knew the items of information pertinent to his patients correct diagnosis, often did not consider the right answer particularly if the diagnosis was an unusual disease. I resigned the position of Chairman in 1970 intending to resume my position as Professor of Medicine. However, the University saw fit to offer me the appointment as University Professor (Medicine). The University of Pittsburgh follows the practice of Harvard University, established by President James Bryant Conant in the late 1930s, in which a University Professor is a professor at large and reports only to the president of the university. He has no department, no school and is not under administrative supervision by a dean or vice-president. Thus the position allows maximal academic freedom. In this new position I felt strongly that I should conduct worthwhile research. It was almost fifteen years since I had worked in my chosen field of clinical investigation, namely splanchnic blood flow and metabolism, and I felt that research in that area had passed me by. Remembering the two points mentioned earlier — the excessive knowledge base of internal medicine and the problem of considering the correct diagnosis — I asked myself what could be done to correct these problems. It seemed that the computer with its huge memory could correct the first and I wondered if it could not help as well with the second. At that point I knew no more about computers than the average layman so I sought advice. Dr. Gerhard Werner, our Chairman of Pharmacology, was working with computers in an attempt to map all of the neurological centers of the human brain stem with particular reference to their interconnections and functions. He was particularly concerned about the actions of pharmacological agents on this complex system. Working with him on this problem was Dr. Harry Pople, a computer scientist with special interest in “artificial intelligence”. The problem chosen was so complex and difficult that Werner and Pople were making little progress. Gerhard listened patiently to my ideas and promptly stated that he thought the projects were feasible utilizing the computer. In regard to the diagnostic component of my ambition he strongly advised that “artificial intelligence” be used. Pople was brought into the discussion and was greatly interested, I believe because of the feasibility of the project and the recognition of its practical application to the practice of medicine. The upshot was that Pople joined me in my project and Werner and Pople abandoned the work on the brain stem. Pople knew nothing about medicine and I knew nothing about computer science. Thus the first step in our collaboration was my analysis for Pople of the diagnostic process. I chose a goodly number of actual cases from clinical pathological conferences (CPCs) because they contained ample clinical data and because the correct diagnoses were known. At each small step of the way through the diagnostic process I was required to explain what the clinical information meant in context and my reasons for considering certain diagnoses. This provided to Pople insight into the diagnostic process. After analyzing dozens of such cases I felt as though I had undergone a sort of “psychoanalysis”. From this experience Pople wrote the first computer diagnostic programs seeking to emulate my diagnostic process. This has led certain “wags” to nickname our project “Jack in the box”. For this initial attempt Pople used the LISP computer language. We were granted access to the PROPHET PDP-10, a time-sharing mainframe maintained in Boston by the National Institutes of Health (NIH) but devoted particularly to pharmacological research. Thus we were interlopers. The first name we applied to our project was DIALOG, for diagnostic logic, but this had to be dropped because the name was in conflict with a computer program already on the market and copyrighted. The next name chosen was INTERNIST for obvious reason. However, the American Society for Internal Medicine publishes a journal entitled “The Internist” and they objected to our use of INTERNIST although there seems to be little relationship or conflict between a printed journal and a computer software program. Rather than fight the issue we simply added the Roman numeral one to our title which then became INTERNIST-I, which continues to this day. Pople's initial effort was unsuccessful, however. He diligently had incorporated details regarding anatomy and much basic pathophysiology, I believe because in my initial CPC analyses I had brought into consideration such items of information so that Pople could understand how I got from A to B etc. The diagnostician in internal medicine knows, of course, much anatomy and patho-physiology but these are brought into consideration in only a minority of diagnostic problems. He knows, for example, that the liver is in the right upper quadrant and just beneath the right leaf of the diaphragm. In most diagnostic instances this information is “subconscious”. Our first computer diagnostic program included too many such details and as a result was very slow and frequently got into analytical “loops” from which it could not extricate itself. We decided that we had to simplify the program but by that juncture much of 1971 had passed on. The new program was INTERNIST-I and even today most of the basic structure devised in 1972 remains intact. INTERNIST-I is written in INTERLISP and has operated on the PDP-10 and the DEC 2060. It has also been adapted to the VAX 780. Certain younger people have contributed significantly to the program, particularly Dr. Zachary Moraitis and Dr. Randolph Miller. The latter interrupted his regular medical school education to spend the year 1974-75 as a fellow in our laboratory and since finishing his formal medical education in 1979 has been active as a full time faculty member of the team. Several Ph.D. candidates in computer science have also made significant contributions as have dozens of medical students during electives on the project. INTERNIST-I is really quite a simple system as far as its operating system or inference engine is concerned. Three basic numbers are concerned in and manipulated in the ranking of elicited disease hypotheses. The first of these is the importance (IMPORT) of each of the more than 4,100 manifestations of disease which are contained in the knowledge base. IMPORTS are a global representation of the clinical importance of a given finding graded from 1 to 5, the latter being maximal, focusing on how necessary it is to explain the manifestation regardless of the final diagnosis. Thus massive splenomegaly has an IMPORT of 5 whereas anorexia has an IMPORT of 1. Mathematical weights are assigned to IMPORT numbers on a non-linear scale. The second basic number is the evoking strength (EVOKS), the numbers ranging from 0 to 5. The number answers the question, that given a particular manifestation of disease, how strongly does one consider disease A versus all other diagnostic possibilities in a clinical situation. A zero indicates that a particular clinical manifestation is non-specific, i.e. so widely spread among diseases that the above question cannot be answered usefully. Again, anorexia is a good example of a non-specific manifestation. The EVOKS number 5, on the other hand, indicates that a manifestation is essentially pathognomonic for a particular disease. The third basic number is the frequency (FREQ) which answers the question that given a particular disease what is the frequency or incidence of occurrence of a particular clinical finding. FREQ numbers range from 1 to 5, one indicating that the finding is rare or unusual in the disease and 5 indicating that the finding is present in essentially all instances of the disease. Each diagnosis which is evoked is ranked mathematically on the basis of support for it, both positive and negative. Like the import number, the values for EVOKS and FREQ numbers increase in a non-linear fashion. The establishment or conclusion of a diagnosis is not based on any absolute score, as in Bayesian systems, but on how much better is the support of diagnosis A as compared to its nearest competitor. This difference is anchored to the value of an EVOKS of 5, a pathognomonic finding. When the list of evoked diagnoses is ranked mathematically on the basis of EVOKS, FREQ and IMPORT, the list is partitioned based upon the similarity of support for individual diagnoses. Thus a heart disease is compared with other heart diseases and not brain diseases since the patient may have a heart disorder and a brain disease concommitantly. Thus apples are compared with apples and not oranges. When a diagnosis is concluded, the computer consults a list of interrelationships among diseases (LINKS) and bonuses are awarded, again in a non-linear fashion for numbers ranging from 1 to 5 — 1 indicating a weak interrelationship and 5 a universal interrelationship. Thus multiple interrelated diagnoses are preferred over independent ones provided the support for the second and other diagnoses is adequate. Good clinicians use this same rule of thumb. LINKS are of various types: PCED is used when disease A precedes disease B, e.g. acute rheumatic fever precedes early rheumatic valvular disease; PDIS - disease A predisposes to disease B, e.g. AIDS predisposes to pneumocystis pneumonia; CAUS - disease A causes disease B, e.g. thrombophlebitis of the lower extremities may cause pulmonary embolism; and COIN - there is a statistical interrelationship between disease A and disease B but scientific medical information is not explicit on the relationship, e.g. Hashimoto's thyroiditis coincides with pernicious anemia, both so called autoimmune diseases. The maximal number of correct diagnoses made in a single case analysis is, to my recollection, eleven. In working with INTERNIST-I during the remainder of the 1970s several important points about the system were learned or appreciated. The first and foremost of these is the importance of a complete and accurate knowledge base. Omissions from a disease profile can be particularly troublesome. If a manifestation of disease is not listed on a disease profile the computer can only conclude that that manifestation does not occur in the disease, and if a patient demonstrates the particular manifestation it counts against the diagnosis. Fortunately, repeated exercise of the diagnostic system brings to attention many inadvertent omissions. It is important to establish the EVOKS and FREQ numbers as accurately as possible. Continual updating of the knowledge base, including newly described diseases and new information about diseases previously profiled, is critical. Dr. Edward Feigenbaum recognized the importance of the accuracy and completeness of knowledge bases as the prime requisite of expert systems of any sort. He emphasized this point in his keynote address to MEDINFO-86 (1). Standardized, clear and explicit nomenclature is required in expressing disease names and particularly in naming the thousands of individual manifestations of disease. Such rigidity can make the use of INTERNIST-I difficult for the uninitiated user. Therefore, in QMR more latitude and guidance is provided the user. For example, the user of INTERNIST-I must enter ABDOMEN PAIN RIGHT UPPER QUADRANT exactly whereas in QMR the user may enter PAI ABD RUQ and the system recognizes the term as above. The importance of “properties” attached to the great majority of clinical manifestations was solidly evident. Properties express such conditions that if A is true then B is automatically false (or true as the case may be). The properties also allow credit to be awarded for or against B as the case may be. Properties also provide order to the asking of questions in the interrogative mode. They also state prerequisites and unrequisites for various procedures. As examples, one generally does not perform a superficial lymph node biopsy unless lymph nodes are enlarged (prerequisite). Similarly, a percutaneous liver biopsy is inadvisable if the blood platelets are less than 50,000 (unrequisite). It became clear quite early in the utilization of INTERNIST-I that systemic or multisystem diseases had an advantage versus localized disorders in diagnosis. This is because systemic diseases have very long and more inclusive manifestation lists. It became necessary, therefore, to subdivide systemic diseases into various components when appropriate. Systemic lupus erythematosus provides a good example. Lupus nephritis must be compared in our system with other renal diseases and such comparison is allowed by our partitioning algorithm. Likewise, cerebral lupus must be differentiated from other central nervous system disorders. Furthermore, either renal lupus or cerebral lupus can occur at times without significant clinical evidence of other systemic involvement. In order to reassemble the components of a systemic disease we devised the systemic LINK (SYST) which expresses the interrelationship of each subcomponent to the parent systemic disease. It became apparent quite early that expert systems like INTERNIST do not deal with the time axis of a disease well at all, and this seems to be generally true of expert systems in “artificial intelligence”. Certain parameters dealing with time can be expressed by devising particular manifestations, e.g. a blood transfusion preceding the development of acute hepatitis B by 2 to 6 months. But time remains a problem which is yet to be solved satisfactorily including QMR. It has been clearly apparent over the years that both the knowledge base and the diagnostic consultant programs of both INTERNIST-I and QMR have considerable educational value. The disease profiles, the list of diseases in which a given clinical manifestation occurs (ordered by EVOKS and FREQ), and the interconnections among diseases (LINKS) provide a quick and ready means of acquiring at least orienting clinical information. Such has proved useful not only to medical students and residents but to clinical practitioners as well. In the interrogative mode of the diagnostic systems the student will frequently ask “Why was that question asked?” An instructor can either provide insight or ready consultation of the knowledge base by the student will provide a simple semi-quantitative reason for the question. Lastly, let the author state that working with INTERNIST-I and QMR over the years seems to have had real influence on his own diagnostic approaches and habits. Thus my original psycho-analysis when working with Pople has been reinforced.",
+      "date": "December 1, 1987",
+      "proceedingsTitle": "Proceedings of ACM conference on History of medical informatics",
+      "conferenceName": "",
+      "place": "New York, NY, USA",
+      "volume": "",
+      "pages": "195–197",
+      "series": "HMI '87",
+      "language": "",
+      "shortTitle": "",
+      "url": "https://doi.org/10.1145/41526.41543",
+      "accessDate": "2021-04-15",
+      "archive": "",
+      "archiveLocation": "",
+      "libraryCatalog": "ACM Digital Library",
+      "callNumber": "",
+      "rights": "",
+      "extra": "",
+      "tags": [
+        {
+          "tag": "sz"
+        }
+      ],
+      "collections": [
+        "MTUXENI8"
+      ],
+      "relations": {},
+      "dateAdded": "2021-04-15T23:18:51Z",
+      "dateModified": "2021-06-02T17:45:31Z"
     },
     {
       "id": "9296070/25TEJPHA",
@@ -4124,7 +9117,40 @@
             6
           ]
         ]
-      }
+      },
+      "key": "25TEJPHA",
+      "version": 1984,
+      "itemType": "document",
+      "creators": [
+        {
+          "creatorType": "author",
+          "name": "Anonymous"
+        }
+      ],
+      "abstractNote": "The Xerox Common Lisp Implementation Notes cover several aspects of the Lyric release. In these notes you will find:\n• An explanation of how Xerox Common Lisp extends the Common Lisp standard. For example, in Xerox Common Lisp the Common Lisp array-constructing function make-array has additional keyword\narguments that enhance its functionality.\n• An explanation of how several ambiguities in Steele's Common Lisp: the Language were\nresolved.\n• A description of additional features that provide far more than extensions to Common Lisp.",
+      "date": "June 1987",
+      "url": "http://www.bitsavers.org/pdf/xerox/interlisp-d/198706_Lyric/3102464_Lyric_Common_Lisp_Implementation_Notes_Jun87.pdf",
+      "accessDate": "",
+      "archive": "",
+      "archiveLocation": "",
+      "libraryCatalog": "",
+      "callNumber": "",
+      "rights": "",
+      "extra": "",
+      "tags": [
+        {
+          "tag": "Interlisp-D"
+        },
+        {
+          "tag": "s2z"
+        }
+      ],
+      "collections": [
+        "3CNYFDHF"
+      ],
+      "relations": {},
+      "dateAdded": "2021-05-31T16:10:32Z",
+      "dateModified": "2021-05-31T18:29:27Z"
     },
     {
       "id": "9296070/F9XE85C9",
@@ -4160,43 +9186,52 @@
             23
           ]
         ]
-      }
-    },
-    {
-      "id": "9296070/F9XE85C9",
-      "type": "article",
-      "title": "Artificial intelligence Systems Xerox LOOPS, A Friendly Primer",
-      "publisher": "Xerox Corporation",
-      "URL": "http://www.bitsavers.org/pdf/xerox/interlisp-d/198510_Koto/3102242_Xerox_LOOPS_A_Friendly_Primer_Mar87.pdf",
-      "shortTitle": "Interlisp-D_A-Friendly-Primer",
-      "language": "en",
-      "author": [
+      },
+      "key": "F9XE85C9",
+      "version": 2430,
+      "itemType": "document",
+      "creators": [
         {
-          "family": "Mears",
-          "given": "Lyn Ann"
+          "creatorType": "author",
+          "firstName": "Lyn Ann",
+          "lastName": "Mears"
         },
         {
-          "family": "Rees",
-          "given": "Ted"
+          "creatorType": "author",
+          "firstName": "Ted",
+          "lastName": "Rees"
         }
       ],
-      "issued": {
-        "date-parts": [
-          [
-            "1987",
-            3
-          ]
+      "abstractNote": "",
+      "date": "March, 1987",
+      "url": "http://www.bitsavers.org/pdf/xerox/interlisp-d/198510_Koto/3102242_Xerox_LOOPS_A_Friendly_Primer_Mar87.pdf",
+      "accessDate": "2021-04-23T17:08:36Z",
+      "archive": "",
+      "archiveLocation": "",
+      "libraryCatalog": "",
+      "callNumber": "",
+      "rights": "",
+      "extra": "",
+      "tags": [
+        {
+          "tag": "Interlisp-D"
+        },
+        {
+          "tag": "s2z"
+        }
+      ],
+      "collections": [
+        "MTUXENI8",
+        "8MSYRKQA"
+      ],
+      "relations": {
+        "dc:replaces": [
+          "http://zotero.org/groups/2914042/items/ARPPJMIN",
+          "http://zotero.org/groups/2914042/items/KLCR6KYN"
         ]
       },
-      "accessed": {
-        "date-parts": [
-          [
-            2021,
-            4,
-            23
-          ]
-        ]
-      }
+      "dateAdded": "2021-04-25T18:13:25Z",
+      "dateModified": "2021-05-31T18:32:46Z"
     },
     {
       "id": "9296070/692EZNZV",
@@ -4240,7 +9275,46 @@
             3
           ]
         ]
-      }
+      },
+      "key": "692EZNZV",
+      "version": 2608,
+      "itemType": "conferencePaper",
+      "creators": [
+        {
+          "creatorType": "author",
+          "firstName": "Randall H.",
+          "lastName": "Trigg"
+        },
+        {
+          "creatorType": "author",
+          "firstName": "Peggy M.",
+          "lastName": "Irish"
+        }
+      ],
+      "abstractNote": "This paper reports on an investigation into the use of the NoteCards hypertext system for writing. We describe a wide variety of personal styles adopted by 20 researchers at Xerox as they “inhabit” NoteCards. This variety is displayed in each of their writing activities: notetaking, organizing and reorganizing their work, maintaining references and bibliographies, and preparing documents. In addition, we discuss the distinctive personal decisions made as to which activities are appropriate for NoteCards in the first place. Finally, we conclude with a list of recommendations for system designers arising from this work.",
+      "date": "Novembre 1, 1987",
+      "proceedingsTitle": "Proceedings of the ACM conference on Hypertext",
+      "conferenceName": "",
+      "place": "New York, NY, USA",
+      "volume": "",
+      "pages": "89–108",
+      "series": "HYPERTEXT '87",
+      "language": "",
+      "url": "https://doi.org/10.1145/317426.317435",
+      "accessDate": "2023-03-03",
+      "archive": "",
+      "archiveLocation": "",
+      "libraryCatalog": "ACM Digital Library",
+      "callNumber": "",
+      "rights": "",
+      "extra": "",
+      "tags": [],
+      "collections": [
+        "QTUS8XEQ"
+      ],
+      "relations": {},
+      "dateAdded": "2023-03-03T10:49:02Z",
+      "dateModified": "2023-03-03T10:49:02Z"
     }
   ],
   "1988": [
@@ -4267,32 +9341,65 @@
             1988
           ]
         ]
-      }
-    },
-    {
-      "id": "9296070/VS7BU7LL",
-      "type": "article-journal",
-      "title": "An interactive knowledge-based system for group problem solving",
-      "container-title": "IEEE Transactions on Systems, Man, & Cybernetics",
-      "page": "610-617",
-      "volume": "18",
-      "issue": "4",
-      "abstract": "Discusses a distributed system for human–computer interaction based on a network of computers. The system aids group problem solving by enabling participants to share in a construct elicitation process based on repertory grid techniques that have applications in education, management, and expert systems development. In education, the learner is attempting to acquire a specific construct system for the subject matter; in management, people with different construct systems are attempting to work together toward common objectives; in expert systems development, the knowledge engineer is attempting to make overt and encode the relevant construction system of an expert. The participant construct system enables individuals to interact through networked personal computers to develop mutual understanding of a problem domain through the use of repertory grid techniques. (PsycINFO Database Record (c) 2016 APA, all rights reserved)",
-      "DOI": "10.1109/21.17379",
-      "note": "Place: US\nPublisher: Institute of Electrical & Electronics Engineers Inc",
-      "author": [
+      },
+      "key": "VS7BU7LL",
+      "version": 2502,
+      "itemType": "journalArticle",
+      "creators": [
         {
-          "family": "Shaw",
-          "given": "Mildred L."
+          "creatorType": "author",
+          "firstName": "Mildred L.",
+          "lastName": "Shaw"
         }
       ],
-      "issued": {
-        "date-parts": [
-          [
-            1988
-          ]
-        ]
-      }
+      "abstractNote": "Discusses a distributed system for human–computer interaction based on a network of computers. The system aids group problem solving by enabling participants to share in a construct elicitation process based on repertory grid techniques that have applications in education, management, and expert systems development. In education, the learner is attempting to acquire a specific construct system for the subject matter; in management, people with different construct systems are attempting to work together toward common objectives; in expert systems development, the knowledge engineer is attempting to make overt and encode the relevant construction system of an expert. The participant construct system enables individuals to interact through networked personal computers to develop mutual understanding of a problem domain through the use of repertory grid techniques. (PsycINFO Database Record (c) 2016 APA, all rights reserved)",
+      "publicationTitle": "IEEE Transactions on Systems, Man, & Cybernetics",
+      "pages": "610-617",
+      "date": "1988",
+      "series": "",
+      "seriesTitle": "",
+      "seriesText": "",
+      "journalAbbreviation": "",
+      "language": "",
+      "ISSN": "0018-9472",
+      "shortTitle": "",
+      "url": "",
+      "accessDate": "",
+      "archive": "",
+      "archiveLocation": "",
+      "libraryCatalog": "APA PsycNet",
+      "callNumber": "",
+      "rights": "",
+      "extra": "Place: US\nPublisher: Institute of Electrical & Electronics Engineers Inc",
+      "tags": [
+        {
+          "tag": "Computer Applications",
+          "type": 1
+        },
+        {
+          "tag": "Education",
+          "type": 1
+        },
+        {
+          "tag": "Group Problem Solving",
+          "type": 1
+        },
+        {
+          "tag": "Human Machine Systems",
+          "type": 1
+        },
+        {
+          "tag": "Management",
+          "type": 1
+        }
+      ],
+      "collections": [
+        "MTUXENI8",
+        "QTUS8XEQ"
+      ],
+      "relations": {},
+      "dateAdded": "2022-08-05T04:11:20Z",
+      "dateModified": "2022-08-05T04:11:20Z"
     },
     {
       "id": "9296070/FDA3AUNV",
@@ -4331,7 +9438,46 @@
             4
           ]
         ]
-      }
+      },
+      "key": "FDA3AUNV",
+      "version": 2478,
+      "itemType": "journalArticle",
+      "creators": [
+        {
+          "creatorType": "author",
+          "firstName": "T.",
+          "lastName": "Koschmann"
+        },
+        {
+          "creatorType": "author",
+          "firstName": "M.W.",
+          "lastName": "Evens"
+        }
+      ],
+      "abstractNote": "",
+      "publicationTitle": "IEEE Software",
+      "pages": "36-42",
+      "date": "07/1988",
+      "series": "",
+      "seriesTitle": "",
+      "seriesText": "",
+      "ISSN": "0740-7459",
+      "shortTitle": "",
+      "url": "http://ieeexplore.ieee.org/document/17800/",
+      "accessDate": "2022-08-04T23:56:13Z",
+      "archive": "",
+      "archiveLocation": "",
+      "libraryCatalog": "DOI.org (Crossref)",
+      "callNumber": "",
+      "rights": "",
+      "extra": "",
+      "tags": [],
+      "collections": [
+        "MTUXENI8"
+      ],
+      "relations": {},
+      "dateAdded": "2022-08-04T23:56:13Z",
+      "dateModified": "2022-08-04T23:56:13Z"
     },
     {
       "id": "9296070/9RRR7G7F",
@@ -4368,7 +9514,41 @@
             3
           ]
         ]
-      }
+      },
+      "key": "9RRR7G7F",
+      "version": 2599,
+      "itemType": "journalArticle",
+      "creators": [
+        {
+          "creatorType": "author",
+          "firstName": "Frank,G.",
+          "lastName": "Halasz"
+        }
+      ],
+      "abstractNote": "NoteCards, developed by a team at Xerox PARC, was designed to support the task of transforming a chaotic collection of unrelated thoughts into an integrated, orderly interpretation of ideas and their interconnections. This article presents NoteCards as a foil against which to explore some of the major limitations of the current generation of hypermedia systems, and characterizes the issues that must be addressed in designing the next generation systems.",
+      "publicationTitle": "Communications of the ACM",
+      "pages": "836–852",
+      "date": "Luglio 1, 1988",
+      "series": "",
+      "seriesTitle": "",
+      "seriesText": "",
+      "language": "",
+      "ISSN": "0001-0782",
+      "url": "https://doi.org/10.1145/48511.48514",
+      "accessDate": "2023-03-03T10:46:11Z",
+      "archive": "",
+      "archiveLocation": "",
+      "libraryCatalog": "July 1988",
+      "callNumber": "",
+      "rights": "",
+      "extra": "",
+      "tags": [],
+      "collections": [
+        "QTUS8XEQ"
+      ],
+      "relations": {},
+      "dateAdded": "2023-03-03T10:46:11Z",
+      "dateModified": "2023-03-03T10:46:11Z"
     }
   ],
   "1989": [
@@ -4413,7 +9593,64 @@
             28
           ]
         ]
-      }
+      },
+      "key": "GPMCN5XC",
+      "version": 2418,
+      "itemType": "conferencePaper",
+      "creators": [
+        {
+          "creatorType": "author",
+          "firstName": "Philip R.",
+          "lastName": "Martz"
+        },
+        {
+          "creatorType": "author",
+          "firstName": "Matt",
+          "lastName": "Heffron"
+        },
+        {
+          "creatorType": "author",
+          "firstName": "Suresh",
+          "lastName": "Kalbag"
+        },
+        {
+          "creatorType": "author",
+          "firstName": "Douglas F.",
+          "lastName": "Dyckes"
+        },
+        {
+          "creatorType": "author",
+          "firstName": "Paul",
+          "lastName": "Voelker"
+        }
+      ],
+      "abstractNote": "Peptide synthesis is an important research tool. However, successful syntheses require considerable effort from the scientist. We have produced an expert System, the PepPro™ Peptide Synthesis Expert System, that helps the scientist improve peptide syntheses. To use PepPro the scientist enters the peptide to be synthesized. PepPro then applies its synthesis rules to analyze the peptide, to predict coupling. problems, and to recommend solutions. PepPro produces a synthesis report that summarizes the analysis and recommendations. The program includes a capability that allows the scientist to write new synthesis rules and add them to the PepPro knowledge base. PepPro was developed on Xerox 11xx series workstations using Beckman’s proprietary development environment MP). We then compiled PepPro to run on the IBM PC. PepPro has limitations that derive from unpredictable events during a synthesis. Despite the limitations, PepPro provides several important benefits. The major one is that it makes peptide syntheses easier, less time-consuming, and more efficient.",
+      "date": "March 28–30, 1989",
+      "proceedingsTitle": "PROCEEDINGS OF THE FIRST ANNUAL CONFERENCE ON INNOVATIVE APPLICATIONS OF ARTIFICIAL INTELLIGENCE",
+      "conferenceName": "THE FIRST ANNUAL CONFERENCE ON INNOVATIVE APPLICATIONS OF ARTIFICIAL INTELLIGENCE",
+      "place": "Stanford, California",
+      "volume": "",
+      "pages": "",
+      "series": "",
+      "language": "",
+      "DOI": "",
+      "ISBN": "",
+      "shortTitle": "",
+      "url": "https://www.aaai.org/Papers/IAAI/1989/IAAI89-010.pdf",
+      "accessDate": "",
+      "archive": "",
+      "archiveLocation": "",
+      "libraryCatalog": "",
+      "callNumber": "",
+      "rights": "",
+      "extra": "",
+      "tags": [],
+      "collections": [
+        "MTUXENI8"
+      ],
+      "relations": {},
+      "dateAdded": "2022-06-29T19:34:03Z",
+      "dateModified": "2022-06-29T19:38:35Z"
     }
   ],
   "1990": [
@@ -4455,7 +9692,77 @@
             1
           ]
         ]
-      }
+      },
+      "key": "SYHYTLHH",
+      "version": 2706,
+      "itemType": "patent",
+      "creators": [
+        {
+          "creatorType": "inventor",
+          "firstName": "Thomas A.",
+          "lastName": "Lipkis"
+        },
+        {
+          "creatorType": "inventor",
+          "firstName": "William S.",
+          "lastName": "Mark"
+        },
+        {
+          "creatorType": "inventor",
+          "firstName": "Melvin W.",
+          "lastName": "Pirtle"
+        }
+      ],
+      "abstractNote": "A computer-based tool, in the form of a computer system and method, for designing, constructing and interacting with any system containing or comprising concurrent asynchronous processes, such as a factory operation. In the system according to the invention a variety of development and execution tools are supported. The invention features a highly visual user presentation of a control system, including structure, specification, and operation, offering a user an interactive capability for rapid design, modification, and exploration of the operating characteristics of a control system comprising asynchronous processes. The invention captures a representation of the system (RS) that is equivalent to the actual system (AS)--rather than a simulation of the actual system. This allows the invention to perform tests and modification on RS instead of AS, yet get accurate results. RS and AS are equivalent because AS is generated directly from RS by an automated process. Effectively, pressing a button in the RS environment can \"create\" the AS version or any selected portion of it, by \"downloading\" a translation of the RS version that can be executed by a programmable processor in the AS environment. Information can flow both ways between AS and RS. That AS and RS can interact is important. This allows RS to \"take on\" the \"state\" of AS whenever desired, through an \"uploading\" procedure, thereby reflecting accurately the condition of AS at a specific point in time.",
+      "place": "",
+      "country": "US",
+      "assignee": "Savoir",
+      "issuingAuthority": "United States",
+      "patentNumber": "US4914567A",
+      "filingDate": "1988-10-24",
+      "pages": "",
+      "applicationNumber": "US07/261,953",
+      "priorityNumbers": "",
+      "issueDate": "1990-04-03",
+      "references": "",
+      "legalStatus": "",
+      "language": "",
+      "shortTitle": "",
+      "url": "https://patents.google.com/patent/US4914567A/en",
+      "accessDate": "2021-06-01T20:38:19Z",
+      "rights": "",
+      "extra": "",
+      "tags": [
+        {
+          "tag": "control",
+          "type": 1
+        },
+        {
+          "tag": "designing",
+          "type": 1
+        },
+        {
+          "tag": "objects",
+          "type": 1
+        },
+        {
+          "tag": "programming",
+          "type": 1
+        },
+        {
+          "tag": "recited",
+          "type": 1
+        },
+        {
+          "tag": "sz"
+        }
+      ],
+      "collections": [
+        "MTUXENI8"
+      ],
+      "relations": {},
+      "dateAdded": "2021-06-01T20:38:19Z",
+      "dateModified": "2023-04-20T02:58:38Z"
     },
     {
       "id": "9296070/GDWUKLUH",
@@ -4489,10 +9796,145 @@
             2
           ]
         ]
-      }
+      },
+      "key": "GDWUKLUH",
+      "version": 2612,
+      "itemType": "webpage",
+      "creators": [
+        {
+          "creatorType": "author",
+          "firstName": "World Leaders in Research-Based User",
+          "lastName": "Experience"
+        }
+      ],
+      "abstractNote": "Jakob Nielsen's trip report from the ACM Hypertext'89 conference. Includes summary of Meyrowitz' discussion of open integrating hypertext and the extent to which the Memex vision has been realized so far.",
+      "websiteTitle": "Nielsen Norman Group",
+      "websiteType": "",
+      "date": "April 1, 1990",
+      "url": "https://www.nngroup.com/articles/trip-report-hypertext-89/",
+      "accessDate": "2023-03-02T15:56:30Z",
+      "rights": "",
+      "extra": "",
+      "tags": [],
+      "collections": [
+        "QTUS8XEQ"
+      ],
+      "relations": {},
+      "dateAdded": "2023-03-02T15:56:30Z",
+      "dateModified": "2023-03-04T01:58:05Z"
     }
   ],
   "1991": [
+    {
+      "id": "9296070/5QACWN9U",
+      "type": "patent",
+      "title": "Interactive method of developing software interfaces",
+      "abstract": "A system and method for interactive design of user manipulable graphic elements. A computer has display and stored tasks wherein the appearance of graphic elements and methods for their manipulation are defined. Each graphic element is defined by at least one figure specification, one mask specification and one map specification. An interactive display editor program defines specifications of said graphic elements. An interactive program editor program defines programming data and methods associated with said graphic elements. A display program uses the figure, map and mask specifications for assembling graphic elements upon the display and enabling user manipulation of said graphic elements.",
+      "URL": "https://patents.google.com/patent/US5041992A/en",
+      "number": "US5041992A",
+      "author": [
+        {
+          "family": "Cunningham",
+          "given": "Robert E."
+        },
+        {
+          "family": "Bonar",
+          "given": "Jeffery G."
+        },
+        {
+          "family": "Corbett",
+          "given": "John D."
+        }
+      ],
+      "issued": {
+        "date-parts": [
+          [
+            1991,
+            8,
+            20
+          ]
+        ]
+      },
+      "accessed": {
+        "date-parts": [
+          [
+            2021,
+            6,
+            1
+          ]
+        ]
+      },
+      "key": "5QACWN9U",
+      "version": 2031,
+      "itemType": "patent",
+      "creators": [
+        {
+          "creatorType": "inventor",
+          "firstName": "Robert E.",
+          "lastName": "Cunningham"
+        },
+        {
+          "creatorType": "inventor",
+          "firstName": "Jeffery G.",
+          "lastName": "Bonar"
+        },
+        {
+          "creatorType": "inventor",
+          "firstName": "John D.",
+          "lastName": "Corbett"
+        }
+      ],
+      "abstractNote": "A system and method for interactive design of user manipulable graphic elements. A computer has display and stored tasks wherein the appearance of graphic elements and methods for their manipulation are defined. Each graphic element is defined by at least one figure specification, one mask specification and one map specification. An interactive display editor program defines specifications of said graphic elements. An interactive program editor program defines programming data and methods associated with said graphic elements. A display program uses the figure, map and mask specifications for assembling graphic elements upon the display and enabling user manipulation of said graphic elements.",
+      "place": "",
+      "country": "US",
+      "assignee": "University of Pittsburgh",
+      "issuingAuthority": "United States",
+      "patentNumber": "US5041992A",
+      "filingDate": "1988-10-24",
+      "pages": "",
+      "applicationNumber": "US07/261,770",
+      "priorityNumbers": "",
+      "issueDate": "1991-08-20",
+      "references": "",
+      "legalStatus": "",
+      "language": "",
+      "shortTitle": "",
+      "url": "https://patents.google.com/patent/US5041992A/en",
+      "accessDate": "2021-06-01T20:44:02Z",
+      "rights": "",
+      "extra": "",
+      "tags": [
+        {
+          "tag": "bit mapped",
+          "type": 1
+        },
+        {
+          "tag": "display",
+          "type": 1
+        },
+        {
+          "tag": "graphic",
+          "type": 1
+        },
+        {
+          "tag": "objects",
+          "type": 1
+        },
+        {
+          "tag": "program",
+          "type": 1
+        },
+        {
+          "tag": "sz"
+        }
+      ],
+      "collections": [
+        "MTUXENI8"
+      ],
+      "relations": {},
+      "dateAdded": "2021-06-01T20:44:02Z",
+      "dateModified": "2021-06-01T20:44:33Z"
+    },
     {
       "id": "9296070/J62GHLSJ",
       "type": "patent",
@@ -4531,7 +9973,74 @@
             1
           ]
         ]
-      }
+      },
+      "key": "J62GHLSJ",
+      "version": 2110,
+      "itemType": "patent",
+      "creators": [
+        {
+          "creatorType": "inventor",
+          "firstName": "Morton S.",
+          "lastName": "Balban"
+        },
+        {
+          "creatorType": "inventor",
+          "firstName": "Ming-Shong",
+          "lastName": "Lan"
+        },
+        {
+          "creatorType": "inventor",
+          "firstName": "Rodney M.",
+          "lastName": "Panos"
+        }
+      ],
+      "abstractNote": "An apparatus and a method are disclosed for composing an imposition in terms of an arrangement of printing plates on selected of the image positions on selected units of a printing press to print a given edition, by first assigning each section of this edition to one of the press areas. Thereafter, each printing unit is examined to determine an utilization value thereof in terms of the placement of the printing plates on the image positions and the relative number of image positions to which printing plates are assigned with respect to the total number of image positions. Thereafter, a list of the image positions for each of the sections and its area, is constructed by examining one printing unit at a time in an order according to the placement of that printing unit in the array and examining its utilization value to determine whether or not to include a particular image position of that printing unit in the list. As a result, a list of the image positions is constructed in a sequence corresponding to numerical order of the pages in the section under consideration. Finally, that list of the image positions and the corresponding section and page numbers is displayed in a suitable fashion to inform a user of how to place the printing plates in the desired arrangement onto the printing units of the press to print this given edition.",
+      "place": "",
+      "country": "US",
+      "assignee": "Rockwell International Corp",
+      "issuingAuthority": "United States",
+      "patentNumber": "US4984773A",
+      "filingDate": "1987-10-06",
+      "pages": "",
+      "applicationNumber": "US07/105,159",
+      "priorityNumbers": "",
+      "issueDate": "1991-01-15",
+      "references": "",
+      "legalStatus": "",
+      "language": "",
+      "shortTitle": "",
+      "url": "https://patents.google.com/patent/US4984773A/en",
+      "accessDate": "2021-06-01T20:50:08Z",
+      "rights": "",
+      "extra": "",
+      "tags": [
+        {
+          "tag": "color",
+          "type": 1
+        },
+        {
+          "tag": "composing",
+          "type": 1
+        },
+        {
+          "tag": "imposition",
+          "type": 1
+        },
+        {
+          "tag": "press",
+          "type": 1
+        },
+        {
+          "tag": "printing",
+          "type": 1
+        }
+      ],
+      "collections": [
+        "MTUXENI8"
+      ],
+      "relations": {},
+      "dateAdded": "2021-06-01T20:50:08Z",
+      "dateModified": "2021-07-06T19:47:24Z"
     },
     {
       "id": "9296070/KXVS2RBT",
@@ -4571,47 +10080,74 @@
             1
           ]
         ]
-      }
-    },
-    {
-      "id": "9296070/5QACWN9U",
-      "type": "patent",
-      "title": "Interactive method of developing software interfaces",
-      "abstract": "A system and method for interactive design of user manipulable graphic elements. A computer has display and stored tasks wherein the appearance of graphic elements and methods for their manipulation are defined. Each graphic element is defined by at least one figure specification, one mask specification and one map specification. An interactive display editor program defines specifications of said graphic elements. An interactive program editor program defines programming data and methods associated with said graphic elements. A display program uses the figure, map and mask specifications for assembling graphic elements upon the display and enabling user manipulation of said graphic elements.",
-      "URL": "https://patents.google.com/patent/US5041992A/en",
-      "number": "US5041992A",
-      "author": [
+      },
+      "key": "KXVS2RBT",
+      "version": 2107,
+      "itemType": "patent",
+      "creators": [
         {
-          "family": "Cunningham",
-          "given": "Robert E."
+          "creatorType": "inventor",
+          "firstName": "D. Austin",
+          "lastName": "Henderson"
         },
         {
-          "family": "Bonar",
-          "given": "Jeffery G."
+          "creatorType": "inventor",
+          "firstName": "Stuart K.",
+          "lastName": "Card"
         },
         {
-          "family": "Corbett",
-          "given": "John D."
+          "creatorType": "inventor",
+          "firstName": "John T.",
+          "lastName": "Maxwell"
         }
       ],
-      "issued": {
-        "date-parts": [
-          [
-            1991,
-            8,
-            20
-          ]
-        ]
-      },
-      "accessed": {
-        "date-parts": [
-          [
-            2021,
-            6,
-            1
-          ]
-        ]
-      }
+      "abstractNote": "Workspaces provided by an object-based user interface appear to share windows and other display objects. Each workspace's data structure includes, for each window in that workspace, a linking data structure called a placement which links to the display system object which provides that window, which may be a display system object in a preexisting window system. The placement also contains display characteristics of the window when displayed in that workspace, such as position and size. Therefore, a display system object can be linked to several workspaces by a placement in each of the workspaces' data structures, and the window it provides to each of those workspaces can have unique display characteristics, yet appear to the user to be the same window or versions of the same window. As a result, the workspaces appear to be sharing a window. Workspaces can also appear to share a window if each workspace's data structure includes data linking to another workspace with a placement to the shared window. The user can invoke a switch between workspaces by selecting a display object called a door, and a back door to the previous workspace is created automatically so that the user is not trapped in a workspace. A display system object providing a window to a workspace being left remains active so that when that workspace is reentered, the window will have the same contents as when it disappeared. Also, the placements of a workspace are updated so that when the workspace is reentered its windows are organized the same as when the user left that workspace. The user can enter an overview display which shows a representation of each workspace and the windows it contains so that the user can navigate to any workspace from the overview.",
+      "place": "",
+      "country": "US",
+      "assignee": "Xerox Corp",
+      "issuingAuthority": "United States",
+      "patentNumber": "US5072412A",
+      "filingDate": "1987-03-25",
+      "pages": "",
+      "applicationNumber": "US07/030,766",
+      "priorityNumbers": "",
+      "issueDate": "1991-12-10",
+      "references": "",
+      "legalStatus": "",
+      "language": "",
+      "shortTitle": "",
+      "url": "https://patents.google.com/patent/US5072412A/en",
+      "accessDate": "2021-06-01T15:46:49Z",
+      "rights": "",
+      "extra": "",
+      "tags": [
+        {
+          "tag": "accessing",
+          "type": 1
+        },
+        {
+          "tag": "data",
+          "type": 1
+        },
+        {
+          "tag": "display",
+          "type": 1
+        },
+        {
+          "tag": "objects",
+          "type": 1
+        },
+        {
+          "tag": "workspace",
+          "type": 1
+        }
+      ],
+      "collections": [
+        "MTUXENI8"
+      ],
+      "relations": {},
+      "dateAdded": "2021-06-01T15:46:49Z",
+      "dateModified": "2021-07-06T19:43:28Z"
     },
     {
       "id": "9296070/TN3W6XLN",
@@ -4643,10 +10179,127 @@
             1
           ]
         ]
-      }
+      },
+      "key": "TN3W6XLN",
+      "version": 2488,
+      "itemType": "conferencePaper",
+      "creators": [
+        {
+          "creatorType": "author",
+          "firstName": "William",
+          "lastName": "Newman"
+        },
+        {
+          "creatorType": "author",
+          "firstName": "Margery",
+          "lastName": "Eldridge"
+        },
+        {
+          "creatorType": "author",
+          "firstName": "Michael",
+          "lastName": "Lamming"
+        }
+      ],
+      "abstractNote": "This paper presents one part of a broad research project entitled 'Activity-Based Information Retrieval' (AIR) which is being carded out at EuroPARC. The basic hypothesis of this project is that if contextual data about human activities can be automatically captured and later presented as recognisable descriptions of past episodes, then human memory of those past episodes can be improved. This paper describes an application called Pepys, designed to yield descriptions of episodes based on automatically collected location data. The program pays particular attention to meetings and other episodes involving two or more people. The episodes are presented to the user as a diary generated at the end of each day and distributed by electronic mail. The paper also discusses the methods used to assess the accuracy of the descriptions generated by the recogniser.",
+      "date": "1991-01-01",
+      "proceedingsTitle": "",
+      "conferenceName": "",
+      "place": "",
+      "publisher": "",
+      "volume": "",
+      "pages": "",
+      "series": "",
+      "language": "",
+      "url": "",
+      "accessDate": "",
+      "archive": "",
+      "archiveLocation": "",
+      "libraryCatalog": "ResearchGate",
+      "callNumber": "",
+      "rights": "",
+      "extra": "",
+      "tags": [],
+      "collections": [
+        "MTUXENI8"
+      ],
+      "relations": {},
+      "dateAdded": "2022-08-05T00:06:14Z",
+      "dateModified": "2022-08-05T00:06:14Z"
     }
   ],
   "1992": [
+    {
+      "id": "9296070/GTHVJ545",
+      "type": "patent",
+      "title": "Window system with independently replaceable window functionality",
+      "abstract": "A workspace data structure, such as a window hierarchy or network, includes functional data units that include data relating to workspace functionality. These functional data units are associated with data units corresponding to the workspaces such that a functional data unit can be replaced by a functional data unit compatible with a different set of functions without modifying the structure of other data units. Each workspace data unit may have a replaceably associated functional data unit called an input contract relating to its input functions and another called an output contract relating to its output functions. A parent workspace's data unit and the data units of its children may together have a replaceably associated functional data unit, called a windowing contract, relating to the windowing relationship between the parent and the children. The data structure may also include an auxiliary data unit associated between the data units of the parent and children windows, and the windowing contract may be associated with the auxiliary data unit. The contracts can be accessed and replaced by a processor in a system that includes the data structure. The contracts can be instances of classes in an object-oriented programming language, and can be replaceably associated by pointers associated with the system objects. Alternatively, a contract can be replaceably associated through dynamic multiple inheritance, with the superclasses of each workspace class including one or more contract classes such that changing the class of an instance of a workspace class serves to replace the contract.",
+      "URL": "https://patents.google.com/patent/US5121478A",
+      "number": "US5121478A",
+      "author": [
+        {
+          "family": "Rao",
+          "given": "Ramana B."
+        }
+      ],
+      "issued": {
+        "date-parts": [
+          [
+            1992,
+            6,
+            9
+          ]
+        ]
+      },
+      "accessed": {
+        "date-parts": [
+          [
+            2021,
+            4,
+            16
+          ]
+        ]
+      },
+      "key": "GTHVJ545",
+      "version": 1621,
+      "itemType": "patent",
+      "creators": [
+        {
+          "creatorType": "inventor",
+          "firstName": "Ramana B.",
+          "lastName": "Rao"
+        }
+      ],
+      "abstractNote": "A workspace data structure, such as a window hierarchy or network, includes functional data units that include data relating to workspace functionality. These functional data units are associated with data units corresponding to the workspaces such that a functional data unit can be replaced by a functional data unit compatible with a different set of functions without modifying the structure of other data units. Each workspace data unit may have a replaceably associated functional data unit called an input contract relating to its input functions and another called an output contract relating to its output functions. A parent workspace's data unit and the data units of its children may together have a replaceably associated functional data unit, called a windowing contract, relating to the windowing relationship between the parent and the children. The data structure may also include an auxiliary data unit associated between the data units of the parent and children windows, and the windowing contract may be associated with the auxiliary data unit. The contracts can be accessed and replaced by a processor in a system that includes the data structure. The contracts can be instances of classes in an object-oriented programming language, and can be replaceably associated by pointers associated with the system objects. Alternatively, a contract can be replaceably associated through dynamic multiple inheritance, with the superclasses of each workspace class including one or more contract classes such that changing the class of an instance of a workspace class serves to replace the contract.",
+      "place": "",
+      "country": "United States",
+      "assignee": "Xerox Corporation",
+      "issuingAuthority": "",
+      "patentNumber": "US5121478A",
+      "filingDate": "1990-11-15",
+      "pages": "",
+      "applicationNumber": "US07/614,957",
+      "priorityNumbers": "",
+      "issueDate": "1992-06-09",
+      "references": "",
+      "legalStatus": "",
+      "language": "",
+      "shortTitle": "",
+      "url": "https://patents.google.com/patent/US5121478A",
+      "accessDate": "2021-04-16T21:57:07Z",
+      "rights": "",
+      "extra": "",
+      "tags": [
+        {
+          "tag": "sz"
+        }
+      ],
+      "collections": [
+        "MTUXENI8"
+      ],
+      "relations": {},
+      "dateAdded": "2021-04-16T21:57:07Z",
+      "dateModified": "2021-06-01T20:55:21Z"
+    },
     {
       "id": "9296070/LP7U9CZK",
       "type": "patent",
@@ -4678,7 +10331,63 @@
             1
           ]
         ]
-      }
+      },
+      "key": "LP7U9CZK",
+      "version": 2109,
+      "itemType": "patent",
+      "creators": [
+        {
+          "creatorType": "inventor",
+          "firstName": "Michel J.",
+          "lastName": "Denber"
+        }
+      ],
+      "abstractNote": "In a graphic display system, display control software is modified to impart motion to a pop-up menu to attract the attention of the user. The menu becomes animated when a control and comparison circuit confirms that a mouse driven cursor on the screen is moving away from the pop-up menu indicating that the operator is unaware of the menu's presence. The menu moves or \"tags-along\" after the cursor until the user takes notice and makes the appropriate selection.",
+      "place": "",
+      "country": "EP",
+      "assignee": "Xerox Corp",
+      "issuingAuthority": "European Union",
+      "patentNumber": "EP0464742A2",
+      "filingDate": "1991-07-01",
+      "pages": "",
+      "applicationNumber": "EP91110869A",
+      "priorityNumbers": "",
+      "issueDate": "1992-01-08",
+      "references": "",
+      "legalStatus": "",
+      "shortTitle": "",
+      "url": "https://patents.google.com/patent/EP0464742A2/en",
+      "accessDate": "2021-06-01T20:41:11Z",
+      "rights": "",
+      "extra": "",
+      "tags": [
+        {
+          "tag": "cursor",
+          "type": 1
+        },
+        {
+          "tag": "menu",
+          "type": 1
+        },
+        {
+          "tag": "mouse",
+          "type": 1
+        },
+        {
+          "tag": "pop",
+          "type": 1
+        },
+        {
+          "tag": "screen",
+          "type": 1
+        }
+      ],
+      "collections": [
+        "MTUXENI8"
+      ],
+      "relations": {},
+      "dateAdded": "2021-06-01T20:41:11Z",
+      "dateModified": "2021-07-06T19:46:52Z"
     },
     {
       "id": "9296070/PX3PWI8C",
@@ -4714,39 +10423,69 @@
             1
           ]
         ]
-      }
-    },
-    {
-      "id": "9296070/GTHVJ545",
-      "type": "patent",
-      "title": "Window system with independently replaceable window functionality",
-      "abstract": "A workspace data structure, such as a window hierarchy or network, includes functional data units that include data relating to workspace functionality. These functional data units are associated with data units corresponding to the workspaces such that a functional data unit can be replaced by a functional data unit compatible with a different set of functions without modifying the structure of other data units. Each workspace data unit may have a replaceably associated functional data unit called an input contract relating to its input functions and another called an output contract relating to its output functions. A parent workspace's data unit and the data units of its children may together have a replaceably associated functional data unit, called a windowing contract, relating to the windowing relationship between the parent and the children. The data structure may also include an auxiliary data unit associated between the data units of the parent and children windows, and the windowing contract may be associated with the auxiliary data unit. The contracts can be accessed and replaced by a processor in a system that includes the data structure. The contracts can be instances of classes in an object-oriented programming language, and can be replaceably associated by pointers associated with the system objects. Alternatively, a contract can be replaceably associated through dynamic multiple inheritance, with the superclasses of each workspace class including one or more contract classes such that changing the class of an instance of a workspace class serves to replace the contract.",
-      "URL": "https://patents.google.com/patent/US5121478A",
-      "number": "US5121478A",
-      "author": [
+      },
+      "key": "PX3PWI8C",
+      "version": 2104,
+      "itemType": "patent",
+      "creators": [
         {
-          "family": "Rao",
-          "given": "Ramana B."
+          "creatorType": "inventor",
+          "firstName": "Reid G.",
+          "lastName": "Smith"
+        },
+        {
+          "creatorType": "inventor",
+          "firstName": "Eric J.",
+          "lastName": "Schoen"
         }
       ],
-      "issued": {
-        "date-parts": [
-          [
-            1992,
-            6,
-            9
-          ]
-        ]
-      },
-      "accessed": {
-        "date-parts": [
-          [
-            2021,
-            4,
-            16
-          ]
-        ]
-      }
+      "abstractNote": "A declarative object-oriented approach to menu construction provides a mechanism for specifying the behavior, appearance and function of menus as part of an interactive user interface. Menus are constructed from interchangeable object building blocks to obtain the characteristics wanted without the need to write new code or code and maintaining a coherent interface standard. The approach is implemented by dissecting interface menu behavior into modularized objects specifying orthogonal components of desirable menu behaviors. Once primary characteristics for orthogonal dimensions of menu behavior are identified, individual objects are constructed to provide specific alternatives for the behavior within the definitions of each dimension. Finally, specific objects from each dimension are combined to construct a menu having the desired selections of menu behaviors.",
+      "place": "",
+      "country": "US",
+      "assignee": "Schlumberger Technology Corp",
+      "issuingAuthority": "United States",
+      "patentNumber": "US5119475A",
+      "filingDate": "1991-08-29",
+      "pages": "",
+      "applicationNumber": "US07/754,366",
+      "priorityNumbers": "",
+      "issueDate": "1992-06-02",
+      "references": "",
+      "legalStatus": "",
+      "language": "",
+      "shortTitle": "",
+      "url": "https://patents.google.com/patent/US5119475A/en",
+      "accessDate": "2021-06-01T20:51:48Z",
+      "rights": "",
+      "extra": "",
+      "tags": [
+        {
+          "tag": "behavior",
+          "type": 1
+        },
+        {
+          "tag": "behaviors",
+          "type": 1
+        },
+        {
+          "tag": "class",
+          "type": 1
+        },
+        {
+          "tag": "display",
+          "type": 1
+        },
+        {
+          "tag": "menu",
+          "type": 1
+        }
+      ],
+      "collections": [
+        "MTUXENI8"
+      ],
+      "relations": {},
+      "dateAdded": "2021-06-01T20:51:49Z",
+      "dateModified": "2021-07-06T19:38:44Z"
     },
     {
       "id": "9296070/F4U78E9V",
@@ -4770,7 +10509,45 @@
             1
           ]
         ]
-      }
+      },
+      "key": "F4U78E9V",
+      "version": 2752,
+      "itemType": "journalArticle",
+      "creators": [
+        {
+          "creatorType": "author",
+          "firstName": "Alison",
+          "lastName": "Lee"
+        }
+      ],
+      "abstractNote": "History tools allow users to access past interactions kept in a history and to\nincorporate them into the context of their current operations. Such tools appear in\nvarious forms in many of today’s computing systems, but despite their prevalence,they have received little attention as user support tools. This dissertation investigates, through a series of studies, history–based, user support tools. The studies focus on three primary factors influencing the utility of history–based, user support tools: design of history tools, support of a behavioural phenomenon in user interactions, and mental and physical effort associated with using history tools. Design of history tools strongly influences a user’s perception of their utility. In surveying a wide collection of history tools, we identify seven independent uses of the information with no single history tool supporting all seven uses. Based on\ncognitive and behavioural considerations associated with the seven history uses,\nwe propose several kinds of history information and history functions that need to be supported in new designs of history tools integrating all seven uses of history. An exploratory study of the UNIX environment reveals that user interactions\nexhibit a behavioural phenomenon, nominally referred to as locality. This is the phenomenon where users repeatedly reference a small group of commands during extended intervals of their session. We apply two concepts from computer memory research (i.e., working sets and locality) to examine this behavioural artifact and to propose a strategy for predicting repetitive opportunities and candidates. Our studies reveal that users exhibit locality in only 31% of their sessions whereas users repeat individual commands in 75% of their sessions. We also found that history tool use occurs primarily in locality periods. Thus, history tools which localize their prediction opportunities to locality periods can predict effectively the reuse candidates.\nFinally, the effort, mental and physical, associated with using a history tool\nto expedite repetitive commands can influence a user’s decision to use history\ntools. We analyze the human information–processing operations involved in the task of specifying a recurrent command for a given approach and design (assuming that the command is fully generated and resides in the user’s working memory and that users exhibit expert, error–free task performance behaviour). We find that in most of the proposed history designs, users expend less physical effort at the expense of more mental effort. The increased mental effort can be alleviated by providing history tools which require simpler mental operations (e.g., working memory retrievals and perceptual processing). Also, we find that the typing approach requires less mental effort at the expense of more physical effort. Finally, despite the overhead associated with switching to the use of history tools, users (with a typing speed of 55 wpm or less) do expend less overall effort to specify recurrent commands (which have been generated and appear in working\nmemory) using history tools compared to typing from scratch. The results of the three sets of studies provide insights into current history tools and point favourably towards the use of history tools for user support, especially history tools that support the reuse of previous commands, but additional research into history tool designs and usability factors is needed. Our studies demonstrate the importance of considering various psychological and behavioural factors and the importance of different grains of analysis.",
+      "publicationTitle": "University of Toronto",
+      "volume": "",
+      "issue": "",
+      "pages": "187",
+      "date": "1992-01-01",
+      "series": "",
+      "seriesTitle": "",
+      "seriesText": "",
+      "journalAbbreviation": "",
+      "DOI": "",
+      "ISSN": "",
+      "shortTitle": "",
+      "url": "",
+      "accessDate": "",
+      "archive": "",
+      "archiveLocation": "",
+      "libraryCatalog": "ResearchGate",
+      "callNumber": "",
+      "rights": "",
+      "extra": "",
+      "tags": [],
+      "collections": [
+        "3CNYFDHF"
+      ],
+      "relations": {},
+      "dateAdded": "2023-03-04T02:05:29Z",
+      "dateModified": "2023-04-28T06:10:18Z"
     },
     {
       "id": "9296070/9SEIVVBA",
@@ -4813,7 +10590,71 @@
             15
           ]
         ]
-      }
+      },
+      "key": "9SEIVVBA",
+      "version": 2707,
+      "itemType": "conferencePaper",
+      "creators": [
+        {
+          "creatorType": "author",
+          "firstName": "David",
+          "lastName": "Kurlander"
+        },
+        {
+          "creatorType": "author",
+          "firstName": "Steven",
+          "lastName": "Feiner"
+        }
+      ],
+      "abstractNote": "We describe enhancements to graphical search and replace that allow users to extend the capabilities of a graphical editor. Interactive constraint-based search and replace can search for objects that obey user-specified sets of constraints and automatically apply other constraints to modify these objects. We show how an interactive tool that employs this technique makes it possible for users to define sets of constraints graphically that modify existing illustrations or control the creation of new illustrations. The interface uses the same visual language as the editor and allows users to understand and create powerful rules without conventional programming. Rules can be saved and retrieved for use alone or in combination. Examples, generated with a working implementation, demonstrate applications to drawing beautification and transformation.",
+      "date": "June 1, 1992",
+      "proceedingsTitle": "Proceedings of the SIGCHI Conference on Human Factors in Computing Systems",
+      "conferenceName": "",
+      "place": "New York, NY, USA",
+      "volume": "",
+      "pages": "609–618",
+      "series": "CHI '92",
+      "language": "",
+      "shortTitle": "",
+      "url": "https://doi.org/10.1145/142750.143053",
+      "accessDate": "2021-04-15",
+      "archive": "",
+      "archiveLocation": "",
+      "libraryCatalog": "ACM Digital Library",
+      "callNumber": "",
+      "rights": "",
+      "extra": "",
+      "tags": [
+        {
+          "tag": "constraint specification",
+          "type": 1
+        },
+        {
+          "tag": "demonstrational techniques",
+          "type": 1
+        },
+        {
+          "tag": "editor extensibility",
+          "type": 1
+        },
+        {
+          "tag": "graphical editing",
+          "type": 1
+        },
+        {
+          "tag": "interactive techniques",
+          "type": 1
+        },
+        {
+          "tag": "sz"
+        }
+      ],
+      "collections": [
+        "MTUXENI8"
+      ],
+      "relations": {},
+      "dateAdded": "2021-04-15T23:22:52Z",
+      "dateModified": "2023-04-20T03:00:32Z"
     }
   ],
   "1993": [
@@ -4851,7 +10692,69 @@
             1
           ]
         ]
-      }
+      },
+      "key": "78B7IS7F",
+      "version": 2109,
+      "itemType": "patent",
+      "creators": [
+        {
+          "creatorType": "inventor",
+          "firstName": "Michel J.",
+          "lastName": "Denber"
+        },
+        {
+          "creatorType": "inventor",
+          "firstName": "Henry P.",
+          "lastName": "Jankowski"
+        }
+      ],
+      "abstractNote": "A method and apparatus are shown for improving bit-image quality in video display terminals and xerographic processors. In one embodiment, each scan line of a source image is ANDed with the scan line above to remove half-bits and thin halftones. In other embodiments, entire blocks of data are processed by bit-block transfer operations, such as ANDing a copy of the source image with a copy of itself shifted by one bit. Also, a source image can be compared to a shifted copy of itself to locate diagonal lines in order to place gray pixels bordering these lines.",
+      "place": "",
+      "country": "US",
+      "assignee": "Xerox Corp",
+      "issuingAuthority": "United States",
+      "patentNumber": "US5250934A",
+      "filingDate": "1990-12-31",
+      "pages": "",
+      "applicationNumber": "US07/636,395",
+      "priorityNumbers": "",
+      "issueDate": "1993-10-05",
+      "references": "",
+      "legalStatus": "",
+      "language": "",
+      "shortTitle": "",
+      "url": "https://patents.google.com/patent/US5250934A/en",
+      "accessDate": "2021-06-01T20:46:19Z",
+      "rights": "",
+      "extra": "",
+      "tags": [
+        {
+          "tag": "bit",
+          "type": 1
+        },
+        {
+          "tag": "image",
+          "type": 1
+        },
+        {
+          "tag": "memory buffer",
+          "type": 1
+        },
+        {
+          "tag": "output",
+          "type": 1
+        },
+        {
+          "tag": "shift register",
+          "type": 1
+        }
+      ],
+      "collections": [
+        "MTUXENI8"
+      ],
+      "relations": {},
+      "dateAdded": "2021-06-01T20:46:19Z",
+      "dateModified": "2021-07-06T19:46:40Z"
     },
     {
       "id": "9296070/PHI92FUI",
@@ -4873,7 +10776,28 @@
             28
           ]
         ]
-      }
+      },
+      "key": "PHI92FUI",
+      "version": 2385,
+      "itemType": "webpage",
+      "creators": [],
+      "abstractNote": "",
+      "websiteTitle": "",
+      "websiteType": "",
+      "date": "1993",
+      "shortTitle": "",
+      "url": "https://www.cs.cmu.edu/Groups/AI/html/faqs/lang/lisp/part4/faq-doc-2.html",
+      "accessDate": "2021-07-28T19:24:42Z",
+      "language": "",
+      "rights": "",
+      "extra": "",
+      "tags": [],
+      "collections": [
+        "3CNYFDHF"
+      ],
+      "relations": {},
+      "dateAdded": "2021-07-28T19:24:42Z",
+      "dateModified": "2022-06-27T03:07:38Z"
     },
     {
       "id": "9296070/J6WNHTXX",
@@ -4917,7 +10841,50 @@
             15
           ]
         ]
-      }
+      },
+      "key": "J6WNHTXX",
+      "version": 2030,
+      "itemType": "conferencePaper",
+      "creators": [
+        {
+          "creatorType": "author",
+          "firstName": "Uffe K.",
+          "lastName": "Wiil"
+        },
+        {
+          "creatorType": "author",
+          "firstName": "John J.",
+          "lastName": "Leggett"
+        }
+      ],
+      "abstractNote": "An approach to flexible hyperbase (hypertext database) support predicated on the notion of ex-tensibility is presented. The extensible hypertext platform (Hyperform) implements basic hyperbase services that can be tailored to provide specialised hyperbase support. Hypeeform is based on an inter-nal computational engine that provides an object-oriented extension language which allows new data model objects and operations to be added at run-time. Hyperform has a number of built-in classes to pro-vide basic hyperbase features such as concurrency control, notification control (events), access control, version control and search and query. Each of these classes can be specialised using multiple inheritance to form virtually any type of hyperbase support needed in next-generation hypertext systems. This approach greatly reduces the effort required to provide high-quality customized hyperbase support for distributed hypertext applications. Hyper-form is implemented and operational in Unix environments. This paper describes the Hyperform approach, discusses its advantages and disadvantages, and gives examples of simulating the 11AM and the Danish Hyperlime in Hyperform. Hyper-form is compared with related work from the HAM generation of hyperbase systems and the current status of the project is reviewed.",
+      "date": "December 1, 1993",
+      "proceedingsTitle": "Proceedings of the ACM conference on Hypertext",
+      "conferenceName": "",
+      "place": "New York, NY, USA",
+      "volume": "",
+      "pages": "251–261",
+      "series": "ECHT '92",
+      "language": "",
+      "url": "https://doi.org/10.1145/168466.171510",
+      "accessDate": "2021-04-15",
+      "archive": "",
+      "archiveLocation": "",
+      "libraryCatalog": "ACM Digital Library",
+      "callNumber": "",
+      "rights": "",
+      "extra": "",
+      "tags": [
+        {
+          "tag": "sz"
+        }
+      ],
+      "collections": [
+        "HVGVBYYB"
+      ],
+      "relations": {},
+      "dateAdded": "2021-04-15T23:22:52Z",
+      "dateModified": "2021-06-03T19:37:45Z"
     },
     {
       "id": "9296070/6L8UHVSY",
@@ -4958,7 +10925,51 @@
             3
           ]
         ]
-      }
+      },
+      "key": "6L8UHVSY",
+      "version": 2032,
+      "itemType": "journalArticle",
+      "creators": [
+        {
+          "creatorType": "author",
+          "firstName": "Mickey R.",
+          "lastName": "Boyd"
+        },
+        {
+          "creatorType": "author",
+          "firstName": "David B.",
+          "lastName": "Whalley"
+        }
+      ],
+      "abstractNote": "This paper describes two related tools developed to support the isolation and analysts of optimization errors in the vpo optimizer. Both tools rely on vpo identifying sequences of changes, referred to as transformations. that result in semantically equivalent (and usually improved) code. One tool determines the first transfer. motion that causes incorrect output of the execution of the compiled program. This tool not only automatically isolates the illegal transformation, but also identifies the location and instant the transformation is performed in vpo. To assist in the analysis of an optimization error, a graphical optimization viewer was also implemented that can display the state of the generated instructions before and after each transformation performed by vpo. Unique features of the optimization viewer include reverse viewing (or undoing) of transformations and the ability to stop at breakpoints associated with the generated instructions. Both tools are useful independently. Together these tools form a powerful environment for facilitating the retargeting of vpo to a new machine and supporting experimentation with new optimizations. In addition, the optimization viewercan be used as a teaching aid in compiler classes.",
+      "publicationTitle": "ACM SIGPLAN Notices",
+      "pages": "26–35",
+      "date": "June 1, 1993",
+      "series": "",
+      "seriesTitle": "",
+      "seriesText": "",
+      "language": "",
+      "ISSN": "0362-1340",
+      "shortTitle": "",
+      "url": "https://doi.org/10.1145/173262.155093",
+      "accessDate": "2021-06-03T18:23:32Z",
+      "archive": "",
+      "archiveLocation": "",
+      "libraryCatalog": "June 1993",
+      "callNumber": "",
+      "rights": "",
+      "extra": "",
+      "tags": [
+        {
+          "tag": "sz"
+        }
+      ],
+      "collections": [
+        "MTUXENI8"
+      ],
+      "relations": {},
+      "dateAdded": "2021-06-03T18:23:32Z",
+      "dateModified": "2021-06-03T18:27:10Z"
     }
   ],
   "1994": [
@@ -5012,7 +11023,62 @@
             16
           ]
         ]
-      }
+      },
+      "key": "CI5AB787",
+      "version": 2108,
+      "itemType": "patent",
+      "creators": [
+        {
+          "creatorType": "inventor",
+          "name": "Jan O. Pedersen"
+        },
+        {
+          "creatorType": "inventor",
+          "name": "Per-Kristian Halvorsen"
+        },
+        {
+          "creatorType": "inventor",
+          "name": "Douglass R. Cutting"
+        },
+        {
+          "creatorType": "inventor",
+          "name": "John W. Tukey"
+        },
+        {
+          "creatorType": "inventor",
+          "name": "Eric A. Bier"
+        },
+        {
+          "creatorType": "inventor",
+          "name": "Daniel G. Bobrow"
+        }
+      ],
+      "abstractNote": "An information retrieval system and method are provided in which an operator inputs one or more query words which are used to determine a search key for searching through a corpus of documents, and which returns any matches between the search key and the corpus of documents as a phrase containing the word data matching the query word(s), a non-stop (content) word next adjacent to the matching word data, and all intervening stop-words between the matching word data and the next adjacent non-stop word. The operator, after reviewing one or more of the returned phrases can then use one or more of the next adjacent non-stop-words as new query words to reformulate the search key and perform a subsequent search through the document corpus. This process can be conducted iteratively, until the appropriate documents of interest are located. The additional non-stop-words from each phrase are preferably aligned with each other (e.g., by columnation) to ease viewing of the \"new\" content words.",
+      "place": "",
+      "country": "United States",
+      "assignee": "Xerox Corporation",
+      "issuingAuthority": "",
+      "patentNumber": "US5278980A",
+      "filingDate": "1991-08-16",
+      "pages": "",
+      "applicationNumber": "US07/745,794",
+      "priorityNumbers": "",
+      "issueDate": "1994-01-11",
+      "references": "",
+      "legalStatus": "",
+      "language": "",
+      "shortTitle": "",
+      "url": "https://patents.google.com/patent/US5278980A",
+      "accessDate": "2021-04-16T21:57:07Z",
+      "rights": "",
+      "extra": "",
+      "tags": [],
+      "collections": [
+        "MTUXENI8"
+      ],
+      "relations": {},
+      "dateAdded": "2021-04-16T21:57:07Z",
+      "dateModified": "2021-07-06T19:46:16Z"
     },
     {
       "id": "9296070/ELBQRBKS",
@@ -5048,7 +11114,72 @@
             1
           ]
         ]
-      }
+      },
+      "key": "ELBQRBKS",
+      "version": 2049,
+      "itemType": "patent",
+      "creators": [
+        {
+          "creatorType": "inventor",
+          "firstName": "Ronald M.",
+          "lastName": "Kaplan"
+        },
+        {
+          "creatorType": "inventor",
+          "firstName": "John T. III",
+          "lastName": "Maxwell"
+        }
+      ],
+      "abstractNote": "A text-compression technique utilizes a plurality of word-number mappers (\"WNMs\") in a frequency-ordered hierarchical structure. The particular structure of the set of WNMs depends on the specific encoding regime, but can be summarized as follows. Each WNM in the set is characterized by an ordinal WNM number and a WNM size (maximum number of tokens) that is in general a non-decreasing function of the WNM number. A given token is assigned a number pair, the first being one of the WNM numbers, and the second being the token's position or number in that WNM. Typically, the most frequently occurring tokens are mapped with a smaller-numbered WNM. The set of WNMs is generated on a first pass through the database to be compressed. The database is parsed into tokens, and a rank-order list based on the frequency of occurrence is generated. This list is partitioned in a manner to define the set of WNMs. Actual compression of the data base occurs on a second pass, using the set of WNMs generated on the first pass. The database is parsed into tokens, and for each token, the set of WNMs is searched to find the token. Once the token is found, it is assigned the appropriate number pair and is encoded. This proceeds until the entire database has been compressed.",
+      "place": "",
+      "country": "US",
+      "assignee": "Xerox Corp",
+      "issuingAuthority": "United States",
+      "patentNumber": "US5325091A",
+      "filingDate": "1992-09-09",
+      "pages": "",
+      "applicationNumber": "US07/942,665",
+      "priorityNumbers": "",
+      "issueDate": "1994-06-28",
+      "references": "",
+      "legalStatus": "",
+      "language": "",
+      "shortTitle": "",
+      "url": "https://patents.google.com/patent/US5325091A/en",
+      "accessDate": "2021-06-01T20:53:07Z",
+      "rights": "",
+      "extra": "",
+      "tags": [
+        {
+          "tag": "encoded",
+          "type": 1
+        },
+        {
+          "tag": "sz"
+        },
+        {
+          "tag": "token",
+          "type": 1
+        },
+        {
+          "tag": "tokens",
+          "type": 1
+        },
+        {
+          "tag": "wnm",
+          "type": 1
+        },
+        {
+          "tag": "wnms",
+          "type": 1
+        }
+      ],
+      "collections": [
+        "MTUXENI8"
+      ],
+      "relations": {},
+      "dateAdded": "2021-06-01T20:53:07Z",
+      "dateModified": "2021-06-03T17:15:06Z"
     }
   ],
   "1995": [
@@ -5090,7 +11221,77 @@
             1
           ]
         ]
-      }
+      },
+      "key": "HXGPKBTB",
+      "version": 2026,
+      "itemType": "patent",
+      "creators": [
+        {
+          "creatorType": "inventor",
+          "firstName": "Ronald M.",
+          "lastName": "Kaplan"
+        },
+        {
+          "creatorType": "inventor",
+          "firstName": "Martin",
+          "lastName": "Kay"
+        },
+        {
+          "creatorType": "inventor",
+          "firstName": "John",
+          "lastName": "Maxwell"
+        }
+      ],
+      "abstractNote": "An FSM data structure is encoded by generating a transition unit of data corresponding to each transition which leads ultimately to a final state of the FSM. Information about the states is included in the transition units, so that the encoded data structure can be written without state units of data. The incoming transition units to a final state each contain an indication of finality. The incoming transition units to a state which has no outgoing transition units each contain a branch ending indication. The outgoing transition units of each state are ordered into a comparison sequence for comparison with a received element, and all but the last outgoing transition unit contain an alternative indication of a subsequent alternative outgoing transition. The indications are incorporated with the label of each transition unit into a single byte, and the remaining byte values are allocated among a number of pointer data units, some of which begin full length pointers and some of which begin pointer indexes to tables where pointers are entered. The pointers may be used where a state has a large number of incoming transitions or where the block of transition units depending from a state is broken down to speed access. The first outgoing transition unit of a state is positioned immediately after one of the incoming transitions so that it may be found without a pointer. Each alternative outgoing transition unit is stored immediately after the block beginning with the previous outgoing transition unit so that it may be found by proceeding through the transition units until the number of alternative bits and the number of branch ending bits balance.",
+      "place": "",
+      "country": "US",
+      "assignee": "Xerox Corp",
+      "issuingAuthority": "United States",
+      "patentNumber": "US5450598A",
+      "filingDate": "1992-03-18",
+      "pages": "",
+      "applicationNumber": "US07/855,129",
+      "priorityNumbers": "",
+      "issueDate": "1995-09-12",
+      "references": "",
+      "legalStatus": "",
+      "language": "",
+      "shortTitle": "",
+      "url": "https://patents.google.com/patent/US5450598A/en",
+      "accessDate": "2021-06-01T20:39:53Z",
+      "rights": "",
+      "extra": "",
+      "tags": [
+        {
+          "tag": "alternative",
+          "type": 1
+        },
+        {
+          "tag": "data",
+          "type": 1
+        },
+        {
+          "tag": "state",
+          "type": 1
+        },
+        {
+          "tag": "subsequence",
+          "type": 1
+        },
+        {
+          "tag": "sz"
+        },
+        {
+          "tag": "transition",
+          "type": 1
+        }
+      ],
+      "collections": [
+        "MTUXENI8"
+      ],
+      "relations": {},
+      "dateAdded": "2021-06-01T20:39:53Z",
+      "dateModified": "2021-06-01T20:40:17Z"
     },
     {
       "id": "9296070/A52363YK",
@@ -5155,45 +11356,81 @@
             25
           ]
         ]
-      }
-    },
-    {
-      "id": "9296070/HFRDQ97U",
-      "type": "article-journal",
-      "title": "Freeing the essence of a computation",
-      "container-title": "ACM SIGPLAN Lisp Pointers",
-      "page": "25-36",
-      "volume": "VIII",
-      "issue": "2",
-      "abstract": "In theory, abstraction is important, but in practice, so is performance. Thus, there is a struggle between an abstract description of an algorithm and its efficient implementation. This struggle can be mediated by using an interpreter or a compiler. An interpreter takes a program that is a high level abstract description of an algorithm and applies it to some data. Don't think of an interpreter as slow. An interpreter is important enough to software that it is often implemented in hardware. A compiler takes the program and produces another program, perhaps in another language. The resulting program is applied to some data by another interpreter.",
-      "URL": "https://dl.acm.org/doi/10.1145/224133.224136",
-      "DOI": "10.1145/224133.224136",
-      "journalAbbreviation": "SIGPLAN Lisp Pointers",
-      "language": "en",
-      "author": [
+      },
+      "key": "A52363YK",
+      "version": 1700,
+      "itemType": "journalArticle",
+      "creators": [
         {
-          "family": "Anderson",
-          "given": "Kenneth R."
+          "creatorType": "author",
+          "firstName": "Ramana",
+          "lastName": "Rao"
+        },
+        {
+          "creatorType": "author",
+          "firstName": "Jan O.",
+          "lastName": "Pedersen"
+        },
+        {
+          "creatorType": "author",
+          "firstName": "Marti A.",
+          "lastName": "Hearst"
+        },
+        {
+          "creatorType": "author",
+          "firstName": "Jock D.",
+          "lastName": "Mackinlay"
+        },
+        {
+          "creatorType": "author",
+          "firstName": "Stuart K.",
+          "lastName": "Card"
+        },
+        {
+          "creatorType": "author",
+          "firstName": "Larry",
+          "lastName": "Masinter"
+        },
+        {
+          "creatorType": "author",
+          "firstName": "Per-Kristian",
+          "lastName": "Halvorsen"
+        },
+        {
+          "creatorType": "author",
+          "firstName": "George C.",
+          "lastName": "Robertson"
         }
       ],
-      "issued": {
-        "date-parts": [
-          [
-            "1995",
-            5,
-            5
-          ]
-        ]
-      },
-      "accessed": {
-        "date-parts": [
-          [
-            2021,
-            4,
-            25
-          ]
-        ]
-      }
+      "abstractNote": "Effective information access involves rich interactions between users and information residing in diverse locations. Users seek and retrieve information from the sources—for example, file serves, databases, and digital libraries—and use various tools to browse, manipulate, reuse, and generally process the information. We have developed a number of techniques that support various aspects of the process of user/information interaction. These techniques can be considered attempts to increase the bandwidth and quality of the interactions between users and information in an information workspace—an environment designed to support information work (see Figure 1).",
+      "publicationTitle": "Communications of the ACM",
+      "pages": "29-39",
+      "date": "April 1, 1995",
+      "series": "",
+      "seriesTitle": "",
+      "seriesText": "",
+      "language": "",
+      "ISSN": "0001-0782",
+      "shortTitle": "",
+      "url": "https://doi.org/10.1145/205323.205326",
+      "accessDate": "2021-04-25T19:13:13Z",
+      "archive": "",
+      "archiveLocation": "",
+      "libraryCatalog": "April 1995",
+      "callNumber": "",
+      "rights": "",
+      "extra": "",
+      "tags": [
+        {
+          "tag": "sz"
+        }
+      ],
+      "collections": [
+        "MTUXENI8"
+      ],
+      "relations": {},
+      "dateAdded": "2021-04-25T21:01:24Z",
+      "dateModified": "2021-06-02T18:06:57Z"
     },
     {
       "id": "9296070/6L976844",
@@ -5232,7 +11469,123 @@
             25
           ]
         ]
-      }
+      },
+      "key": "6L976844",
+      "version": 1979,
+      "itemType": "journalArticle",
+      "creators": [
+        {
+          "creatorType": "author",
+          "firstName": "Kent M.",
+          "lastName": "Pitman"
+        }
+      ],
+      "abstractNote": "Much has been written about Lazy Evaluation in Lisp---less about the other end of the spectrum---Ambitious Evaluation. Ambition is a very subjective concept, though, and if you have some preconceived idea of what you think an Ambitious Evaluator might be about, you might want to set it aside for a few minutes because this probably isn't going to be what you expect.",
+      "publicationTitle": "ACM SIGPLAN Lisp Pointers",
+      "pages": "1-44",
+      "date": "May 5, 1995",
+      "series": "",
+      "seriesTitle": "",
+      "seriesText": "",
+      "ISSN": "1045-3563",
+      "url": "https://dl.acm.org/doi/10.1145/224133.224137",
+      "accessDate": "2021-04-25T15:28:51Z",
+      "archive": "",
+      "archiveLocation": "",
+      "libraryCatalog": "DOI.org (Crossref)",
+      "callNumber": "",
+      "rights": "",
+      "extra": "",
+      "tags": [
+        {
+          "tag": "sz"
+        }
+      ],
+      "collections": [
+        "HVGVBYYB"
+      ],
+      "relations": {
+        "dc:replaces": "http://zotero.org/groups/2914042/items/ZCDWRE8L"
+      },
+      "dateAdded": "2021-04-25T19:54:45Z",
+      "dateModified": "2021-05-29T20:09:42Z"
+    },
+    {
+      "id": "9296070/HFRDQ97U",
+      "type": "article-journal",
+      "title": "Freeing the essence of a computation",
+      "container-title": "ACM SIGPLAN Lisp Pointers",
+      "page": "25-36",
+      "volume": "VIII",
+      "issue": "2",
+      "abstract": "In theory, abstraction is important, but in practice, so is performance. Thus, there is a struggle between an abstract description of an algorithm and its efficient implementation. This struggle can be mediated by using an interpreter or a compiler. An interpreter takes a program that is a high level abstract description of an algorithm and applies it to some data. Don't think of an interpreter as slow. An interpreter is important enough to software that it is often implemented in hardware. A compiler takes the program and produces another program, perhaps in another language. The resulting program is applied to some data by another interpreter.",
+      "URL": "https://dl.acm.org/doi/10.1145/224133.224136",
+      "DOI": "10.1145/224133.224136",
+      "journalAbbreviation": "SIGPLAN Lisp Pointers",
+      "language": "en",
+      "author": [
+        {
+          "family": "Anderson",
+          "given": "Kenneth R."
+        }
+      ],
+      "issued": {
+        "date-parts": [
+          [
+            "1995",
+            5,
+            5
+          ]
+        ]
+      },
+      "accessed": {
+        "date-parts": [
+          [
+            2021,
+            4,
+            25
+          ]
+        ]
+      },
+      "key": "HFRDQ97U",
+      "version": 1892,
+      "itemType": "journalArticle",
+      "creators": [
+        {
+          "creatorType": "author",
+          "firstName": "Kenneth R.",
+          "lastName": "Anderson"
+        }
+      ],
+      "abstractNote": "In theory, abstraction is important, but in practice, so is performance. Thus, there is a struggle between an abstract description of an algorithm and its efficient implementation. This struggle can be mediated by using an interpreter or a compiler. An interpreter takes a program that is a high level abstract description of an algorithm and applies it to some data. Don't think of an interpreter as slow. An interpreter is important enough to software that it is often implemented in hardware. A compiler takes the program and produces another program, perhaps in another language. The resulting program is applied to some data by another interpreter.",
+      "publicationTitle": "ACM SIGPLAN Lisp Pointers",
+      "pages": "25-36",
+      "date": "May 5, 1995",
+      "series": "",
+      "seriesTitle": "",
+      "seriesText": "",
+      "ISSN": "1045-3563",
+      "shortTitle": "",
+      "url": "https://dl.acm.org/doi/10.1145/224133.224136",
+      "accessDate": "2021-04-25T15:28:51Z",
+      "archive": "",
+      "archiveLocation": "",
+      "libraryCatalog": "DOI.org (Crossref)",
+      "callNumber": "",
+      "rights": "",
+      "extra": "",
+      "tags": [
+        {
+          "tag": "sz"
+        }
+      ],
+      "collections": [
+        "MV55NAER",
+        "HVGVBYYB"
+      ],
+      "relations": {},
+      "dateAdded": "2021-04-25T19:54:39Z",
+      "dateModified": "2021-06-03T19:16:47Z"
     }
   ],
   "1996": [
@@ -5270,54 +11623,49 @@
             25
           ]
         ]
-      }
+      },
+      "key": "CHD59QIJ",
+      "version": 1137,
+      "itemType": "journalArticle",
+      "creators": [
+        {
+          "creatorType": "author",
+          "firstName": "Herman T.",
+          "lastName": "Tavani"
+        }
+      ],
+      "abstractNote": "",
+      "publicationTitle": "ACM SIGCAS Computers and Society",
+      "pages": "22-29",
+      "date": "May 1, 1996",
+      "series": "",
+      "seriesTitle": "",
+      "seriesText": "",
+      "language": "",
+      "ISSN": "0095-2737",
+      "shortTitle": "",
+      "url": "https://doi.org/10.1145/236394.236396",
+      "accessDate": "2021-04-25T14:44:40Z",
+      "archive": "",
+      "archiveLocation": "",
+      "libraryCatalog": "June 1996",
+      "callNumber": "",
+      "rights": "",
+      "extra": "",
+      "tags": [
+        {
+          "tag": "sz"
+        }
+      ],
+      "collections": [
+        "HVGVBYYB"
+      ],
+      "relations": {},
+      "dateAdded": "2021-04-25T21:00:28Z",
+      "dateModified": "2021-05-29T19:02:30Z"
     }
   ],
   "1998": [
-    {
-      "id": "9296070/C4NIHH58",
-      "type": "patent",
-      "title": "Object-oriented computer user interface",
-      "abstract": "A computer user interface includes a mechanism of graphically representing and displaying user-definable objects of multiple types. The object types that can be represented include data records, not limited to a particular kind of data, and agents. An agent processes information automatically on behalf of the user. Another mechanism allows a user to define objects, for example by using a template. These two mechanisms act together to allow each object to be displayed to the user and acted upon by the user in a uniform way regardless of type. For example, templates for defining objects allow a specification to be input by a user defining processing that can be performed by an agent.",
-      "URL": "https://patents.google.com/patent/US5790116A/en",
-      "number": "US5790116A",
-      "author": [
-        {
-          "family": "Malone",
-          "given": "Thomas W."
-        },
-        {
-          "family": "Lai",
-          "given": "Kum-Yew"
-        },
-        {
-          "family": "Yu",
-          "given": "Keh-Chiang"
-        },
-        {
-          "family": "Berenson",
-          "given": "Richard W."
-        }
-      ],
-      "issued": {
-        "date-parts": [
-          [
-            1998,
-            8,
-            4
-          ]
-        ]
-      },
-      "accessed": {
-        "date-parts": [
-          [
-            2021,
-            6,
-            1
-          ]
-        ]
-      }
-    },
     {
       "id": "9296070/7MK4IUTY",
       "type": "patent",
@@ -5360,7 +11708,200 @@
             1
           ]
         ]
-      }
+      },
+      "key": "7MK4IUTY",
+      "version": 2038,
+      "itemType": "patent",
+      "creators": [
+        {
+          "creatorType": "inventor",
+          "firstName": "Geoffrey D.",
+          "lastName": "Nunberg"
+        },
+        {
+          "creatorType": "inventor",
+          "firstName": "Tayloe H.",
+          "lastName": "Stansbury"
+        },
+        {
+          "creatorType": "inventor",
+          "firstName": "Curtis",
+          "lastName": "Abbott"
+        },
+        {
+          "creatorType": "inventor",
+          "firstName": "Brian C.",
+          "lastName": "Smith"
+        }
+      ],
+      "abstractNote": "",
+      "place": "",
+      "country": "EP",
+      "assignee": "Xerox Corp",
+      "issuingAuthority": "European Union",
+      "patentNumber": "EP0370778B1",
+      "filingDate": "1989-11-21",
+      "pages": "",
+      "applicationNumber": "EP89312093A",
+      "priorityNumbers": "",
+      "issueDate": "1998-06-03",
+      "references": "",
+      "legalStatus": "",
+      "shortTitle": "",
+      "url": "https://patents.google.com/patent/EP0370778B1/en",
+      "accessDate": "2021-06-01T20:48:33Z",
+      "rights": "",
+      "extra": "",
+      "tags": [
+        {
+          "tag": "data",
+          "type": 1
+        },
+        {
+          "tag": "punctuational",
+          "type": 1
+        },
+        {
+          "tag": "sz"
+        },
+        {
+          "tag": "text",
+          "type": 1
+        },
+        {
+          "tag": "units",
+          "type": 1
+        },
+        {
+          "tag": "words",
+          "type": 1
+        }
+      ],
+      "collections": [
+        "MTUXENI8"
+      ],
+      "relations": {},
+      "dateAdded": "2021-06-01T20:48:33Z",
+      "dateModified": "2021-06-01T20:48:58Z"
+    },
+    {
+      "id": "9296070/C4NIHH58",
+      "type": "patent",
+      "title": "Object-oriented computer user interface",
+      "abstract": "A computer user interface includes a mechanism of graphically representing and displaying user-definable objects of multiple types. The object types that can be represented include data records, not limited to a particular kind of data, and agents. An agent processes information automatically on behalf of the user. Another mechanism allows a user to define objects, for example by using a template. These two mechanisms act together to allow each object to be displayed to the user and acted upon by the user in a uniform way regardless of type. For example, templates for defining objects allow a specification to be input by a user defining processing that can be performed by an agent.",
+      "URL": "https://patents.google.com/patent/US5790116A/en",
+      "number": "US5790116A",
+      "author": [
+        {
+          "family": "Malone",
+          "given": "Thomas W."
+        },
+        {
+          "family": "Lai",
+          "given": "Kum-Yew"
+        },
+        {
+          "family": "Yu",
+          "given": "Keh-Chiang"
+        },
+        {
+          "family": "Berenson",
+          "given": "Richard W."
+        }
+      ],
+      "issued": {
+        "date-parts": [
+          [
+            1998,
+            8,
+            4
+          ]
+        ]
+      },
+      "accessed": {
+        "date-parts": [
+          [
+            2021,
+            6,
+            1
+          ]
+        ]
+      },
+      "key": "C4NIHH58",
+      "version": 2042,
+      "itemType": "patent",
+      "creators": [
+        {
+          "creatorType": "inventor",
+          "firstName": "Thomas W.",
+          "lastName": "Malone"
+        },
+        {
+          "creatorType": "inventor",
+          "firstName": "Kum-Yew",
+          "lastName": "Lai"
+        },
+        {
+          "creatorType": "inventor",
+          "firstName": "Keh-Chiang",
+          "lastName": "Yu"
+        },
+        {
+          "creatorType": "inventor",
+          "firstName": "Richard W.",
+          "lastName": "Berenson"
+        }
+      ],
+      "abstractNote": "A computer user interface includes a mechanism of graphically representing and displaying user-definable objects of multiple types. The object types that can be represented include data records, not limited to a particular kind of data, and agents. An agent processes information automatically on behalf of the user. Another mechanism allows a user to define objects, for example by using a template. These two mechanisms act together to allow each object to be displayed to the user and acted upon by the user in a uniform way regardless of type. For example, templates for defining objects allow a specification to be input by a user defining processing that can be performed by an agent.",
+      "place": "",
+      "country": "US",
+      "assignee": "Massachusetts Institute of Technology",
+      "issuingAuthority": "United States",
+      "patentNumber": "US5790116A",
+      "filingDate": "1995-06-07",
+      "pages": "",
+      "applicationNumber": "US08/484,415",
+      "priorityNumbers": "",
+      "issueDate": "1998-08-04",
+      "references": "",
+      "legalStatus": "",
+      "language": "",
+      "shortTitle": "",
+      "url": "https://patents.google.com/patent/US5790116A/en",
+      "accessDate": "2021-06-01T20:51:03Z",
+      "rights": "",
+      "extra": "",
+      "tags": [
+        {
+          "tag": "folder",
+          "type": 1
+        },
+        {
+          "tag": "objects",
+          "type": 1
+        },
+        {
+          "tag": "sz"
+        },
+        {
+          "tag": "type",
+          "type": 1
+        },
+        {
+          "tag": "types",
+          "type": 1
+        },
+        {
+          "tag": "user",
+          "type": 1
+        }
+      ],
+      "collections": [
+        "MTUXENI8"
+      ],
+      "relations": {},
+      "dateAdded": "2021-06-01T20:51:03Z",
+      "dateModified": "2021-06-01T20:51:21Z"
     },
     {
       "id": "9296070/MV2TXBJZ",
@@ -5400,7 +11941,76 @@
             1
           ]
         ]
-      }
+      },
+      "key": "MV2TXBJZ",
+      "version": 2010,
+      "itemType": "patent",
+      "creators": [
+        {
+          "creatorType": "inventor",
+          "firstName": "Jock D.",
+          "lastName": "Mackinlay"
+        },
+        {
+          "creatorType": "inventor",
+          "firstName": "Stuart K.",
+          "lastName": "Card"
+        },
+        {
+          "creatorType": "inventor",
+          "firstName": "George G.",
+          "lastName": "Robertson"
+        }
+      ],
+      "abstractNote": "",
+      "place": "",
+      "country": "EP",
+      "assignee": "Xerox Corp",
+      "issuingAuthority": "European Union",
+      "patentNumber": "EP0471484B1",
+      "filingDate": "1991-08-02",
+      "pages": "",
+      "applicationNumber": "EP19910307114",
+      "priorityNumbers": "",
+      "issueDate": "1998-09-16",
+      "references": "",
+      "legalStatus": "",
+      "shortTitle": "",
+      "url": "https://patents.google.com/patent/EP0471484B1/en",
+      "accessDate": "2021-06-01T20:41:54Z",
+      "rights": "",
+      "extra": "",
+      "tags": [
+        {
+          "tag": "image",
+          "type": 1
+        },
+        {
+          "tag": "motion",
+          "type": 1
+        },
+        {
+          "tag": "poi",
+          "type": 1
+        },
+        {
+          "tag": "region",
+          "type": 1
+        },
+        {
+          "tag": "sz"
+        },
+        {
+          "tag": "viewpoint",
+          "type": 1
+        }
+      ],
+      "collections": [
+        "MTUXENI8"
+      ],
+      "relations": {},
+      "dateAdded": "2021-06-01T20:41:54Z",
+      "dateModified": "2021-06-01T20:42:38Z"
     },
     {
       "id": "9296070/ZRI4MHTQ",
@@ -5436,7 +12046,46 @@
             15
           ]
         ]
-      }
+      },
+      "key": "ZRI4MHTQ",
+      "version": 1506,
+      "itemType": "journalArticle",
+      "creators": [
+        {
+          "creatorType": "author",
+          "firstName": "Kate",
+          "lastName": "Ehrlich"
+        }
+      ],
+      "abstractNote": "",
+      "publicationTitle": "Interactions",
+      "pages": "36–47",
+      "date": "November 1, 1998",
+      "series": "",
+      "seriesTitle": "",
+      "seriesText": "",
+      "language": "",
+      "ISSN": "1072-5520",
+      "shortTitle": "",
+      "url": "https://doi.org/10.1145/287821.287827",
+      "accessDate": "2021-04-15T23:22:06Z",
+      "archive": "",
+      "archiveLocation": "",
+      "libraryCatalog": "Nov./Dec. 1998",
+      "callNumber": "",
+      "rights": "",
+      "extra": "",
+      "tags": [
+        {
+          "tag": "sz"
+        }
+      ],
+      "collections": [
+        "MTUXENI8"
+      ],
+      "relations": {},
+      "dateAdded": "2021-04-15T23:22:52Z",
+      "dateModified": "2021-06-01T18:51:38Z"
     }
   ],
   "2001": [
@@ -5512,7 +12161,86 @@
             15
           ]
         ]
-      }
+      },
+      "key": "XMCBCFMT",
+      "version": 2158,
+      "itemType": "bookSection",
+      "creators": [
+        {
+          "creatorType": "seriesEditor",
+          "firstName": "Gerhard",
+          "lastName": "Goos"
+        },
+        {
+          "creatorType": "seriesEditor",
+          "firstName": "Juris",
+          "lastName": "Hartmanis"
+        },
+        {
+          "creatorType": "seriesEditor",
+          "firstName": "Jan",
+          "lastName": "van Leeuwen"
+        },
+        {
+          "creatorType": "editor",
+          "firstName": "Roberto",
+          "lastName": "Moreno-Díaz"
+        },
+        {
+          "creatorType": "editor",
+          "firstName": "Bruno",
+          "lastName": "Buchberger"
+        },
+        {
+          "creatorType": "editor",
+          "firstName": "José",
+          "lastName": "Luis Freire"
+        },
+        {
+          "creatorType": "author",
+          "firstName": "Michael",
+          "lastName": "Affenzeller"
+        },
+        {
+          "creatorType": "author",
+          "firstName": "Franz",
+          "lastName": "Pichler"
+        },
+        {
+          "creatorType": "author",
+          "firstName": "Rudolf",
+          "lastName": "Mittelmann"
+        }
+      ],
+      "abstractNote": "CAST.FSM denotes a CAST tool which has been developed at the Institute of Systems Science at the University of Linz during the years 1986–1993. The first version of CAST.FSM was implemented in INTERLISP-D and LOOPS for the Siemens-Xerox workstation 5815 (“Dandelion”). CAST.FSM supports the application of the theory of finite state machines for hardware design tasks between the architecture level and the level of gate circuits. The application domain, to get practical experience for CAST.FSM, was the field of VLSI design of ASICS’s where the theory of finite state machines can be applied to improve the testability of such circuits (“design for testability”) and to optimise the required silicon area of the circuit (“floor planning”). An overview of CAST as a whole and of CAST.FSM as a CAST tool is given in [11]. In our presentation we want to report on the re-engineering of CAST.FSM and on new types of applications of CAST.FSM which are currently under investigation. In this context we will distinguish between three different problems:\n1.\nthe implementation of CAST.FSM in ANSI Common Lisp and the design of a new user interface by Rudolf Mittelmann [5].\n\n \n2.\nthe search for systemstheoretical concepts in modelling intelligent hierarchical systems based on the past work of Arthur Koestler [3] following the concepts presented by Franz Pichler in [10].\n\n \n3.\nthe construction of hierarchical formal models (of multi-layer type) to study attributes which are assumed for SOHO-structures (SOHO = Self Organizing Hierarchical Order) of A. Koestler.\n\n \nThe latter problem will deserve the main attention in our presentation. In the present paper we will build such a hierarchical model following the concepts of parallel decomposition of finite state machines (FSMs) and interpret it as a multi-layer type of model.",
+      "bookTitle": "Computer Aided Systems Theory — EUROCAST 2001",
+      "series": "",
+      "seriesNumber": "",
+      "numberOfVolumes": "",
+      "edition": "",
+      "place": "Berlin",
+      "date": "2001",
+      "pages": "36-44",
+      "shortTitle": "",
+      "url": "http://link.springer.com/10.1007/3-540-45654-6_3",
+      "accessDate": "2021-04-15T23:03:04Z",
+      "archive": "",
+      "archiveLocation": "",
+      "libraryCatalog": "DOI.org (Crossref)",
+      "callNumber": "",
+      "rights": "",
+      "extra": "Series Title: Lecture Notes in Computer Science\nDOI: 10.1007/3-540-45654-6_3",
+      "tags": [
+        {
+          "tag": "sz"
+        }
+      ],
+      "collections": [
+        "MTUXENI8"
+      ],
+      "relations": {},
+      "dateAdded": "2021-04-15T23:03:04Z",
+      "dateModified": "2021-07-26T02:28:28Z"
     }
   ],
   "2003": [
@@ -5548,75 +12276,62 @@
             2003
           ]
         ]
-      }
-    },
-    {
-      "id": "9296070/IVA8R7A2",
-      "type": "report",
-      "title": "Programming Languages -- The LOOPS Project (1982-1986)",
-      "publisher": "Xerox Parc",
-      "abstract": "The LOOPS (Lisp Object-Oriented Language) project was started to support development of expert systems project at PARC. We wanted a language that had many of the\nfeatures of frame languages, such as objects, annotated values, inheritance, and attached procedures. We drew heavily on Smalltalk-80, which was being developed next door.",
-      "URL": "https://larrymasinter.net/stefik-loops.pdf",
-      "language": "en",
-      "author": [
+      },
+      "key": "IVA8R7A2",
+      "version": 2429,
+      "itemType": "report",
+      "creators": [
         {
-          "family": "Bobrow",
-          "given": "Daniel"
+          "creatorType": "author",
+          "firstName": "Daniel",
+          "lastName": "Bobrow"
         },
         {
-          "family": "Mittal",
-          "given": "Sanjay"
+          "creatorType": "author",
+          "firstName": "Sanjay",
+          "lastName": "Mittal"
         },
         {
-          "family": "Lanning",
-          "given": "Stanley"
+          "creatorType": "author",
+          "firstName": "Stanley",
+          "lastName": "Lanning"
         },
         {
-          "family": "Stefik",
-          "given": "Mark"
+          "creatorType": "author",
+          "firstName": "Mark",
+          "lastName": "Stefik"
         }
       ],
-      "issued": {
-        "date-parts": [
-          [
-            2003
-          ]
-        ]
-      }
-    },
-    {
-      "id": "9296070/IVA8R7A2",
-      "type": "report",
-      "title": "Programming Languages -- The LOOPS Project (1982-1986)",
-      "publisher": "Xerox Parc",
-      "abstract": "The LOOPS (Lisp Object-Oriented Language) project was started to support development of expert systems project at PARC. We wanted a language that had many of the\nfeatures of frame languages, such as objects, annotated values, inheritance, and attached procedures. We drew heavily on Smalltalk-80, which was being developed next door.",
-      "URL": "https://larrymasinter.net/stefik-loops.pdf",
-      "language": "en",
-      "author": [
+      "abstractNote": "The LOOPS (Lisp Object-Oriented Language) project was started to support development of expert systems project at PARC. We wanted a language that had many of the\nfeatures of frame languages, such as objects, annotated values, inheritance, and attached procedures. We drew heavily on Smalltalk-80, which was being developed next door.",
+      "reportNumber": "",
+      "reportType": "",
+      "seriesTitle": "",
+      "place": "",
+      "institution": "Xerox Parc",
+      "date": "2003",
+      "pages": "",
+      "shortTitle": "",
+      "url": "https://larrymasinter.net/stefik-loops.pdf",
+      "accessDate": "",
+      "archive": "",
+      "archiveLocation": "",
+      "libraryCatalog": "Zotero",
+      "callNumber": "",
+      "rights": "",
+      "extra": "",
+      "tags": [
         {
-          "family": "Bobrow",
-          "given": "Daniel"
-        },
-        {
-          "family": "Mittal",
-          "given": "Sanjay"
-        },
-        {
-          "family": "Lanning",
-          "given": "Stanley"
-        },
-        {
-          "family": "Stefik",
-          "given": "Mark"
+          "tag": "sz"
         }
       ],
-      "issued": {
-        "date-parts": [
-          [
-            2003
-          ]
-        ]
-      }
+      "collections": [
+        "MTUXENI8",
+        "3CNYFDHF",
+        "8MSYRKQA"
+      ],
+      "relations": {},
+      "dateAdded": "2021-04-16T04:16:13Z",
+      "dateModified": "2021-07-26T02:31:14Z"
     }
   ],
   "2006": [
@@ -5647,7 +12362,37 @@
             25
           ]
         ]
-      }
+      },
+      "key": "88GP5KT3",
+      "version": 2039,
+      "itemType": "webpage",
+      "creators": [
+        {
+          "creatorType": "author",
+          "firstName": "Al",
+          "lastName": "Kossow"
+        }
+      ],
+      "abstractNote": "",
+      "websiteTitle": "",
+      "websiteType": "",
+      "date": "2006",
+      "url": "http://pdp-10.trailing-edge.com/",
+      "accessDate": "2021-04-25T13:14:32Z",
+      "language": "",
+      "rights": "",
+      "extra": "",
+      "tags": [
+        {
+          "tag": "sz"
+        }
+      ],
+      "collections": [
+        "HVGVBYYB"
+      ],
+      "relations": {},
+      "dateAdded": "2021-04-25T21:00:27Z",
+      "dateModified": "2021-06-02T18:24:30Z"
     }
   ],
   "2007": [
@@ -5686,7 +12431,46 @@
             15
           ]
         ]
-      }
+      },
+      "key": "4QGNIKFU",
+      "version": 1464,
+      "itemType": "journalArticle",
+      "creators": [
+        {
+          "creatorType": "author",
+          "firstName": "Lauri",
+          "lastName": "Karttunen"
+        }
+      ],
+      "abstractNote": "This article is a perspective on some important developments in semantics and in computational linguistics over the past forty years. It reviews two lines of research that lie at opposite ends of the field: semantics and morphology. The semantic part deals with issues from the 1970s such as discourse referents, implicative verbs, presuppositions, and questions. The second part presents a brief history of the application of finite-state transducers to linguistic analysis starting with the advent of two-level morphology in the early 1980s and culminating in successful commercial applications in the 1990s. It offers some commentary on the relationship, or the lack thereof, between computational and paper-and-pencil linguistics. The final section returns to the semantic issues and their application to currently popular tasks such as textual inference and question answering.",
+      "publicationTitle": "Computational Linguistics",
+      "pages": "443–467",
+      "date": "December 1, 2007",
+      "series": "",
+      "seriesTitle": "",
+      "seriesText": "",
+      "language": "",
+      "ISSN": "0891-2017",
+      "shortTitle": "",
+      "url": "https://doi.org/10.1162/coli.2007.33.4.443",
+      "accessDate": "2021-04-15T23:18:32Z",
+      "archive": "",
+      "archiveLocation": "",
+      "libraryCatalog": "December 2007",
+      "callNumber": "",
+      "rights": "",
+      "extra": "",
+      "tags": [
+        {
+          "tag": "sz"
+        }
+      ],
+      "collections": [
+        "MTUXENI8"
+      ],
+      "relations": {},
+      "dateAdded": "2021-04-15T23:18:51Z",
+      "dateModified": "2021-06-01T15:39:14Z"
     }
   ],
   "2008": [
@@ -5716,7 +12500,26 @@
             5
           ]
         ]
-      }
+      },
+      "key": "PCL5WHQQ",
+      "version": 2484,
+      "itemType": "blogPost",
+      "creators": [],
+      "abstractNote": "Okay, quick… how many people besides Alan Kay can you name that worked at Xerox PARC? Not very many, eh? Yeah, that’s your loss. It wasn’t all about the guys like Kay that get all…",
+      "blogTitle": "Learning Lisp",
+      "websiteType": "",
+      "date": "2008-10-24T18:43:08+00:00",
+      "url": "https://lispy.wordpress.com/2008/10/24/lisp50-notes-part-v-interlisp-parc-and-the-common-lisp-consolidation-wars/",
+      "accessDate": "2022-08-05T00:01:02Z",
+      "rights": "",
+      "extra": "",
+      "tags": [],
+      "collections": [
+        "TVX6WEZX"
+      ],
+      "relations": {},
+      "dateAdded": "2022-08-05T00:01:02Z",
+      "dateModified": "2022-08-05T00:01:02Z"
     },
     {
       "id": "9296070/DVGRZ62H",
@@ -5755,7 +12558,49 @@
             15
           ]
         ]
-      }
+      },
+      "key": "DVGRZ62H",
+      "version": 1327,
+      "itemType": "conferencePaper",
+      "creators": [
+        {
+          "creatorType": "author",
+          "firstName": "Warren",
+          "lastName": "Teitelman"
+        }
+      ],
+      "abstractNote": "I was first introduced to Lisp in 1962 as a first year graduate student at M.I.T. in a class taught by James Slagle. Having programmed in Fortran and assembly, I was impressed with Lisp's elegance. In particular, Lisp enabled expressing recursion in a manner that was so simple that many first time observers would ask the question, \"Where does the program do the work?\" (Answer - between the parentheses!) Lisp also provided the ability to manipulate programs, since Lisp programs were themselves data (S-expressions) the same as other list structures used to represent program data. This made Lisp an ideal language for writing programs that themselves constructed programs or proved things about programs. Since I was at M.I.T. to study Artificial Intelligence, program writing programs was something that interested me greatly.",
+      "date": "October 20, 2008",
+      "proceedingsTitle": "Celebrating the 50th Anniversary of Lisp",
+      "conferenceName": "",
+      "place": "New York, NY, USA",
+      "volume": "",
+      "pages": "1–5",
+      "series": "LISP50",
+      "language": "",
+      "shortTitle": "",
+      "url": "https://doi.org/10.1145/1529966.1529971",
+      "accessDate": "2021-04-15",
+      "archive": "",
+      "archiveLocation": "",
+      "libraryCatalog": "ACM Digital Library",
+      "callNumber": "",
+      "rights": "",
+      "extra": "",
+      "tags": [
+        {
+          "tag": "Interlisp-D"
+        },
+        {
+          "tag": "s2z"
+        }
+      ],
+      "collections": [
+        "TVX6WEZX"
+      ],
+      "relations": {},
+      "dateAdded": "2021-04-15T23:18:51Z",
+      "dateModified": "2021-05-31T18:21:01Z"
     }
   ],
   "2010": [
@@ -5788,10 +12633,118 @@
             21
           ]
         ]
-      }
+      },
+      "key": "IKAJUF8S",
+      "version": 1749,
+      "itemType": "webpage",
+      "creators": [
+        {
+          "creatorType": "author",
+          "name": "Jill Marci Sybalsky"
+        }
+      ],
+      "abstractNote": "",
+      "websiteTitle": "VENUE",
+      "websiteType": "",
+      "date": "March 4, 2010",
+      "shortTitle": "",
+      "url": "https://web.archive.org/web/20100304002925/http://top2bottom.net:80/medley.html",
+      "accessDate": "2021-04-21T16:54:57Z",
+      "language": "",
+      "rights": "",
+      "extra": "",
+      "tags": [
+        {
+          "tag": "sz"
+        }
+      ],
+      "collections": [
+        "3CNYFDHF"
+      ],
+      "relations": {
+        "dc:replaces": [
+          "http://zotero.org/groups/2914042/items/TCBI7DAA",
+          "http://zotero.org/groups/2914042/items/W4SZMEFA",
+          "http://zotero.org/groups/2914042/items/JPTQYV4P",
+          "http://zotero.org/groups/2914042/items/XQES9BAH"
+        ]
+      },
+      "dateAdded": "2021-04-22T03:48:38Z",
+      "dateModified": "2021-06-02T18:56:58Z"
     }
   ],
   "2011": [
+    {
+      "id": "9296070/MJP8UYEV",
+      "type": "motion_picture",
+      "title": "Truckin Knowledge Competition (1983)",
+      "abstract": "In 1983 the Knowledge Systems Area at Xerox PARC taught experimental courses on knowledge programming. The Truckin' knowledge competition was the final exam at the end of a one week course. Students programmed their trucks to compete in Truckin' simulation world -- buying and selling goods, getting gas as needed, avoiding bandits, and so on. All of the trucks competed in the final. The winner was the truck with the most cash parked nearest Alice's Restaurant. See www.markstefik.com/?page_id=359",
+      "URL": "https://www.youtube.com/watch?v=Pt-Sv1ynGKc",
+      "author": [
+        {
+          "family": "Mark Stefik",
+          "given": ""
+        }
+      ],
+      "issued": {
+        "date-parts": [
+          [
+            2011,
+            4,
+            10
+          ]
+        ]
+      },
+      "accessed": {
+        "date-parts": [
+          [
+            2021,
+            5,
+            17
+          ]
+        ]
+      },
+      "key": "MJP8UYEV",
+      "version": 1479,
+      "itemType": "videoRecording",
+      "creators": [
+        {
+          "creatorType": "director",
+          "name": "Mark Stefik"
+        }
+      ],
+      "abstractNote": "In 1983 the Knowledge Systems Area at Xerox PARC taught experimental courses on knowledge programming. The Truckin' knowledge competition was the final exam at the end of a one week course. Students programmed their trucks to compete in Truckin' simulation world -- buying and selling goods, getting gas as needed, avoiding bandits, and so on. All of the trucks competed in the final. The winner was the truck with the most cash parked nearest Alice's Restaurant. See www.markstefik.com/?page_id=359",
+      "videoRecordingFormat": "",
+      "seriesTitle": "",
+      "volume": "",
+      "numberOfVolumes": "",
+      "place": "",
+      "studio": "",
+      "date": "2011-04-10",
+      "runningTime": "2:28",
+      "language": "",
+      "ISBN": "",
+      "shortTitle": "",
+      "url": "https://www.youtube.com/watch?v=Pt-Sv1ynGKc",
+      "accessDate": "2021-05-17T22:01:48Z",
+      "archive": "",
+      "archiveLocation": "",
+      "libraryCatalog": "YouTube",
+      "callNumber": "",
+      "rights": "",
+      "extra": "",
+      "tags": [
+        {
+          "tag": "sz"
+        }
+      ],
+      "collections": [
+        "MTUXENI8"
+      ],
+      "relations": {},
+      "dateAdded": "2021-05-17T22:01:48Z",
+      "dateModified": "2021-06-01T15:59:18Z"
+    },
     {
       "id": "9296070/PUPZYPIV",
       "type": "motion_picture",
@@ -5822,38 +12775,46 @@
             17
           ]
         ]
-      }
-    },
-    {
-      "id": "9296070/MJP8UYEV",
-      "type": "motion_picture",
-      "title": "Truckin Knowledge Competition (1983)",
-      "abstract": "In 1983 the Knowledge Systems Area at Xerox PARC taught experimental courses on knowledge programming. The Truckin' knowledge competition was the final exam at the end of a one week course. Students programmed their trucks to compete in Truckin' simulation world -- buying and selling goods, getting gas as needed, avoiding bandits, and so on. All of the trucks competed in the final. The winner was the truck with the most cash parked nearest Alice's Restaurant. See www.markstefik.com/?page_id=359",
-      "URL": "https://www.youtube.com/watch?v=Pt-Sv1ynGKc",
-      "author": [
+      },
+      "key": "PUPZYPIV",
+      "version": 1671,
+      "itemType": "videoRecording",
+      "creators": [
         {
-          "family": "Mark Stefik",
-          "given": ""
+          "creatorType": "director",
+          "name": "Mark Stefik"
         }
       ],
-      "issued": {
-        "date-parts": [
-          [
-            2011,
-            4,
-            10
-          ]
-        ]
-      },
-      "accessed": {
-        "date-parts": [
-          [
-            2021,
-            5,
-            17
-          ]
-        ]
-      }
+      "abstractNote": "The Colab project at PARC was an experiment in creating an electronic meeting room. This project developed multi-user interfaces, telepointers, and other innovations at the time. This movie shows the Cognoter tool which was a multi-user brainstorming tool used for collaborative development of an outline for a paper. See /www.markstefik.com/?page_id=155\"",
+      "videoRecordingFormat": "",
+      "seriesTitle": "",
+      "volume": "",
+      "numberOfVolumes": "",
+      "place": "",
+      "studio": "",
+      "date": "2011-04-10",
+      "runningTime": "3:23",
+      "language": "",
+      "ISBN": "",
+      "url": "https://www.youtube.com/watch?v=iPZTOosKjAE",
+      "accessDate": "2021-05-17T22:02:37Z",
+      "archive": "",
+      "archiveLocation": "",
+      "libraryCatalog": "YouTube",
+      "callNumber": "",
+      "rights": "",
+      "extra": "",
+      "tags": [
+        {
+          "tag": "sz"
+        }
+      ],
+      "collections": [
+        "MTUXENI8"
+      ],
+      "relations": {},
+      "dateAdded": "2021-05-17T22:02:37Z",
+      "dateModified": "2021-06-02T17:44:36Z"
     }
   ],
   "2012": [
@@ -5887,7 +12848,48 @@
             2
           ]
         ]
-      }
+      },
+      "key": "ZE7EVJYM",
+      "version": 1897,
+      "itemType": "videoRecording",
+      "creators": [
+        {
+          "creatorType": "director",
+          "firstName": "Wayne",
+          "lastName": "Oldford"
+        }
+      ],
+      "abstractNote": "Guy DesVignes and R. Wayne Oldford, 1988 \n \nThis video (in 3 pieces) describes the use of graphical programming with an example, showing the encapsulation of several steps of an analysis into a single reusable tool.   An INTERLISP-D programming environment with the object oriented system LOOPS is used for software development. \nWork is on a Xerox Lisp Workstation  (Xerox 1186). \n \nFirst of 3 pieces of a single video. \n \nFirst piece: Graphical Programming (1988) - Part 0 \n       Contains: \n        \"Opening\"   \n            -  Introduction by a young Wayne Oldford   \n               (refers to earlier video called \"Data Analysis Networks \n                in DINDE\")  \n       \"Part 0 Statistical Analysis Maps\" \n            - review of the interactive data analysis network representation  \n              of a statistical analysis. \n \nSecond piece:  Graphical Programming (1988) - Parts 1 and 2 \n       Contains: \n        \"Part 1   Toolboxes\"   \n            -  Review of the elements of a statistical toolbox in DINDE  \n       \"Part 2 The Analysis Path\" \n            - Demonstrates exploration of a path in an existing \n              analysis map and its representation as a pattern, \n              It is shown how to capture this pattern in DINDE as a new \n             new program represented as an \"AnalysisPath\" object.. \n              This is what is meant by  \"graphical programming\". \n \n \nThird piece: \"Graphical Programming (1988) - Part 3\" \n       Contains: \n        \"Part 3   Graphical Programming \n                        Example: Added Variable Plots\"   \n            - Demonstrates graphical programming by constructing \n              an added variable plot.  This is done by constructing the \n              appropriate analysis path on some data, capturing the pattern \n              adding it to the toolbox and then applying it to new data. \n \n        \"Summary\" \n \n \nSound has been cleaned up a little. \nComplete video also available in whole at  \n        stat-graphics.org/movies/graphical-programming.html",
+      "videoRecordingFormat": "",
+      "seriesTitle": "",
+      "volume": "",
+      "numberOfVolumes": "",
+      "place": "",
+      "studio": "Xerox Lisp Workstation",
+      "date": "2012-02-16",
+      "runningTime": "6:28",
+      "language": "",
+      "ISBN": "",
+      "shortTitle": "",
+      "url": "https://www.youtube.com/watch?v=J4F6ioMKiqw&t=53s",
+      "accessDate": "2021-05-02T21:20:07Z",
+      "archive": "",
+      "archiveLocation": "",
+      "libraryCatalog": "YouTube",
+      "callNumber": "",
+      "rights": "",
+      "extra": "",
+      "tags": [
+        {
+          "tag": "sz"
+        }
+      ],
+      "collections": [
+        "MTUXENI8"
+      ],
+      "relations": {},
+      "dateAdded": "2021-05-02T21:20:07Z",
+      "dateModified": "2021-06-03T19:20:49Z"
     },
     {
       "id": "9296070/FJ2M3GNL",
@@ -5919,7 +12921,48 @@
             2
           ]
         ]
-      }
+      },
+      "key": "FJ2M3GNL",
+      "version": 1897,
+      "itemType": "videoRecording",
+      "creators": [
+        {
+          "creatorType": "director",
+          "firstName": "Wayne",
+          "lastName": "Oldford"
+        }
+      ],
+      "abstractNote": "Guy DesVignes and R. Wayne Oldford, 1988 \n \nThis video (in 3 pieces) describes the use of graphical programming with an example, showing the encapsulation of several steps of an analysis into a single reusable tool.   An INTERLISP-D programming environment with the object oriented system LOOPS is used for software development. \nWork is on a Xerox Lisp Workstation  (Xerox 1186). \n \nSecond of 3 pieces of a single video. \n \nFirst piece: Graphical Programming (1988) - Part 0 \n       Contains: \n        \"Opening\"   \n            -  Introduction by Wayne Oldford   \n               (refers to earlier video called \"Data Analysis Networks \n                in DINDE\")  \n       \"Part 0 Statistical Analysis Maps\" \n            - review of the interactive data analysis network representation  \n              of a statistical analysis. \n \nSecond piece:  Graphical Programming (1988) - Parts 1 and 2 \n       Contains: \n        \"Part 1   Toolboxes\"   \n            -  Review of the elements of a statistical toolbox in DINDE  \n       \"Part 2 The Analysis Path\" \n            - Demonstrates exploration of a path in an existing \n              analysis map and its representation as a pattern, \n              It is shown how to capture this pattern in DINDE as a new \n             new program represented as an \"AnalysisPath\" object.. \n              This is what is meant by  \"graphical programming\". \n \n \nThird piece: \"Graphical Programming (1988) - Part 3\" \n       Contains: \n        \"Part 3   Graphical Programming \n                        Example: Added Variable Plots\"   \n            - Demonstrates graphical programming by constructing \n              an added variable plot.  This is done by constructing the \n              appropriate analysis path on some data, capturing the pattern \n              adding it to the toolbox and then applying it to new data. \n \n        \"Summary\" \n \n \nSound has been cleaned up a little. \nComplete video also available in whole at  \n        stat-graphics.org/movies/graphical-programming.html",
+      "videoRecordingFormat": "",
+      "seriesTitle": "",
+      "volume": "",
+      "numberOfVolumes": "",
+      "place": "",
+      "studio": "Xerox Lisp Workstation",
+      "date": "2012-02-17",
+      "runningTime": "11:18",
+      "language": "",
+      "ISBN": "",
+      "shortTitle": "",
+      "url": "https://www.youtube.com/watch?v=wlN0hHLZL8c",
+      "accessDate": "2021-05-02T21:22:30Z",
+      "archive": "",
+      "archiveLocation": "",
+      "libraryCatalog": "YouTube",
+      "callNumber": "",
+      "rights": "",
+      "extra": "",
+      "tags": [
+        {
+          "tag": "sz"
+        }
+      ],
+      "collections": [
+        "MTUXENI8"
+      ],
+      "relations": {},
+      "dateAdded": "2021-05-02T21:22:30Z",
+      "dateModified": "2021-06-03T19:21:33Z"
     },
     {
       "id": "9296070/TEHSJNIS",
@@ -5944,7 +12987,99 @@
             2
           ]
         ]
-      }
+      },
+      "key": "TEHSJNIS",
+      "version": 2103,
+      "itemType": "videoRecording",
+      "creators": [
+        {
+          "creatorType": "castMember",
+          "name": "TVontaro"
+        }
+      ],
+      "abstractNote": "This clip looks at two examples of larger tutorial--CAI systems that were developed by the Ontario Institute for Studies and Education, and Xerox's PARC.\n\nIt is from Episode 7 of the classic 1983 television series, Bits and Bytes, which starred Luba Goy and Billy Van.  It was produced by TVOntario, but is no longer available for purchase.",
+      "videoRecordingFormat": "",
+      "seriesTitle": "",
+      "volume": "",
+      "numberOfVolumes": "",
+      "place": "",
+      "studio": "",
+      "date": "2012-05-19",
+      "runningTime": "5:42",
+      "language": "",
+      "ISBN": "",
+      "shortTitle": "",
+      "url": "https://www.youtube.com/watch?v=eURtTV_qKw8&t=147s",
+      "accessDate": "2021-05-02T21:17:01Z",
+      "archive": "",
+      "archiveLocation": "",
+      "libraryCatalog": "YouTube",
+      "callNumber": "",
+      "rights": "",
+      "extra": "",
+      "tags": [
+        {
+          "tag": "sz"
+        }
+      ],
+      "collections": [
+        "MTUXENI8"
+      ],
+      "relations": {},
+      "dateAdded": "2021-05-02T21:17:01Z",
+      "dateModified": "2021-07-06T19:37:34Z"
+    }
+  ],
+  "2013": [
+    {
+      "id": "9296070/WFP2799R",
+      "type": "webpage",
+      "title": "Interlisp was the so-called \"west coast\" Lisp that emphasized an interactive pro... | Hacker News",
+      "genre": "Forums",
+      "URL": "https://news.ycombinator.com/item?id=5966399",
+      "language": "en",
+      "issued": {
+        "date-parts": [
+          [
+            2013,
+            6,
+            30
+          ]
+        ]
+      },
+      "accessed": {
+        "date-parts": [
+          [
+            2023,
+            4,
+            29
+          ]
+        ]
+      },
+      "key": "WFP2799R",
+      "version": 2943,
+      "itemType": "webpage",
+      "creators": [],
+      "abstractNote": "",
+      "websiteTitle": "",
+      "websiteType": "Forums",
+      "date": "2013-06-30",
+      "shortTitle": "",
+      "url": "https://news.ycombinator.com/item?id=5966399",
+      "accessDate": "2023-04-29T15:27:11Z",
+      "rights": "",
+      "extra": "",
+      "tags": [
+        {
+          "tag": "Reviewed by SHFT - CSUCI (Joseph Moreno)"
+        }
+      ],
+      "collections": [
+        "3CNYFDHF"
+      ],
+      "relations": {},
+      "dateAdded": "2023-04-29T15:27:11Z",
+      "dateModified": "2023-05-08T15:04:23Z"
     }
   ],
   "2015": [
@@ -5974,7 +13109,50 @@
             1
           ]
         ]
-      }
+      },
+      "key": "23ZCTJ9Z",
+      "version": 2157,
+      "itemType": "journalArticle",
+      "creators": [
+        {
+          "creatorType": "author",
+          "firstName": "Dan",
+          "lastName": "Murphy"
+        }
+      ],
+      "abstractNote": "In the late 1960s, a small group of developers at Bolt, Beranek, and Newman (BBN) in Cambridge, Massachusetts, began work on a new computer operating system, including a kernel, system call API, and user command interface (shell). While such an undertaking, particularly with a small group, became rare in subsequent decades, it was not uncommon in the 1960s. During development, this OS was given the name TENEX. A few years later, TENEX was adopted by Digital Equipment Corporation (DEC) for its new line of large machines to be known as the DECSYSTEM-20, and the operating system was renamed to TOPS-20. The author followed TENEX (or vice versa) on this journey, and these are some reflections and observations from that journey. He touches on some of the technical aspects that made TENEX notable in its day and an influence on operating systems that followed as well as on some of the people and other facets involved in the various steps along the way.",
+      "publicationTitle": "Annals of the History of Computing, IEEE",
+      "issue": "",
+      "pages": "75-82",
+      "date": "January 1, 2015",
+      "series": "",
+      "seriesTitle": "",
+      "seriesText": "",
+      "language": "",
+      "ISSN": "",
+      "shortTitle": "",
+      "url": "https://www.researchgate.net/publication/273523084_TENEX_and_TOPS-20",
+      "accessDate": "",
+      "archive": "",
+      "archiveLocation": "",
+      "libraryCatalog": "ResearchGate",
+      "callNumber": "",
+      "rights": "",
+      "extra": "Publisher: IEEE",
+      "tags": [
+        {
+          "tag": "BBN-LISP"
+        },
+        {
+          "tag": "s2z"
+        }
+      ],
+      "collections": [
+        "TVX6WEZX"
+      ],
+      "relations": {},
+      "dateAdded": "2021-06-01T14:47:05Z",
+      "dateModified": "2021-07-26T02:27:23Z"
     },
     {
       "id": "9296070/THLV47EY",
@@ -6003,7 +13181,105 @@
             23
           ]
         ]
-      }
+      },
+      "key": "THLV47EY",
+      "version": 2148,
+      "itemType": "report",
+      "creators": [
+        {
+          "creatorType": "author",
+          "firstName": "David S.H.",
+          "lastName": "Rosenthal"
+        }
+      ],
+      "abstractNote": "",
+      "reportNumber": "",
+      "reportType": "",
+      "seriesTitle": "",
+      "place": "",
+      "institution": "The Andrew W. Mellon Foundation",
+      "date": "October 2015",
+      "pages": "",
+      "language": "",
+      "shortTitle": "",
+      "url": "",
+      "accessDate": "2016-01-23T04:13:53Z",
+      "archive": "",
+      "archiveLocation": "",
+      "libraryCatalog": "Google Scholar",
+      "callNumber": "",
+      "rights": "",
+      "extra": "",
+      "tags": [],
+      "collections": [
+        "HVGVBYYB"
+      ],
+      "relations": {
+        "owl:sameAs": "http://zotero.org/groups/4052596/items/GEA9ZYT3"
+      },
+      "dateAdded": "2021-06-07T18:46:58Z",
+      "dateModified": "2021-07-26T02:18:40Z"
+    }
+  ],
+  "2016": [
+    {
+      "id": "9296070/YHTJMQLU",
+      "type": "post-weblog",
+      "title": "Xerox Alto Is Rebuilt and Reconnected by the Living Computer Museum",
+      "container-title": "Vulcan Inc.",
+      "abstract": "It’s one thing to read about a true breakthrough, something else to see it in action",
+      "URL": "https://medium.com/vulcan-inc/xerox-alto-is-rebuilt-and-reconnected-by-the-living-computer-museum-e56a7e86be91",
+      "language": "en",
+      "author": [
+        {
+          "family": "Allen",
+          "given": "Paul G."
+        }
+      ],
+      "issued": {
+        "date-parts": [
+          [
+            2016,
+            9,
+            14
+          ]
+        ]
+      },
+      "accessed": {
+        "date-parts": [
+          [
+            2023,
+            5,
+            22
+          ]
+        ]
+      },
+      "key": "YHTJMQLU",
+      "version": 3011,
+      "itemType": "blogPost",
+      "creators": [
+        {
+          "creatorType": "author",
+          "firstName": "Paul G.",
+          "lastName": "Allen"
+        }
+      ],
+      "abstractNote": "It’s one thing to read about a true breakthrough, something else to see it in action",
+      "blogTitle": "Vulcan Inc.",
+      "websiteType": "",
+      "date": "2016-09-14T22:02:44.589Z",
+      "url": "https://medium.com/vulcan-inc/xerox-alto-is-rebuilt-and-reconnected-by-the-living-computer-museum-e56a7e86be91",
+      "accessDate": "2023-05-22T20:22:48Z",
+      "shortTitle": "",
+      "rights": "",
+      "extra": "",
+      "tags": [],
+      "collections": [
+        "HVGVBYYB"
+      ],
+      "relations": {},
+      "dateAdded": "2023-05-22T20:22:48Z",
+      "dateModified": "2023-05-22T20:22:48Z"
     }
   ],
   "2017": [
@@ -6031,7 +13307,42 @@
             2
           ]
         ]
-      }
+      },
+      "key": "4CCTNX5G",
+      "version": 1991,
+      "itemType": "videoRecording",
+      "creators": [],
+      "abstractNote": "Reuploaded from: \nhttp://people.csail.mit.edu/riastradh...​\n\nThanks to \"lispm\" on reddit for all the info: \nhttps://www.reddit.com/r/lisp/comment...​\n\nFrom what I understand SEdit was developed later than DEdit. SEdit is documented first in the 1987 Lyric release of Interlisp-D, see Appendix B:\nhttp://bitsavers.trailing-edge.com/pd...​\nSEdit is expanded in the virtual machine version of Interlisp-D, called Medley. See the Medley 1.0 release notes, appendix B:\nhttp://bitsavers.trailing-edge.com/pd...​\nSome hints for using SEdit\nhttp://bitsavers.trailing-edge.com/pd...​\nIf you want to try it out, maybe this contains the editors:\nhttp://www2.parc.com/isl/groups/nltt/...​",
+      "videoRecordingFormat": "",
+      "seriesTitle": "",
+      "volume": "",
+      "numberOfVolumes": "",
+      "place": "",
+      "studio": "thoughtupquick",
+      "date": "2017-06-22",
+      "runningTime": "4:53",
+      "language": "",
+      "ISBN": "",
+      "shortTitle": "",
+      "url": "https://www.youtube.com/watch?v=2qsmF8HHskg",
+      "accessDate": "2021-05-02T21:18:00Z",
+      "archive": "",
+      "archiveLocation": "",
+      "libraryCatalog": "YouTube",
+      "callNumber": "",
+      "rights": "",
+      "extra": "",
+      "tags": [
+        {
+          "tag": "sz"
+        }
+      ],
+      "collections": [
+        "3CNYFDHF"
+      ],
+      "relations": {},
+      "dateAdded": "2021-05-02T21:18:00Z",
+      "dateModified": "2021-06-05T21:16:20Z"
     },
     {
       "id": "9296070/5QC8XEBV",
@@ -6069,7 +13380,42 @@
             18
           ]
         ]
-      }
+      },
+      "key": "5QC8XEBV",
+      "version": 2228,
+      "itemType": "journalArticle",
+      "creators": [
+        {
+          "creatorType": "author",
+          "firstName": "Johann",
+          "lastName": "DeKleer"
+        }
+      ],
+      "abstractNote": "It is with deep sorrow that we report the passing of former AAAI President Danny Bobrow on March 20, 2017. His family, friends, and colleagues from the Palo Alto Research Center and around the world recently gathered at PARC to commemorate his life and work.",
+      "publicationTitle": "The AI Magazine",
+      "issue": "",
+      "pages": "78",
+      "date": "2017-12-28",
+      "series": "",
+      "seriesTitle": "",
+      "seriesText": "",
+      "journalAbbreviation": "",
+      "ISSN": "0738-4602",
+      "url": "https://web.archive.org/web/201904301959/https://aaai.org/ojs/index.php/aimagazine/article/download/2767/2664",
+      "accessDate": "2021-07-18T22:54:14Z",
+      "archive": "",
+      "archiveLocation": "",
+      "libraryCatalog": "fatcat.wiki",
+      "callNumber": "",
+      "rights": "",
+      "extra": "Publisher: Association for the Advancement of Artificial Intelligence (AAAI)\nReport Number: 38\nFatcat ID: release_wg4g7ikocbagxinabbk2eni52q",
+      "tags": [],
+      "collections": [
+        "HVGVBYYB"
+      ],
+      "relations": {},
+      "dateAdded": "2021-07-18T22:54:14Z",
+      "dateModified": "2021-07-18T22:58:14Z"
     },
     {
       "id": "9296070/S2ZC62QX",
@@ -6102,7 +13448,33 @@
             16
           ]
         ]
-      }
+      },
+      "key": "S2ZC62QX",
+      "version": 1987,
+      "itemType": "webpage",
+      "creators": [
+        {
+          "creatorType": "author",
+          "firstName": "Larry",
+          "lastName": "Masinter"
+        }
+      ],
+      "abstractNote": "17 new photos added to shared album",
+      "websiteTitle": "Google Photos",
+      "websiteType": "",
+      "date": "Sep 30, 2017",
+      "shortTitle": "",
+      "url": "https://photos.google.com/share/AF1QipORUrk2uwraYYJVOZ2R8mH51U4n5uv30V1KJk5zvu5Pd5XtEXuXp8jg1BfwdHBHkw?key=OGxZSU5LbXZPaTdmbnU3QmZiOTRlYnR6SDdMNUJ3",
+      "accessDate": "2021-04-16T04:11:10Z",
+      "rights": "",
+      "extra": "",
+      "tags": [],
+      "collections": [
+        "3CNYFDHF"
+      ],
+      "relations": {},
+      "dateAdded": "2021-04-16T04:11:10Z",
+      "dateModified": "2021-06-05T21:09:39Z"
     }
   ],
   "2019": [
@@ -6139,7 +13511,51 @@
             21
           ]
         ]
-      }
+      },
+      "key": "IRKEPIAR",
+      "version": 2837,
+      "itemType": "blogPost",
+      "creators": [
+        {
+          "creatorType": "author",
+          "firstName": "Anne",
+          "lastName": "Barela"
+        }
+      ],
+      "abstractNote": "Via libingcomputers.org: Josh Dersch writes about research into the Xerox 8010 Information System (codenamed “Dandelion” during development) and commonly referred to as the Star. The Star was envisioned as center point of the office of the future, combining high-resolution graphics with the now-familiar mouse, Ethernet networking for sharing and collaborating, and Xerox’s Laser Printer technology for faithful “WYSIWYG” document reproduction. A revolutionary system when most everyone else was using text based systems.",
+      "blogTitle": "Adafruit Industries - Makers, hackers, artists, designers and engineers!",
+      "websiteType": "Blog",
+      "date": "January 23, 2019",
+      "url": "https://blog.adafruit.com/2019/01/23/introducing-darkstar-a-xerox-star-emulator-vintagecomputing-xerox-emulation/",
+      "accessDate": "2021-04-21T18:09:09Z",
+      "rights": "",
+      "extra": "",
+      "tags": [
+        {
+          "tag": "Dandelion"
+        },
+        {
+          "tag": "Emulation"
+        },
+        {
+          "tag": "Interlisp-D"
+        },
+        {
+          "tag": "Reviewed by SHFT - CSUCI (Ron Vincent A.)"
+        },
+        {
+          "tag": "Star"
+        },
+        {
+          "tag": "sz"
+        }
+      ],
+      "collections": [
+        "3CNYFDHF"
+      ],
+      "relations": {},
+      "dateAdded": "2021-04-22T04:57:15Z",
+      "dateModified": "2023-05-05T14:13:43Z"
     },
     {
       "id": "9296070/ETMY665Q",
@@ -6179,47 +13595,70 @@
             15
           ]
         ]
-      }
-    },
-    {
-      "id": "9296070/ETMY665Q",
-      "type": "paper-conference",
-      "title": "From NoteCards to Notebooks: There and Back Again",
-      "container-title": "Proceedings of the 30th ACM Conference on Hypertext and Social Media",
-      "collection-title": "HT '19",
-      "publisher": "Association for Computing Machinery",
-      "publisher-place": "New York, NY, USA",
-      "page": "19–28",
-      "event-place": "New York, NY, USA",
-      "abstract": "Fifty years since the beginning of the Internet, and three decades of the Dexter Hypertext Reference Model and the World Wide Web mark an opportune time to take stock and consider how hypermedia has developed, and in which direction it might be headed. The modern Web has on one hand turned into a place where very few, very large companies control all major platforms with some highly unfortunately consequences. On the other hand, it has also led to the creation of a highly flexible and nigh ubiquitous set of technologies and practices, which can be used as the basis for future hypermedia research with the rise of computational notebooks as a prime example of a new kind of collaborative and highly malleable applications.",
-      "URL": "https://doi.org/10.1145/3342220.3343666",
-      "DOI": "10.1145/3342220.3343666",
-      "ISBN": "978-1-4503-6885-8",
-      "shortTitle": "From NoteCards to Notebooks",
-      "author": [
+      },
+      "key": "ETMY665Q",
+      "version": 2431,
+      "itemType": "conferencePaper",
+      "creators": [
         {
-          "family": "Bouvin",
-          "given": "Niels Olof"
+          "creatorType": "author",
+          "firstName": "Niels Olof",
+          "lastName": "Bouvin"
         }
       ],
-      "issued": {
-        "date-parts": [
-          [
-            "2019",
-            9,
-            12
-          ]
-        ]
-      },
-      "accessed": {
-        "date-parts": [
-          [
-            2021,
-            4,
-            15
-          ]
-        ]
-      }
+      "abstractNote": "Fifty years since the beginning of the Internet, and three decades of the Dexter Hypertext Reference Model and the World Wide Web mark an opportune time to take stock and consider how hypermedia has developed, and in which direction it might be headed. The modern Web has on one hand turned into a place where very few, very large companies control all major platforms with some highly unfortunately consequences. On the other hand, it has also led to the creation of a highly flexible and nigh ubiquitous set of technologies and practices, which can be used as the basis for future hypermedia research with the rise of computational notebooks as a prime example of a new kind of collaborative and highly malleable applications.",
+      "date": "September 12, 2019",
+      "proceedingsTitle": "Proceedings of the 30th ACM Conference on Hypertext and Social Media",
+      "conferenceName": "",
+      "place": "New York, NY, USA",
+      "volume": "",
+      "pages": "19–28",
+      "series": "HT '19",
+      "language": "",
+      "url": "https://doi.org/10.1145/3342220.3343666",
+      "accessDate": "2021-04-15",
+      "archive": "",
+      "archiveLocation": "",
+      "libraryCatalog": "ACM Digital Library",
+      "callNumber": "",
+      "rights": "",
+      "extra": "",
+      "tags": [
+        {
+          "tag": "computational literacy",
+          "type": 1
+        },
+        {
+          "tag": "computational notebooks",
+          "type": 1
+        },
+        {
+          "tag": "end user programming",
+          "type": 1
+        },
+        {
+          "tag": "hypermedia",
+          "type": 1
+        },
+        {
+          "tag": "open hypermedia",
+          "type": 1
+        },
+        {
+          "tag": "sz"
+        },
+        {
+          "tag": "world wide web",
+          "type": 1
+        }
+      ],
+      "collections": [
+        "MTUXENI8",
+        "QTUS8XEQ"
+      ],
+      "relations": {},
+      "dateAdded": "2021-04-15T23:18:51Z",
+      "dateModified": "2021-06-03T19:17:59Z"
     }
   ],
   "2020": [
@@ -6245,7 +13684,28 @@
             22
           ]
         ]
-      }
+      },
+      "key": "U7GGH7HE",
+      "version": 2379,
+      "itemType": "webpage",
+      "creators": [],
+      "abstractNote": "",
+      "websiteTitle": "",
+      "websiteType": "",
+      "date": "12/8/2020",
+      "shortTitle": "",
+      "url": "https://www.meetup.com/LispNYC/events/vqhmbpybcqblb/attendees/",
+      "accessDate": "2021-06-22T04:50:36Z",
+      "language": "",
+      "rights": "",
+      "extra": "",
+      "tags": [],
+      "collections": [
+        "3CNYFDHF"
+      ],
+      "relations": {},
+      "dateAdded": "2021-06-22T04:50:36Z",
+      "dateModified": "2022-06-27T03:00:45Z"
     },
     {
       "id": "9296070/M74EDUS2",
@@ -6279,13 +13739,39 @@
             3
           ]
         ]
-      }
+      },
+      "key": "M74EDUS2",
+      "version": 2778,
+      "itemType": "webpage",
+      "creators": [
+        {
+          "creatorType": "author",
+          "firstName": "Hsu",
+          "lastName": "Hansen"
+        }
+      ],
+      "abstractNote": "In commemoration of the 40th anniversary of the release of Smalltalk-80, the Computer History Museum is proud to announce a collaboration with Dan Ingalls to preserve and host the “Smalltalk Zoo.”",
+      "websiteTitle": "CHM",
+      "websiteType": "",
+      "date": "2020-12-17T16:42:56+00:00",
+      "shortTitle": "",
+      "url": "https://computerhistory.org/blog/introducing-the-smalltalk-zoo-48-years-of-smalltalk-history-at-chm/",
+      "accessDate": "2021-08-03T17:42:09Z",
+      "rights": "",
+      "extra": "Section: Software History Center",
+      "tags": [],
+      "collections": [
+        "HVGVBYYB"
+      ],
+      "relations": {},
+      "dateAdded": "2021-08-03T17:44:05Z",
+      "dateModified": "2023-04-28T06:27:58Z"
     },
     {
       "id": "9296070/XK2RYFWN",
       "type": "book",
       "title": "livingcomputermuseum/Darkstar",
-      "version": "Darkstar 1.1",
+      "version": 2856,
       "abstract": "A Xerox Star 8010 Emulator. Contribute to livingcomputermuseum/Darkstar development by creating an account on GitHub.",
       "URL": "https://github.com/livingcomputermuseum/Darkstar",
       "ISBN": "N/A",
@@ -6313,7 +13799,56 @@
             15
           ]
         ]
-      }
+      },
+      "key": "XK2RYFWN",
+      "itemType": "computerProgram",
+      "creators": [
+        {
+          "creatorType": "programmer",
+          "firstName": "Living Computers:",
+          "lastName": "Museum+Labs"
+        }
+      ],
+      "abstractNote": "A Xerox Star 8010 Emulator. Contribute to livingcomputermuseum/Darkstar development by creating an account on GitHub.",
+      "seriesTitle": "",
+      "versionNumber": "Darkstar 1.1",
+      "date": "Dec 25, 2020",
+      "system": "",
+      "place": "",
+      "company": "",
+      "programmingLanguage": "C#",
+      "shortTitle": "",
+      "url": "https://github.com/livingcomputermuseum/Darkstar",
+      "rights": "BSD-2-Clause License",
+      "archive": "",
+      "archiveLocation": "",
+      "libraryCatalog": "GitHub",
+      "callNumber": "",
+      "accessDate": "2021-04-15T23:37:35Z",
+      "extra": "original-date: 2019-01-15T20:40:02Z",
+      "tags": [
+        {
+          "tag": "Dandelion"
+        },
+        {
+          "tag": "Emulation"
+        },
+        {
+          "tag": "Reviewed by SHFT - CSUCI (Ron Vincent A.)"
+        },
+        {
+          "tag": "Star"
+        },
+        {
+          "tag": "sz"
+        }
+      ],
+      "collections": [
+        "3CNYFDHF"
+      ],
+      "relations": {},
+      "dateAdded": "2021-04-15T23:37:35Z",
+      "dateModified": "2023-05-05T14:32:28Z"
     }
   ],
   "2021": [
@@ -6349,7 +13884,48 @@
             2
           ]
         ]
-      }
+      },
+      "key": "ITWWEVAK",
+      "version": 2101,
+      "itemType": "videoRecording",
+      "creators": [
+        {
+          "creatorType": "director",
+          "firstName": "Thomas W.",
+          "lastName": "Malone"
+        }
+      ],
+      "abstractNote": "The Information Lens\nThomas Malone (MIT)\n\nCHI+GI '87 Technical Video Program\n\nAbstract\nAn intelligent system for information sharing and coordination (subtitle from the video)\n\nWEB:: http://www.cs.umd.edu/hcil/chivideosl...​\n\nPublished in two videotapes: issue 27, and issue 33-34 of ACM SIGGRAPH Video Review (issue 27 appeared in same tape as issue 26, i.e. the CHI '87 Electronic Theater).\nVideo Chair: Richard J. Beach (Xerox PARC)\nLocation: Toronto, Canada",
+      "videoRecordingFormat": "",
+      "seriesTitle": "",
+      "volume": "",
+      "numberOfVolumes": "",
+      "place": "Toronto, Canada",
+      "studio": "ACM SIGCHI",
+      "date": "2021-01-13",
+      "runningTime": "15:24",
+      "language": "",
+      "ISBN": "",
+      "shortTitle": "",
+      "url": "https://www.youtube.com/watch?v=o7P0cM5VqKc",
+      "accessDate": "2021-05-02T21:24:46Z",
+      "archive": "",
+      "archiveLocation": "",
+      "libraryCatalog": "YouTube",
+      "callNumber": "",
+      "rights": "",
+      "extra": "",
+      "tags": [
+        {
+          "tag": "sz"
+        }
+      ],
+      "collections": [
+        "MTUXENI8"
+      ],
+      "relations": {},
+      "dateAdded": "2021-05-02T21:24:46Z",
+      "dateModified": "2021-07-04T01:43:55Z"
     },
     {
       "id": "9296070/2DFHC6FQ",
@@ -6377,7 +13953,39 @@
             27
           ]
         ]
-      }
+      },
+      "key": "2DFHC6FQ",
+      "version": 2367,
+      "itemType": "encyclopediaArticle",
+      "creators": [],
+      "abstractNote": "The Dipmeter Advisor was an early expert system developed in the 1980s by Schlumberger  with the help of artificial-intelligence workers at MIT to aid in the analysis of data gathered during oil exploration. The Advisor was generally not merely an inference engine and a knowledge base of ~90 rules, but generally was a full-fledged workstation, running on one of Xerox's 1100 Dolphin Lisp machines (or in general on Xerox's \"1100 Series Scientific Information Processors\" line) and written in INTERLISP-D, with a pattern recognition layer which in turn fed a GUI menu-driven interface. It was developed by a number of people, including Reid G. Smith, James D. Baker, and Robert L. Young.It was primarily influential not because of any great technical leaps, but rather because it was so successful for Schlumberger's oil divisions and because it was one of the few success stories of the AI bubble to receive wide publicity before the AI winter.\nThe AI rules of the Dipmeter Advisor were primarily derived from Al Gilreath, a Schlumberger interpretation engineer who developed the \"red, green, blue\" pattern method of dipmeter interpretation.\nUnfortunately this method had limited application in more complex geological environments outside the Gulf Coast, and the Dipmeter Advisor was primarily used within Schlumberger as a graphical display tool to assist interpretation by trained geoscientists, rather than as an AI tool for use by novice interpreters. However, the tool pioneered a new approach to workstation-assisted graphical interpretation of geological information.",
+      "encyclopediaTitle": "Wikipedia",
+      "series": "",
+      "seriesNumber": "",
+      "volume": "",
+      "numberOfVolumes": "",
+      "edition": "",
+      "place": "",
+      "publisher": "",
+      "date": "2021-12-15T11:24:46Z",
+      "pages": "",
+      "ISBN": "",
+      "shortTitle": "",
+      "url": "https://en.wikipedia.org/w/index.php?title=Dipmeter_Advisor&oldid=1060421060",
+      "accessDate": "2022-06-27T01:39:35Z",
+      "archive": "",
+      "archiveLocation": "",
+      "libraryCatalog": "Wikipedia",
+      "callNumber": "",
+      "rights": "Creative Commons Attribution-ShareAlike License",
+      "extra": "Page Version ID: 1060421060",
+      "tags": [],
+      "collections": [
+        "MTUXENI8"
+      ],
+      "relations": {},
+      "dateAdded": "2022-06-27T01:39:35Z",
+      "dateModified": "2022-06-27T01:39:35Z"
     },
     {
       "id": "9296070/JELN3BBL",
@@ -6410,7 +14018,48 @@
             21
           ]
         ]
-      }
+      },
+      "key": "JELN3BBL",
+      "version": 1395,
+      "itemType": "encyclopediaArticle",
+      "creators": [
+        {
+          "creatorType": "editor",
+          "name": "Jekkara"
+        }
+      ],
+      "abstractNote": "Interlisp (also seen with a variety of capitalizations) is a programming environment built around a version of the programming language Lisp. Interlisp development began in 1966 at Bolt, Beranek and Newman (renamed BBN Technologies) in Cambridge, Massachusetts with Lisp implemented for the Digital Equipment Corporation (DEC) PDP-1 computer by Danny Bobrow and D. L. Murphy. In 1970, Alice K. Hartley implemented BBN LISP, which ran on PDP-10 machines running the operating system TENEX (renamed TOPS-20). In 1973, when Danny Bobrow, Warren Teitelman and Ronald Kaplan moved from BBN to the Xerox Palo Alto Research Center (PARC), it was renamed Interlisp. Interlisp became a popular Lisp development tool for artificial intelligence (AI) researchers at Stanford University and elsewhere in the community of the Defense Advanced Research Projects Agency (DARPA). Interlisp was notable for integrating interactive development tools into an integrated development environment (IDE), such as a debugger, an automatic correction tool for simple errors (via do what I mean (DWIM) software design, and analysis tools.",
+      "encyclopediaTitle": "Wikipedia",
+      "series": "",
+      "seriesNumber": "",
+      "volume": "",
+      "numberOfVolumes": "",
+      "edition": "",
+      "place": "",
+      "publisher": "",
+      "date": "March 24, 2021",
+      "pages": "",
+      "ISBN": "",
+      "shortTitle": "",
+      "url": "https://en.wikipedia.org/w/index.php?title=Interlisp&oldid=1014034897",
+      "accessDate": "2021-04-21T18:20:14Z",
+      "archive": "",
+      "archiveLocation": "",
+      "libraryCatalog": "Wikipedia",
+      "callNumber": "",
+      "rights": "",
+      "extra": "",
+      "tags": [
+        {
+          "tag": "sz"
+        }
+      ],
+      "collections": [
+        "TVX6WEZX"
+      ],
+      "relations": {},
+      "dateAdded": "2021-04-22T03:48:38Z",
+      "dateModified": "2021-05-29T20:57:33Z"
     },
     {
       "id": "9296070/RCFRZY85",
@@ -6460,59 +14109,234 @@
             21
           ]
         ]
-      }
+      },
+      "key": "RCFRZY85",
+      "version": 2295,
+      "itemType": "journalArticle",
+      "creators": [
+        {
+          "creatorType": "author",
+          "firstName": "Daniel",
+          "lastName": "Cardoso-Llach"
+        },
+        {
+          "creatorType": "author",
+          "firstName": "Eric",
+          "lastName": "Kaltman"
+        },
+        {
+          "creatorType": "author",
+          "firstName": "Emek",
+          "lastName": "Erdolu"
+        },
+        {
+          "creatorType": "author",
+          "firstName": "Zachary",
+          "lastName": "Furste"
+        }
+      ],
+      "abstractNote": "This paper explores the potential of distributed emulation networks to support research and pedagogy into historical and sociotechnical aspects of software. Emulation is a type of virtualization that re-creates the conditions for a piece of legacy software to operate on a modern system. The paper first offers a review of Computer-Supported Cooperative Work (CSCW), Human-Computer Interaction (HCI), and Science and Technology Studies (STS) literature engaging with software as historical and sociotechnical artifacts, and with emulation as a vehicle of scholarly inquiry. It then documents the novel use of software emulations as a pedagogical resource and research tool for legacy software systems analysis. This is accomplished through the integration of the Emulation as a Service Infrastructure (EaaSI) distributed emulation network into a university-level course focusing on computer-aided design (CAD). The paper offers a detailed case study of a pedagogical experience oriented to incorporate emulations into software research and learning. It shows how emulations allow for close, user-centered analyses of software systems that highlight both their historical evolution and core interaction concepts, and how they shape the work practices of their users.",
+      "publicationTitle": "Proceedings of the ACM on Human-Computer Interaction",
+      "pages": "294:1–294:22",
+      "date": "October 18, 2021",
+      "series": "",
+      "seriesTitle": "",
+      "seriesText": "",
+      "language": "",
+      "ISSN": "",
+      "url": "https://doi.org/10.1145/3476035",
+      "accessDate": "2021-10-21T19:07:29Z",
+      "archive": "",
+      "archiveLocation": "",
+      "libraryCatalog": "October 2021",
+      "callNumber": "",
+      "rights": "",
+      "extra": "",
+      "tags": [
+        {
+          "tag": "architecture",
+          "type": 1
+        },
+        {
+          "tag": "autocad",
+          "type": 1
+        },
+        {
+          "tag": "computer-aided design",
+          "type": 1
+        },
+        {
+          "tag": "emulation",
+          "type": 1
+        },
+        {
+          "tag": "pedagogy",
+          "type": 1
+        },
+        {
+          "tag": "software history",
+          "type": 1
+        }
+      ],
+      "collections": [
+        "HVGVBYYB"
+      ],
+      "relations": {},
+      "dateAdded": "2021-10-21T19:07:29Z",
+      "dateModified": "2021-10-21T19:07:29Z"
     }
   ],
-  "Undated": [
+  "2022": [
     {
-      "id": "9296070/9VAUTPVT",
-      "type": "article",
-      "title": "1982-Bobrow-Stefik-Data-Object-Pgming.pdf"
-    },
-    {
-      "id": "9296070/EPG3LWQF",
-      "type": "article",
-      "title": "1986-commonloops-oopsla66.pdf"
-    },
-    {
-      "id": "9296070/2GN25ESU",
-      "type": "article",
-      "title": "1979-stefik-examination-of-frame-structured.pdf"
-    },
-    {
-      "id": "9296070/7MG5RV9Y",
-      "type": "article",
-      "title": "1987-Themes-Variations-Stefik-Loops-.pdf"
-    },
-    {
-      "id": "9296070/HI5WIUJQ",
-      "type": "article",
-      "title": "ED285570.pdf",
-      "URL": "https://files.eric.ed.gov/fulltext/ED285570.pdf",
+      "id": "9296070/3UNHV59N",
+      "type": "webpage",
+      "title": "Lisp and Symbolic Computation",
+      "container-title": "Table of contents for issues of Lisp and Symbolic Computation",
+      "URL": "http://ftp.math.utah.edu/pub/tex/bib/toc/lispsymbcomput.html",
+      "issued": {
+        "date-parts": [
+          [
+            2022,
+            12,
+            2
+          ]
+        ]
+      },
       "accessed": {
         "date-parts": [
           [
             2021,
-            8,
-            6
+            4,
+            25
           ]
         ]
-      }
+      },
+      "key": "3UNHV59N",
+      "version": 2951,
+      "itemType": "webpage",
+      "creators": [],
+      "abstractNote": "",
+      "websiteTitle": "Table of contents for issues of Lisp and Symbolic Computation",
+      "websiteType": "",
+      "date": "2022-12-02",
+      "shortTitle": "",
+      "url": "http://ftp.math.utah.edu/pub/tex/bib/toc/lispsymbcomput.html",
+      "accessDate": "2021-04-25T15:43:43Z",
+      "language": "",
+      "rights": "",
+      "extra": "",
+      "tags": [
+        {
+          "tag": "Reviewed by SHFT - CSUCI (Joseph Moreno)"
+        },
+        {
+          "tag": "sz"
+        }
+      ],
+      "collections": [
+        "HVGVBYYB"
+      ],
+      "relations": {},
+      "dateAdded": "2021-04-25T21:00:53Z",
+      "dateModified": "2023-05-08T15:08:46Z"
+    }
+  ],
+  "Undated": [
+    {
+      "id": "9296070/2GN25ESU",
+      "type": "article",
+      "title": "1979-stefik-examination-of-frame-structured.pdf",
+      "key": "2GN25ESU",
+      "version": 2451,
+      "itemType": "attachment",
+      "linkMode": "imported_file",
+      "accessDate": "",
+      "url": "",
+      "note": "",
+      "contentType": "application/pdf",
+      "charset": "",
+      "filename": "1979-stefik-examination-of-frame-structured.pdf",
+      "md5": "27e268251988e60f43c0780db27586ed",
+      "mtime": 1653406734000,
+      "tags": [],
+      "collections": [
+        "8MSYRKQA"
+      ],
+      "relations": {},
+      "dateAdded": "2022-07-04T20:14:43Z",
+      "dateModified": "2022-07-04T20:14:43Z"
     },
     {
-      "id": "9296070/SUB44YL9",
+      "id": "9296070/7MG5RV9Y",
       "type": "article",
-      "title": "xerox1108.pdf",
-      "URL": "https://www.1000bit.it/ad/bro/xerox/xerox1108.pdf",
-      "accessed": {
-        "date-parts": [
-          [
-            2023,
-            4,
-            10
-          ]
-        ]
-      }
+      "title": "1987-Themes-Variations-Stefik-Loops-.pdf",
+      "key": "7MG5RV9Y",
+      "version": 2445,
+      "itemType": "attachment",
+      "linkMode": "imported_file",
+      "accessDate": "",
+      "url": "",
+      "note": "",
+      "contentType": "application/pdf",
+      "charset": "",
+      "filename": "1987-Themes-Variations-Stefik-Loops-.pdf",
+      "md5": "64705b90affb920b1aa154397291a83f",
+      "mtime": 1653406564000,
+      "tags": [],
+      "collections": [
+        "8MSYRKQA"
+      ],
+      "relations": {},
+      "dateAdded": "2022-07-04T20:14:25Z",
+      "dateModified": "2022-07-04T20:14:25Z"
+    },
+    {
+      "id": "9296070/9VAUTPVT",
+      "type": "article",
+      "title": "1982-Bobrow-Stefik-Data-Object-Pgming.pdf",
+      "key": "9VAUTPVT",
+      "version": 3027,
+      "itemType": "attachment",
+      "linkMode": "imported_file",
+      "accessDate": "",
+      "url": "",
+      "note": "",
+      "contentType": "application/pdf",
+      "charset": "",
+      "filename": "1982-Bobrow-Stefik-Data-Object-Pgming.pdf",
+      "md5": "b743dfa68f6dbf1e947ca54a0798dfbf",
+      "mtime": 1653406648000,
+      "tags": [],
+      "collections": [
+        "8MSYRKQA"
+      ],
+      "relations": {},
+      "dateAdded": "2022-07-04T20:14:46Z",
+      "dateModified": "2023-09-10T00:45:36Z"
+    },
+    {
+      "id": "9296070/EPG3LWQF",
+      "type": "article",
+      "title": "1986-commonloops-oopsla66.pdf",
+      "key": "EPG3LWQF",
+      "version": 2452,
+      "itemType": "attachment",
+      "linkMode": "imported_file",
+      "accessDate": "",
+      "url": "",
+      "note": "",
+      "contentType": "application/pdf",
+      "charset": "",
+      "filename": "1986-commonloops-oopsla66.pdf",
+      "md5": "85c4d97d1d8a1efb1b1639e9c5ba7ddb",
+      "mtime": 1653406622000,
+      "tags": [],
+      "collections": [
+        "8MSYRKQA"
+      ],
+      "relations": {},
+      "dateAdded": "2022-07-04T20:14:50Z",
+      "dateModified": "2022-07-04T20:14:50Z"
     },
     {
       "id": "9296070/GSH9NUT6",
@@ -6527,29 +14351,97 @@
             30
           ]
         ]
-      }
+      },
+      "key": "GSH9NUT6",
+      "version": 2965,
+      "itemType": "attachment",
+      "linkMode": "imported_url",
+      "accessDate": "2022-01-30T21:06:54Z",
+      "url": "https://opost.com/tenex/ahc_20150101_jan_2015.pdf",
+      "note": "<p>Title:IEEE Annals of the History of Computing</p>\n<p>Volume:31 #1</p>\n<p>Date:2022-01-01</p>\n",
+      "contentType": "application/pdf",
+      "charset": "",
+      "filename": "ahc_20150101_jan_2015.pdf",
+      "md5": "c0908e0e18fa920a88cf7b9b056e1a2d",
+      "mtime": 1643576814019,
+      "tags": [
+        {
+          "tag": "Reviewed by SHFT - CSUCI (Joseph Moreno)"
+        }
+      ],
+      "collections": [
+        "HVGVBYYB"
+      ],
+      "relations": {},
+      "dateAdded": "2022-01-30T21:06:54Z",
+      "dateModified": "2023-05-08T15:12:46Z"
+    },
+    {
+      "id": "9296070/HI5WIUJQ",
+      "type": "article",
+      "title": "ED285570.pdf",
+      "URL": "https://files.eric.ed.gov/fulltext/ED285570.pdf",
+      "accessed": {
+        "date-parts": [
+          [
+            2021,
+            8,
+            6
+          ]
+        ]
+      },
+      "key": "HI5WIUJQ",
+      "version": 3029,
+      "itemType": "attachment",
+      "linkMode": "imported_url",
+      "accessDate": "2021-08-06T03:55:27Z",
+      "url": "https://files.eric.ed.gov/fulltext/ED285570.pdf",
+      "note": "<p>Title:1985 Annual Technical Report: A Research Program in Computer Technology</p>\n<p>Pages:156</p>\n<p>Publisher: University of Southern California, Marina Del Rey. Information Sciences Inst.</p>\n<p>Report NO: ISI/SR-86-170</p>\n<p>Date:1986-12</p>\n",
+      "contentType": "application/pdf",
+      "charset": "",
+      "filename": "ED285570.pdf",
+      "md5": "7e91d67a93a67b2a7d0a0e75112ca21e",
+      "mtime": 1628222127447,
+      "tags": [
+        {
+          "tag": "Reviewed by SHFT - CSUCI (Joseph Moreno)"
+        }
+      ],
+      "collections": [
+        "MTUXENI8"
+      ],
+      "relations": {},
+      "dateAdded": "2021-08-06T03:55:27Z",
+      "dateModified": "2023-09-10T00:52:18Z"
     },
     {
       "id": "9296070/3VK4IB8T",
       "type": "article",
-      "title": "1986-access-oriented.pdf"
-    },
-    {
-      "id": "9296070/RJPVRIGF",
-      "type": "post-weblog",
-      "title": "Truckin’ and the Knowledge Competitions | MJSBlog",
-      "abstract": "MJSBlog - Workin on it",
-      "URL": "https://www.markstefik.com/?page_id=359",
-      "language": "en-US",
-      "accessed": {
-        "date-parts": [
-          [
-            2022,
-            7,
-            17
-          ]
-        ]
-      }
+      "title": "1986-access-oriented.pdf",
+      "key": "3VK4IB8T",
+      "version": 2708,
+      "itemType": "document",
+      "creators": [],
+      "abstractNote": "",
+      "publisher": "",
+      "date": "",
+      "language": "",
+      "shortTitle": "",
+      "url": "",
+      "accessDate": "",
+      "archive": "",
+      "archiveLocation": "",
+      "libraryCatalog": "",
+      "callNumber": "",
+      "rights": "",
+      "extra": "",
+      "tags": [],
+      "collections": [
+        "8MSYRKQA"
+      ],
+      "relations": {},
+      "dateAdded": "2023-04-24T17:14:34Z",
+      "dateModified": "2023-04-24T17:14:34Z"
     },
     {
       "id": "9296070/9LHKWE3T",
@@ -6567,7 +14459,171 @@
           "family": "Stefik",
           "given": "J"
         }
-      ]
+      ],
+      "key": "9LHKWE3T",
+      "version": 2455,
+      "itemType": "journalArticle",
+      "creators": [
+        {
+          "creatorType": "author",
+          "firstName": "G",
+          "lastName": "Bobrow"
+        },
+        {
+          "creatorType": "author",
+          "firstName": "J",
+          "lastName": "Stefik"
+        }
+      ],
+      "abstractNote": "",
+      "publicationTitle": "",
+      "issue": "",
+      "pages": "8",
+      "date": "",
+      "series": "",
+      "seriesTitle": "",
+      "seriesText": "",
+      "journalAbbreviation": "",
+      "DOI": "",
+      "ISSN": "",
+      "shortTitle": "",
+      "url": "",
+      "accessDate": "",
+      "archive": "",
+      "archiveLocation": "",
+      "libraryCatalog": "Zotero",
+      "callNumber": "",
+      "rights": "",
+      "extra": "",
+      "tags": [],
+      "collections": [
+        "8MSYRKQA"
+      ],
+      "relations": {},
+      "dateAdded": "2022-07-04T20:15:13Z",
+      "dateModified": "2022-07-04T20:15:13Z"
+    },
+    {
+      "id": "9296070/B63F5Q8E",
+      "type": "webpage",
+      "title": "Xerox Alto Emulator",
+      "URL": "https://archives.loomcom.com/contraltojs/",
+      "accessed": {
+        "date-parts": [
+          [
+            2021,
+            8,
+            20
+          ]
+        ]
+      },
+      "key": "B63F5Q8E",
+      "version": 2230,
+      "itemType": "webpage",
+      "creators": [],
+      "abstractNote": "",
+      "websiteTitle": "",
+      "websiteType": "",
+      "date": "",
+      "shortTitle": "",
+      "url": "https://archives.loomcom.com/contraltojs/",
+      "accessDate": "2021-08-20T03:31:59Z",
+      "language": "",
+      "rights": "",
+      "extra": "",
+      "tags": [],
+      "collections": [
+        "HVGVBYYB"
+      ],
+      "relations": {},
+      "dateAdded": "2021-08-20T03:31:59Z",
+      "dateModified": "2021-08-20T03:31:59Z"
+    },
+    {
+      "id": "9296070/CER4PF8K",
+      "type": "webpage",
+      "title": "NOTES ON XEROX LISP MACH DEMO",
+      "URL": "https://ml.cddddr.org/lisp@parc/msg00137.html",
+      "author": [
+        {
+          "family": "Rindfleisch",
+          "given": ""
+        }
+      ],
+      "accessed": {
+        "date-parts": [
+          [
+            2021,
+            9,
+            16
+          ]
+        ]
+      },
+      "key": "CER4PF8K",
+      "version": 2783,
+      "itemType": "webpage",
+      "creators": [
+        {
+          "creatorType": "author",
+          "firstName": "",
+          "lastName": "Rindfleisch"
+        }
+      ],
+      "abstractNote": "",
+      "websiteTitle": "",
+      "websiteType": "",
+      "date": "",
+      "shortTitle": "",
+      "url": "https://ml.cddddr.org/lisp@parc/msg00137.html",
+      "accessDate": "2021-09-16T06:22:31Z",
+      "language": "",
+      "rights": "",
+      "extra": "",
+      "tags": [],
+      "collections": [
+        "3CNYFDHF"
+      ],
+      "relations": {},
+      "dateAdded": "2021-09-16T06:22:31Z",
+      "dateModified": "2023-04-28T06:37:01Z"
+    },
+    {
+      "id": "9296070/E4CCUZ35",
+      "type": "webpage",
+      "title": "Industry Briefs",
+      "container-title": "The Scientist Magazine®",
+      "abstract": "Although Envos Corp., an artificial intelligence spin-off of the Xerox Corp., folded back into Xerox last spring after nine months in operation, the parent company is “absolutely” committed to developing similar ventures in the future, according to Xerox spokesman Peter Hawes. “We have been trying to identify [Xerox] technologies,” says Hawes, “and choose which. ..might lend themselves to alternative exploitation.”",
+      "URL": "https://www.the-scientist.com/briefs/industry-briefs-61883",
+      "language": "en",
+      "accessed": {
+        "date-parts": [
+          [
+            2023,
+            4,
+            29
+          ]
+        ]
+      },
+      "key": "E4CCUZ35",
+      "version": 3025,
+      "itemType": "webpage",
+      "creators": [],
+      "abstractNote": "Although Envos Corp., an artificial intelligence spin-off of the Xerox Corp., folded back into Xerox last spring after nine months in operation, the parent company is “absolutely” committed to developing similar ventures in the future, according to Xerox spokesman Peter Hawes. “We have been trying to identify [Xerox] technologies,” says Hawes, “and choose which. ..might lend themselves to alternative exploitation.”",
+      "websiteTitle": "The Scientist Magazine®",
+      "websiteType": "",
+      "date": "",
+      "shortTitle": "",
+      "url": "https://www.the-scientist.com/briefs/industry-briefs-61883",
+      "accessDate": "2023-04-29T15:24:55Z",
+      "rights": "",
+      "extra": "",
+      "tags": [],
+      "collections": [
+        "3CNYFDHF"
+      ],
+      "relations": {},
+      "dateAdded": "2023-04-29T15:24:55Z",
+      "dateModified": "2023-09-10T00:38:11Z"
     },
     {
       "id": "9296070/GZU4TBQ5",
@@ -6585,7 +14641,86 @@
           "family": "Stefik",
           "given": "J"
         }
-      ]
+      ],
+      "key": "GZU4TBQ5",
+      "version": 2444,
+      "itemType": "journalArticle",
+      "creators": [
+        {
+          "creatorType": "author",
+          "firstName": "G",
+          "lastName": "Bobrow"
+        },
+        {
+          "creatorType": "author",
+          "firstName": "J",
+          "lastName": "Stefik"
+        }
+      ],
+      "abstractNote": "",
+      "publicationTitle": "",
+      "issue": "",
+      "pages": "8",
+      "date": "",
+      "series": "",
+      "seriesTitle": "",
+      "seriesText": "",
+      "journalAbbreviation": "",
+      "DOI": "",
+      "ISSN": "",
+      "shortTitle": "",
+      "url": "",
+      "accessDate": "",
+      "archive": "",
+      "archiveLocation": "",
+      "libraryCatalog": "Zotero",
+      "callNumber": "",
+      "rights": "",
+      "extra": "",
+      "tags": [],
+      "collections": [
+        "8MSYRKQA"
+      ],
+      "relations": {},
+      "dateAdded": "2022-07-04T20:14:17Z",
+      "dateModified": "2022-07-04T20:14:18Z"
+    },
+    {
+      "id": "9296070/RJPVRIGF",
+      "type": "post-weblog",
+      "title": "Truckin’ and the Knowledge Competitions | MJSBlog",
+      "abstract": "MJSBlog - Workin on it",
+      "URL": "https://www.markstefik.com/?page_id=359",
+      "language": "en-US",
+      "accessed": {
+        "date-parts": [
+          [
+            2022,
+            7,
+            17
+          ]
+        ]
+      },
+      "key": "RJPVRIGF",
+      "version": 2466,
+      "itemType": "blogPost",
+      "creators": [],
+      "abstractNote": "MJSBlog - Workin on it",
+      "blogTitle": "",
+      "websiteType": "",
+      "date": "",
+      "url": "https://www.markstefik.com/?page_id=359",
+      "accessDate": "2022-07-17T17:17:24Z",
+      "shortTitle": "",
+      "rights": "",
+      "extra": "",
+      "tags": [],
+      "collections": [
+        "8MSYRKQA"
+      ],
+      "relations": {},
+      "dateAdded": "2022-07-17T17:17:24Z",
+      "dateModified": "2022-07-17T17:17:24Z"
     },
     {
       "id": "9296070/S3S3DFYD",
@@ -6607,75 +14742,76 @@
             20
           ]
         ]
-      }
-    },
-    {
-      "id": "9296070/FFAKSC38",
-      "type": "report",
-      "title": "A Display Oriented Programmers Assistant",
-      "abstract": "This paper continues and extends previous work by the author in developing systems which provide the user with various forms of explicit and implicit assistance, and in general co-operate with the user in the development of his programs. The system described in this paper makes extensive use of a bit map display and pointing device (a mouse) to significantly enrich the user's interactions with the system, and to provide capabilities not possible with terminals that essentially emulate hard copy devices. For example, any text that is displayed on the screen can be pointed at and treated as input, exactly as though it were typed, i.e. the user can say use this expression or that value, and then simply point. The user views his programming environment through a collection of display windows, each of which corresponds to a different task or context. The user can manipulate the windows, or the contents of a particular window, by a combination of keyboard inputs or pointing operations. The technique of using different windows for different tasks makes it easy for the user to manage several simultaneous tasks and contexts, e.g. defining programs, testing programs, editing, asking the system for assistance, sending and receiving messages, etc. and to switch back and forth between these tasks at his convenience.",
-      "URL": "http://bitsavers.trailing-edge.com/pdf/xerox/parc/techReports/CSL-77-3_A_Display_Oriented_Programmers_Assistant.pdf",
-      "language": "English",
-      "author": [
+      },
+      "key": "S3S3DFYD",
+      "version": 2678,
+      "itemType": "report",
+      "creators": [
         {
-          "family": "Teitelman",
-          "given": "Warren"
-        }
-      ]
-    },
-    {
-      "id": "9296070/WFP2799R",
-      "type": "webpage",
-      "title": "Interlisp was the so-called \"west coast\" Lisp that emphasized an interactive pro... | Hacker News",
-      "URL": "https://news.ycombinator.com/item?id=5966399",
-      "accessed": {
-        "date-parts": [
-          [
-            2023,
-            4,
-            29
-          ]
-        ]
-      }
-    },
-    {
-      "id": "9296070/E4CCUZ35",
-      "type": "webpage",
-      "title": "Industry Briefs",
-      "container-title": "The Scientist Magazine®",
-      "abstract": "Tables Turn For Xerox Spin-Off Although Envos Corp., an artificial intelligence spin-off of the Xerox Corp., folded back into Xerox last spring after nine months in operation, the parent company is “absolutely” committed to developing similar ventures in the future, according to Xerox spokesman Peter Hawes. “We have been trying to identify [Xerox] technologies,” says Hawes, “and choose which. ..might lend themselves to alternative exploitation.” Envos, which",
-      "URL": "https://www.the-scientist.com/briefs/industry-briefs-61883",
-      "language": "en",
-      "accessed": {
-        "date-parts": [
-          [
-            2023,
-            4,
-            29
-          ]
-        ]
-      }
-    },
-    {
-      "id": "9296070/CER4PF8K",
-      "type": "webpage",
-      "title": "NOTES ON XEROX LISP MACH DEMO",
-      "URL": "https://ml.cddddr.org/lisp@parc/msg00137.html",
-      "author": [
-        {
-          "family": "Rindfleisch",
-          "given": ""
+          "creatorType": "author",
+          "firstName": "Gregg",
+          "lastName": "Foster"
         }
       ],
-      "accessed": {
-        "date-parts": [
-          [
-            2021,
-            9,
-            16
-          ]
-        ]
-      }
+      "abstractNote": "",
+      "reportNumber": "CSD-84-215",
+      "reportType": "",
+      "seriesTitle": "",
+      "place": "",
+      "institution": "",
+      "date": "",
+      "pages": "",
+      "language": "",
+      "shortTitle": "",
+      "url": "https://digitalassets.lib.berkeley.edu/techreports/ucb/text/CSD-84-215.pdf",
+      "accessDate": "2022-12-20T18:24:32Z",
+      "archive": "",
+      "archiveLocation": "",
+      "libraryCatalog": "",
+      "callNumber": "",
+      "rights": "",
+      "extra": "",
+      "tags": [],
+      "collections": [
+        "MTUXENI8"
+      ],
+      "relations": {},
+      "dateAdded": "2023-03-27T22:46:55Z",
+      "dateModified": "2023-04-03T22:19:07Z"
+    },
+    {
+      "id": "9296070/W6MPEB9A",
+      "type": "report",
+      "title": "Xerox 1108 Artifical Intelligence Workstations",
+      "key": "W6MPEB9A",
+      "version": 3007,
+      "itemType": "report",
+      "creators": [],
+      "abstractNote": "",
+      "reportNumber": "",
+      "reportType": "",
+      "seriesTitle": "",
+      "place": "",
+      "institution": "",
+      "date": "",
+      "pages": "",
+      "language": "",
+      "shortTitle": "",
+      "url": "",
+      "accessDate": "",
+      "archive": "",
+      "archiveLocation": "",
+      "libraryCatalog": "",
+      "callNumber": "",
+      "rights": "",
+      "extra": "",
+      "tags": [],
+      "collections": [
+        "3CNYFDHF"
+      ],
+      "relations": {},
+      "dateAdded": "2023-05-08T17:17:21Z",
+      "dateModified": "2023-05-08T17:18:35Z"
     },
     {
       "id": "9296070/Z87XIE6V",
@@ -6690,38 +14826,39 @@
             26
           ]
         ]
-      }
-    },
-    {
-      "id": "9296070/B63F5Q8E",
-      "type": "webpage",
-      "title": "Xerox Alto Emulator",
-      "URL": "https://archives.loomcom.com/contraltojs/",
-      "accessed": {
-        "date-parts": [
-          [
-            2021,
-            8,
-            20
-          ]
-        ]
-      }
-    },
-    {
-      "id": "9296070/3UNHV59N",
-      "type": "webpage",
-      "title": "Lisp and Symbolic Computation",
-      "container-title": "Table of contents for issues of Lisp and Symbolic Computation",
-      "URL": "http://ftp.math.utah.edu/pub/tex/bib/toc/lispsymbcomput.html",
-      "accessed": {
-        "date-parts": [
-          [
-            2021,
-            4,
-            25
-          ]
-        ]
-      }
+      },
+      "key": "Z87XIE6V",
+      "version": 2680,
+      "itemType": "book",
+      "creators": [],
+      "abstractNote": "",
+      "series": "",
+      "seriesNumber": "",
+      "volume": "",
+      "numberOfVolumes": "",
+      "edition": "",
+      "place": "",
+      "publisher": "",
+      "date": "",
+      "numPages": "",
+      "language": "",
+      "ISBN": "",
+      "shortTitle": "",
+      "url": "http://www.bitsavers.org/pdf/xerox/xns_services/services_sparc/Xerox_Globalview_Document_Services_for_Sun_Technical_Reference_Manual_Jun92.pdf",
+      "accessDate": "2022-07-26T02:43:15Z",
+      "archive": "",
+      "archiveLocation": "",
+      "libraryCatalog": "",
+      "callNumber": "",
+      "rights": "",
+      "extra": "",
+      "tags": [],
+      "collections": [
+        "HVGVBYYB"
+      ],
+      "relations": {},
+      "dateAdded": "2023-04-03T22:21:46Z",
+      "dateModified": "2023-04-03T22:22:11Z"
     }
   ]
 }

--- a/layouts/shortcodes/bibTable.html
+++ b/layouts/shortcodes/bibTable.html
@@ -133,6 +133,13 @@ table td:nth-child(4) {
     text-align: center;
 }
 </style>
+
+{{ $notesIcon := "\u24C3" }}
+<script>
+var abstractExpanderOpen = "\u25BC";
+var abstractExpanderClose = "\u25B2";
+</script>
+
 <table style="max-width: 100%">
     <thead>
         <tr>
@@ -167,7 +174,7 @@ table td:nth-child(4) {
             {{ if .abstract }}<div class="abstractContent" id="A{{$itemID }}_Abs">{{ .abstract }}</div>{{ end }}</td>
             <td>{{ if .abstract }}<button type="button" class="abstractExpander" id="A{{$itemID}}">AAA</button>{{ end }}</td>
             <td>{{ if .note }}{{ $notes := split .note "\n" }}
-              <div class="tooltipNotes" id="N{{$itemID}}">NNN<span class="tooltipNotesText tooltipNotes-left" id="N{{$itemID}}_Text">
+              <div class="tooltipNotes" id="N{{$itemID}}">{{$notesIcon}}<span class="tooltipNotesText tooltipNotes-left" id="N{{$itemID}}_Text">
                   {{ range $nn, $note := $notes }}
                     {{ if $nn }}<br>{{ end }}
                     {{ print (safeJS (replace (replace (replace (replace $note "<p>" "") "</p>" "") "-" "\u2011") " " " ")) }}
@@ -182,10 +189,6 @@ table td:nth-child(4) {
   
 </table>
 <script>
-var abstractExpanderOpen = "\u25BC";
-var abstractExpanderClose = "\u25B2";
-var notesIcon = "\u24C3";
-
 function abstractExpanderClick() {
     this.classList.toggle("active");
     var abstractContent = document.getElementById(this.id.concat("_Abs"));
@@ -203,11 +206,6 @@ var coll = document.getElementsByClassName("abstractExpander");
 for (i = 0; i < coll.length; i++) {
   coll[i].textContent = abstractExpanderOpen;
   coll[i].addEventListener("click", abstractExpanderClick); }
-
-coll = document.getElementsByClassName("tooltipNotes");
-
-for (i = 0; i < coll.length; i++) {
-  coll[i].textContent = notesIcon; }
 
 </script>
 

--- a/layouts/shortcodes/bibTable.html
+++ b/layouts/shortcodes/bibTable.html
@@ -1,39 +1,211 @@
+<style>
+.abstractExpander {
+  background-color: #00A6ED;
+  color: white;
+  cursor: pointer;
+  padding: 0px 3px;
+  border: none;
+  text-align: center;
+  margin: auto;
+  outline: none;
+  font-size: 1.5rem;
+}
 
+.abstractContent {
+  padding: 0 5px;
+  display: none;
+  font-size: 0.9rem;
+  overflow: hidden;
+  background-color: #f1f1f1;
+}
+
+.tooltipNotes {
+    position: relative;
+    display: inline-block;
+    font-size: 1.5rem;
+    font-weight: 550;
+    background-color: #00A6ED;
+    color: white;
+    cursor: pointer;
+    padding: 0px 5px;
+    border: none;
+    text-align: center;
+    margin: auto;
+    outline: none;
+}
+
+.tooltipNotes .tooltipNotesText {
+    visibility: hidden;
+    position: absolute;
+    min-width: 150px;
+    max-width: 600px;
+    background-color: #555;
+    color: white;
+    font-size: 1.0rem;
+    text-align: left;
+    padding: 5px;
+    border-radius: 6px;
+    z-index: 1;
+    opacity: 0;
+    transition: opacity 0.3s;
+    overflow-wrap: break-word;
+}
+
+.tooltipNotes:hover .tooltipNotesText {
+    visibility: visible;
+    opacity: 1;
+}
+
+.tooltipNotes-left {
+  top: 0px;
+  bottom:auto;
+  right: 128%;  
+}
+
+.tooltipNotes-left::after {
+    content: "";
+    position: absolute;
+    top: 0.9rem;
+    left: 100%;
+    margin-top: 0px;
+    border-width: 5px;
+    border-style: solid;
+    border-color: transparent transparent transparent #555;
+}
+.tooltipNotes-right {
+  top: -5px;
+  left: 125%;  
+}
+
+.tooltipNotes-right::after {
+    content: "";
+    position: absolute;
+    top: 50%;
+    right: 100%;
+    margin-top: -5px;
+    border-width: 5px;
+    border-style: solid;
+    border-color: transparent #555 transparent transparent;
+}
+
+.tooltipNotes-bottom {
+  top: 135%;
+  left: 50%;  
+  margin-left: -60px;
+}
+
+.tooltipNotes-bottom::after {
+    content: "";
+    position: absolute;
+    bottom: 100%;
+    left: 50%;
+    margin-left: -5px;
+    border-width: 5px;
+    border-style: solid;
+    border-color: transparent transparent #555 transparent;
+}
+
+.tooltipNotes-top {
+  bottom: 125%;
+  left: 50%;  
+  margin-left: -60px;
+}
+
+.tooltipNotes-top::after {
+    content: "";
+    position: absolute;
+    top: 100%;
+    left: 50%;
+    margin-left: -5px;
+    border-width: 5px;
+    border-style: solid;
+    border-color: #555 transparent transparent transparent;
+}
+/* Center 3rd & 4th columns */
+table td:nth-child(3) {
+    text-align: center;
+table td:nth-child(4) {
+    text-align: center;
+}
+</style>
 <table style="max-width: 100%">
     <thead>
         <tr>
-          <th>Author</th>
+          <th style="width:40%">Author</th>
           <th>Title</th>
+          <th>Abstract</th>
           <th>Notes</th>
         </tr>
       </thead>
-      <tbody>
+      <tbody style="overflow:auto">
         {{ $years_items := getJSON "data/bibliography.json" }}
         {{ range $year, $items := $years_items }}
           <tr>
-            <th colspan="3">
-              {{ $year }}
-            </th>
+            <th colspan="4">{{ $year }}</th>
           </tr>
           {{ range $items }}
-            <tr>
-              <td>
-                {{ range .author }}
-                  {{ if .literal }}
-                    {{ .literal }}
-                  {{ else if and .family .given }}
-                    {{ .family }}, {{ .given }}
-                  {{ else }}
-                    {{ .family }}{{ .given }}
-                  {{ end }}<br>
+          <tr>
+            {{ $itemID := (cond (gt (len .id) 0) (replace .id `/` `_`) `_0`) }}
+            <td style="font-size: 0.9rem">  
+              {{ range $na, $au := .author }}
+                {{ if $na }} ;<br> {{ end }}
+                {{ if $au.literal }}
+                  {{ $au.literal }}
+                {{ else if and $au.family $au.given }}
+                  {{ $au.family }}, {{ $au.given }}
+                {{ else }}
+                  {{ $au.family }}{{ $au.given }}
                 {{ end }}
-
-              </td>
-              <td>{{ if .URL }}<a href="{{ .URL }}">{{ .title }}</a>{{ else }}{{ .title }}{{ end }}</td>
-              <td>{{ .note }}</td>
-            </tr>
+              {{ end }}
+            </td>
+            <td>{{ if .URL }}<a href="{{ .URL }}">{{ .title }}</a>{{ else }}{{ .title }}{{ end }}
+            {{ if .abstract }}<div class="abstractContent" id="A{{$itemID }}_Abs">{{ .abstract }}</div>{{ end }}</td>
+            <td>{{ if .abstract }}<button type="button" class="abstractExpander" id="A{{$itemID}}">&#x23EC;</button>{{ end }}</td>
+            <td>{{ if .note }}{{ $notes := split .note "\n" }}
+              <div class="tooltipNotes" id="N{{$itemID}}">&#x24C3;<span class="tooltipNotesText tooltipNotes-left" id="N{{$itemID}}_Text">
+                  {{ range $nn, $note := $notes }}
+                    {{ if $nn }}<br>{{ end }}
+                    {{ print (safeJS (replace (replace (replace (replace $note "<p>" "") "</p>" "") "-" "\u2011") " " " ")) }}
+                  {{ end }}</span>
+               </div>
+               {{ end }}
+             </td>
+          </tr>
           {{ end }}
         {{ end }}
       </tbody>
   
 </table>
+<script>
+function abstractExpanderClick() {
+    this.classList.toggle("active");
+    var abstractContent = document.getElementById(this.id.concat("_Abs"));
+    var bText = this.textContent;
+    if (abstractContent.style.display === "block") {
+      abstractContent.style.display = "none";
+      this.textContent = {{"\u23EC"}};
+    } else {
+      abstractContent.style.display = "block";
+      this.textContent = {{"\u23EB"}};
+    }
+  }
+
+// When the user clicks on <div>, open the popup
+function popupNotesClick() {
+  var popupNotes = document.getElementById(this.id + "_Text");
+  popupNotes.classList.toggle("show");
+}
+
+var i;
+var coll = document.getElementsByClassName("abstractExpander");
+
+for (i = 0; i < coll.length; i++) {
+  coll[i].addEventListener("click", abstractExpanderClick); }
+
+coll = document.getElementsByClassName("popupNotes");
+
+for (i = 0; i < coll.length; i++) {
+  coll[i].addEventListener("click", popupNotesClick); }
+
+</script>
+

--- a/layouts/shortcodes/bibTable.html
+++ b/layouts/shortcodes/bibTable.html
@@ -3,12 +3,12 @@
   background-color: #00A6ED;
   color: white;
   cursor: pointer;
-  padding: 0px 3px;
+  padding: 3px 5px;
   border: none;
   text-align: center;
   margin: auto;
   outline: none;
-  font-size: 1.5rem;
+  font-size: 1.2rem;
 }
 
 .abstractContent {
@@ -22,7 +22,7 @@
 .tooltipNotes {
     position: relative;
     display: inline-block;
-    font-size: 1.5rem;
+    font-size: 1.45rem;
     font-weight: 550;
     background-color: #00A6ED;
     color: white;
@@ -34,6 +34,11 @@
     outline: none;
 }
 
+/*
+Below, where populating the tooltipNotesText, the nested replace functions remove any p-tags, and make - non-breaking.
+It also makes space non-breaking.
+This is because I cannot determine how to specify not to word wrap the content UNTIL it would exceed the container's max-width (if there even IS a way to do so). This causes long items to wrap VERY BADLY. 
+*/
 .tooltipNotes .tooltipNotesText {
     visibility: hidden;
     position: absolute;
@@ -160,9 +165,9 @@ table td:nth-child(4) {
             </td>
             <td>{{ if .URL }}<a href="{{ .URL }}">{{ .title }}</a>{{ else }}{{ .title }}{{ end }}
             {{ if .abstract }}<div class="abstractContent" id="A{{$itemID }}_Abs">{{ .abstract }}</div>{{ end }}</td>
-            <td>{{ if .abstract }}<button type="button" class="abstractExpander" id="A{{$itemID}}">&#x23EC;</button>{{ end }}</td>
+            <td>{{ if .abstract }}<button type="button" class="abstractExpander" id="A{{$itemID}}">AAA</button>{{ end }}</td>
             <td>{{ if .note }}{{ $notes := split .note "\n" }}
-              <div class="tooltipNotes" id="N{{$itemID}}">&#x24C3;<span class="tooltipNotesText tooltipNotes-left" id="N{{$itemID}}_Text">
+              <div class="tooltipNotes" id="N{{$itemID}}">NNN<span class="tooltipNotesText tooltipNotes-left" id="N{{$itemID}}_Text">
                   {{ range $nn, $note := $notes }}
                     {{ if $nn }}<br>{{ end }}
                     {{ print (safeJS (replace (replace (replace (replace $note "<p>" "") "</p>" "") "-" "\u2011") " " " ")) }}
@@ -177,35 +182,32 @@ table td:nth-child(4) {
   
 </table>
 <script>
+var abstractExpanderOpen = "\u25BC";
+var abstractExpanderClose = "\u25B2";
+var notesIcon = "\u24C3";
+
 function abstractExpanderClick() {
     this.classList.toggle("active");
     var abstractContent = document.getElementById(this.id.concat("_Abs"));
-    var bText = this.textContent;
     if (abstractContent.style.display === "block") {
       abstractContent.style.display = "none";
-      this.textContent = {{"\u23EC"}};
+      this.textContent = abstractExpanderOpen;
     } else {
       abstractContent.style.display = "block";
-      this.textContent = {{"\u23EB"}};
+      this.textContent = abstractExpanderClose;
     }
   }
 
-// When the user clicks on <div>, open the popup
-function popupNotesClick() {
-  var popupNotes = document.getElementById(this.id + "_Text");
-  popupNotes.classList.toggle("show");
-}
-
 var i;
 var coll = document.getElementsByClassName("abstractExpander");
-
 for (i = 0; i < coll.length; i++) {
+  coll[i].textContent = abstractExpanderOpen;
   coll[i].addEventListener("click", abstractExpanderClick); }
 
-coll = document.getElementsByClassName("popupNotes");
+coll = document.getElementsByClassName("tooltipNotes");
 
 for (i = 0; i < coll.length; i++) {
-  coll[i].addEventListener("click", popupNotesClick); }
+  coll[i].textContent = notesIcon; }
 
 </script>
 

--- a/scripts/update_bibliography.sh
+++ b/scripts/update_bibliography.sh
@@ -32,23 +32,41 @@ add_items_from_collection $root_collection
 echo "Got $(jq '. | length' <<< "$items") items"
 
 # Piece-wise processing for debugging:
-items=$(jq 'sort_by(.data.date)' <<< "$items")
-# echo "$items" > sorted.json
-items=$(jq 'map(.csljson)' <<< "$items")
-# echo "$items" > mapped.json
+# echo "$items" > 0-rawItems.json
+items=$(jq 'map(.csljson * .data)' <<< "$items")
+# echo "$items" > 1-mapped.json
+
+items=$(jq 'map(if has("note") then .note |= sub("^<div.+?>(?<body>.*)</div>$"; "\(.body)"; "gm") else . end)' <<< "$items")
+# echo "$items" > 2-cleanDiv.json
+#find and eliminate duplicate .id entries
+groupedByID=$(jq 'group_by(.id)' <<< "$items")
+dupIDs=$(jq 'map(select(length>1) | .[0])' <<< "$groupedByID")
+# echo "$dupIDs" > dupIDs.json
+#remove duplicates
+items=$(jq 'map(.[0]) | sort_by(.date)' <<< "$groupedByID")
+# echo "$items" > 3-noDupSorted.json
+finalCount=$(jq '. | length' <<< "$items")
+# onlyURL=$(jq 'map(if ((has("url") and (.url | tostring | length)) | not) and (has("URL") and (.URL | tostring | length)) then . else empty end)' <<< "$items")
+# echo "$onlyURL" > onlyURL.json
+# consolidate URL into url key
+# consolidated=$(jq 'map(if (has("URL") and (.URL | tostring | length)) then setpath(["url"]; .URL) | del(.URL) else . end)' <<< "$items")
+# echo "$consolidated" > consolidated.json
+# noURL=$(jq 'map(if (has("url") and (.url | tostring | length >= 1)) then empty else . end) | . // empty' <<< "$items")
+# echo "$noURL" > noURL.json
 items=$(jq 'group_by(.issued."date-parts"[0][0])' <<< "$items")
-# echo "$items" > grouped.json
+# echo "$items" > 4-grouped.json
 items=$(jq 'map({ (.[0].issued."date-parts"[0][0] // "Undated" | tostring): . })' <<< "$items")
-# echo "$items" > mapped2.json
+# echo "$items" > 5-Undated.json
 items=$(jq 'map(to_entries)' <<< "$items")
-# echo "$items" > entries.json
+# echo "$items" > 6-entries.json
 items=$(jq 'flatten(1)' <<< "$items")
-# echo "$items" > flattened.json
+# echo "$items" > 7-flattened.json
 items=$(jq 'group_by(.key)' <<< "$items")
-# echo "$items" > groupedByKey.json
+# echo "$items" > 8-groupedByKey.json
 items=$(jq 'map(if length == 1 then .[0] else ( { key: (.[0].key), value: (map(.value ) | flatten(1)) } ) end) | from_entries' <<< "$items")
-# echo "$items" > xx.json
+# echo "$items" > 9-final.json
 
 
 echo "Outputting CSL JSON"
+echo "$finalCount entries"
 echo "$items" > "$(dirname "$0")/../data/bibliography.json"


### PR DESCRIPTION
Included the Abstract information in the Bibliography, using an "expander" to show/hide it.

The Notes are now in a tooltip on an icon in the "Notes" table column. (So they don't cause an unusually wide table.) 
Authors & Notes content with multiple entries are split more cleanly. 
The color and some size choices are just "working guesses". 
Refining them should be discussed before going "public" with this.