### PR TITLE
Adding a donations page

### DIFF
--- a/content/en/donate.md
+++ b/content/en/donate.md
@@ -1,0 +1,29 @@
+---
+title: Donate to the Medley Interlisp Project
+weight: 20
+type: docs
+aliases:
+ - /donate
+---
+
+InterlispOrg Inc, the non-profit which runs the Medley Interlisp Project, uses donations to pay for online services, web hosting; larger donations for hiring consultants and contract workers to help with various tasks.
+
+## How to donate
+
+You can donate through the following methods:
+
+<form action="https://www.paypal.com/donate" method="post" target="_top">
+<input type="hidden" name="hosted_button_id" value="X69XCWJ6SJKUG" />
+<input type="image" src="https://www.paypalobjects.com/en_US/i/btn/btn_donate_LG.gif" border="0" name="submit" title="PayPal - The safer, easier way to pay online!" alt="Donate with PayPal button" />
+<img alt="" border="0" src="https://www.paypal.com/en_US/i/scr/pixel.gif" width="1" height="1" />
+</form>
+
+- [PayPal](https://www.paypal.com/donate/?hosted_button_id=MCHS5GWLVYLUY): use the donation button above or send directly to [paypal@interlisp.org](mailto:paypal@interlisp.org)
+- [GitHub Sponsors](https://github.com/sponsors/Interlisp): it's convenient but they do charge a fee — 3% if done through ACH, 6% for credit card donations
+- [our donations team](mailto:board@interlisp.org): for larger amounts contact [board@interlisp.org](mailto:board@interlisp.org)
+- Benevity: for corporate donations InterlispOrg can be found on the Benevity portal by either searching for “Interlisp” or the organization numbered 840-872528093
+
+
+## Tax deducibility
+
+InterlispOrg Inc is a non-profit corporation in California, approved by the IRS for 501(c)3 status, and the California FTB for tax-free status. We can accept donations that may be tax-deductable for the donor.

--- a/content/en/project/getInvolved/_index.md
+++ b/content/en/project/getInvolved/_index.md
@@ -62,7 +62,13 @@ If you would like to join our weekly meetings, [let us know](mailto:info@interli
 
 Check out our [Project List](https://docs.google.com/document/d/1ceXj7VzPeLSM0sBwEnYQqArKsXg0VKCWLTF0zv10LRg/edit?usp=sharing) for ideas. Find something that matches your interests, or propose a different project. Funding is available to help support a limited number of projects.
 
-## 6: Donations
+## 6. Donations
 
 We use donations to pay for online services, web hosting; larger donations for hiring consultants and contract workers to help with various tasks.
-You can donate through GitHub sponsors, which is convenient. They do charge a fee -- 3% if done through ACH, 6% for credit card donations. For larger amounts contact [our donations team](mailto:board@interlisp.org).
+
+You can donate through the following methods:
+
+- [GitHub Sponsors](https://github.com/sponsors/Interlisp): it's convenient but they do charge a fee — 3% if done through ACH, 6% for credit card donations
+- [PayPal](https://www.paypal.com/donate/?hosted_button_id=MCHS5GWLVYLUY): [paypal@interlisp.org](mailto:paypal@interlisp.org)
+- [our donations team](mailto:board@interlisp.org): for larger amounts contact [board@interlisp.org](mailto:board@interlisp.org)
+


### PR DESCRIPTION
The patch restructures the donations section of the [Get Involved](https://interlisp.org/project/getinvolved/) page as a list. This way the options stand out more and make up a template for expansion to more donation methods.