### PR TITLE
Fix layout of `terms` and `questions` paragraphs.

### DIFF
--- a/content/en/_index.html
+++ b/content/en/_index.html
@@ -24,12 +24,15 @@ aliases:
 <p>Medley's life as a commercial product ended in the 1990s, and until 2009 its source code only remained in the hands of the development team. Now the system is running again on modern computer systems, thanks to the combined efforts of original developers and interested newcomers. Our goal is to revive Interlisp in language, environment and spirit through the Medley Interlisp Project.</p>
 
 
+<div class="col">
 <h3>What do all these terms mean?</h3>
 <p>With over five decades of history and many design iterations, there are a lot of names and other vocabulary associated with the project. <a href="medley/project/glossary">Visit the glossary</a> to learn more.
 </p>
-
-<h3>Have other questions?</h3><br />
+<h3>Have other questions?</h3>
 <p><a href="medley/project/faqs">Our FAQs page</a> addresses other common queries about the project.</p>
+</div>
+
+
 
 <!-- >{{< carousel items="1" height="500" unit="px" duration="7000" >}} -->
   

--- a/hugo.toml
+++ b/hugo.toml
@@ -1,5 +1,4 @@
-# baseURL = "https://interlisp.org"
-baseURL = "https://phantomics.github.io/InterlispDraft.github.io/"
+baseURL = "https://interlisp.org"
 
 relativeURLs = true
 canonifyURLs = true


### PR DESCRIPTION
Set site location to generic Interlisp.org root.