### PR TITLE
Using Relative URLs doesn't work with ccustom 404.html

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -1,6 +1,6 @@
 baseURL = "https://interlisp.org"
 
-relativeURLs = true
+relativeURLs = false
 canonifyURLs = true
 
 enableRobotsTXT = true


### PR DESCRIPTION
It took me a long time to figure out that the problem with our custom 404.html in layouts not presenting with any styling was because this flag was set.

The Hugo documentation strongly discourage use of relativeURLs in the hugo settings. 
