### PR TITLE
Change title from 'Using Medley' to 'Documentation'

### DIFF
--- a/content/en/software/using-medley/_index.md
+++ b/content/en/software/using-medley/_index.md
@@ -1,6 +1,6 @@
 ---
-title: Using Medley
-weight: 10
+title: Documentation
+weight: 20
 type: docs
 aliases:
  - /medley/using/docs/medley/orientation/


### PR DESCRIPTION
Rename page and move to bottom of left navigation bar. 

Order is now:
 - Access Medley Online
 - Install and Run
 - Documentation