### PR TITLE
This hides the "Notes" popups in the bibliography.

### DIFF
--- a/layouts/shortcodes/bibTable.html
+++ b/layouts/shortcodes/bibTable.html
@@ -178,7 +178,7 @@ var abstractExpanderClose = "Abstract -";
             {{ range $na, $au := .author }}{{ if $na }}; {{ end }}{{ if $au.literal }}{{ $au.literal }}{{ else if and $au.family $au.given }}{{ $au.family }}, {{ $au.given }}{{ else }}{{ $au.family }}{{ $au.given }}{{ end }}{{ end }}
           </div>{{ end }}
           {{ if .abstract }}<button type="button" class="abstractExpander left" id="A{{$itemID}}">AAA</button>{{ end }}
-          {{ if .note }}
+          {{ if and false .note }}
             {{ $notes := split (plainify .note) "\n" }}
             <div class="tooltipNotes right" id="N{{$itemID}}">Notes
             <span class="tooltipNotesText tooltipNotes-left" id="N{{$itemID}}_Text">


### PR DESCRIPTION
There aren't many notes, and almost all have nearly useless end-user information. 
Also, if the Notes field in the Zotero database may be used for meta-data, it makes even less sense to display it.