### PR TITLE
Add alias to enable direct bibliography URL from website "root"

### DIFF
--- a/content/en/medley/history/publications/table.md
+++ b/content/en/medley/history/publications/table.md
@@ -2,7 +2,7 @@
 title: Bibliography
 weight: 5
 type: docs
-
+aliases: /bibliography
 ---
 
 ## Interlisp Bibliography


### PR DESCRIPTION
(i.e., https://interlisp.org/bibliography)