### PR TITLE
Fix relative path problem.

### DIFF
--- a/layouts/shortcodes/blocks/cover.html
+++ b/layouts/shortcodes/blocks/cover.html
@@ -11,15 +11,19 @@
 
 {{ $promo_image_big := (.Fill (printf "1920x1080 %s" $image_anchor)) -}}
 {{ $promo_image_small := (.Fill (printf "960x540 %s" $image_anchor)) -}}
-<link rel="preload" as="image" href="{{ $promo_image_small.RelPermalink }}" media="(max-width: 1200px)">
-<link rel="preload" as="image" href="{{ $promo_image_big.RelPermalink }}" media="(min-width: 1200px)">
+
+{{ $promo_image_big := trim $promo_image_big "/" }}
+{{ $promo_image_small := trim $promo_image_small "/" }}
+
+<link rel="preload" as="image" href="{{ $promo_image_small }}" media="(max-width: 1200px)">
+<link rel="preload" as="image" href="{{ $promo_image_big }}" media="(min-width: 1200px)">
 <style>
 #{{ $blockID }} {
-    background-image: url({{ $promo_image_small.RelPermalink }}); 
+    background-image: url({{ $promo_image_small }}); 
 }
 @media only screen and (min-width: 1200px) {
     #{{ $blockID }} {
-        background-image: url({{ $promo_image_big.RelPermalink }}); 
+        background-image: url({{ $promo_image_big }}); 
     }
 }
 .hero-logo {


### PR DESCRIPTION
The cover shortcode assumed that url for the location of the background image was an absolute path. This works fine when the base URL is the root directory, /, but fails when the base URL is an offset from the root, i.e., /InterlispDraft.git.io.