### PR TITLE
Adding reading lists of documentation resources

### DIFF
--- a/content/en/software/using-medley/_index.md
+++ b/content/en/software/using-medley/_index.md
@@ -15,11 +15,33 @@ Whether you're just getting started or refreshing your knowledge of Interlisp, w
 The following links lead to PDF files containing Interlisp documentation.
 We are in the process of organizing this documentation.
 
+### Getting started
+
+To learn Medley we recommend that you go over the following reading lists and pursue the resources in the indicated order.
+
+The introductory list gets you started using Medley. The advanced list builds from there and covers programming the system and mastering its tools.
+
+Most of these resources were created decades ago when Medley was a research system and a commercial product, so they may be incomplete or out of date. We will eventually update them.
+
+#### Introductory material
+
+1. [The Basics of Interlisp](Using). Essential information on the Interlisp language and the differences with Common Lisp.
+1. [Medley for the Novice](https://interlisp.org/documentation/Medley-Primer.pdf) (also known as Medley Primer).  An introductory guide to the basics of Medley such as executing commands, using menus and files, manipulating windows, editing and saving Lisp code, using the development tools, and more. Read it in full. The code in chapter 20 "Free Menus" doesn't work and some illustrations are missing.
+1. [SEdit — The Lisp Editor](https://drive.google.com/file/d/12LW5zCZauJvC63NRMJhjNv5qJkuuCflb/view?usp=sharing). The manual of SEdit, the default Lisp code editor.
+1. [LispCourse notes](https://interlisp.org/pub-pdfs/lispcourse/lispcourse.pdf). The notes of a beginner course on the Interlisp environment that goes from the basics of interacting with the system to programming in Lisp. Highly recommended. Skip the sections on printing and the network as modern Medley doesn't fully implement the described functionality. The formatting of the text is partially broken and some sections are missing.
+
+#### Advanced material
+
+1. [INTERLISP: The Language and Its Usage](https://interlisp.org/documentation/1986-interlisp-language-book-1.pdf). An extensive book on the Interlisp language, a prerequisite for accessing the full functionality of Medley from Lisp. Some of the material is about early Interlisp versions that differ from Medley. You may skip the chapters on the Interlisp TTY editor, DWIM, and Conversational Lisp (CLISP).
+1. [Medley Language Reference](https://interlisp.org/documentation/IRM.pdf) (also known as Interlisp Reference Manual). The reference documentation on the Interlisp language, the application platform, and the development environment. The chapters on the Interlisp language are highly recommended. You may skip the chapters on DWIM and CLISP. Some chapters are duplicated, others are missing.
+1. [Medley Interlisp: Interactive Programming Tools](https://interlisp.org/documentation/2021-interlisp-book-3.pdf). Using the development tools and applications. Skip the chapter on DEdit as the tool was replaced by SEdit, the current default Lisp code editor.
+1. [Medley Interlisp: The Interactive Programming Environment](https://interlisp.org/documentation/20211225-interlisp-book-2.pdf). Accessing from Lisp the facilities and tools of the Medley environment such as windows, menus, fonts, and image streams.
+
 ### Unsorted documentation content
 
 Most Interlisp/Medley documentation was written using the Medley Text Editor, one of the first WYSIWYG graphical user interface text editors, called TEdit. Written in and for Interlisp users, it features muliple fonts, embedded graphics including line drawings and raster images.
 
-TEdit files are scattered through the the various Interlisp repositories. For the convenience of those who would rather read the files using more modern tools, see the files from different Medley Interlisp repositories, [converted to PDF](https://drive.google.com/drive/folders/10ZBQty5gEwdBnZHtEbXfe5f1dHGziGZG?usp=sharing). NOTE: This is not a permanent location!
+TEdit files are scattered through the various Interlisp repositories. For the convenience of those who would rather read the files using more modern tools, see the files from different Medley Interlisp repositories, [converted to PDF](https://drive.google.com/drive/folders/10ZBQty5gEwdBnZHtEbXfe5f1dHGziGZG?usp=sharing). NOTE: This is not a permanent location!
 
 For the searcher's conveneience, these have also been combined into searchable PDFs named All-*-PDFs.pdf.
 


### PR DESCRIPTION
As discussed in [issue 1131](https://github.com/Interlisp/medley/issues/1131) the new section *Getting started* in this PR contains two reading lists of documentation resources, one of introductory and the other of advanced material.