### PR TITLE
Link Medley releases from Interlisp.org

### DIFF
--- a/content/en/project/status/_index.md
+++ b/content/en/project/status/_index.md
@@ -24,6 +24,10 @@ The Medley team has produced annual reports documenting their major achievements
 - [2022 Annual Report](/project/status/2022medleyannualreport)
 - [2021 Annual Report](/project/status/2021medleyannualreport)
 
+## Release Notes
+
+Builds of Medley for several operating systems and architectures are released every week on Monday. You can [learn what's changed and download the latest builds](https://github.com/Interlisp/medley/releases).
+
 ## November 2023 Computer Conservation Society event
 
 On November 16, 2023 Steve Kaisler gave the talk "Software Archaeology: The Medley Interlisp Modernisation Project" at a [Computer Conservation Society](https://www.computerconservationsociety.org/) event in London and the recording is available here.

--- a/content/en/project/status/_index.md
+++ b/content/en/project/status/_index.md
@@ -24,9 +24,9 @@ The Medley team has produced annual reports documenting their major achievements
 - [2022 Annual Report](/project/status/2022medleyannualreport)
 - [2021 Annual Report](/project/status/2021medleyannualreport)
 
-## Release Notes
+## Build Notes
 
-Builds of Medley for several operating systems and architectures are released every week on Monday. You can [learn what's changed and download the latest builds](https://github.com/Interlisp/medley/releases).
+Builds of Medley for several operating systems and architectures are generated automatically every week. You can [learn what's changed and download the latest builds](https://github.com/Interlisp/medley/releases).
 
 ## November 2023 Computer Conservation Society event
 


### PR DESCRIPTION
This patch adds to the [News and Status Reports](https://interlisp.org/project/status) page the section Release Notes to link to the [releases page](https://github.com/Interlisp/medley/releases) of Medley's GitHub repo. It addresses [issue #1681](https://github.com/Interlisp/medley/issues/1681).