### PR TITLE
Adding links to ELS 2024 talk and Alex Schroeder's post

### DIFF
--- a/content/en/project/comments/_index.md
+++ b/content/en/project/comments/_index.md
@@ -29,13 +29,16 @@ _Within the Artificial Intelligence and natural language research communities, L
 
 ## Blogs and Online Discussions
 
-- Eugene Zaikonnikov recapped the discovery of the [Interlisp code of Eurisko](https://blog.funcall.org/lisp/2024/03/22/eurisko-lives/), the seminal AI system by Doug Lenat, and shared a video in which Eugene introduces the program and demonstrates it running on Medley.
+- Alex Schroeder [shared his first impressions on and goals for using Medley](https://alexschroeder.ch/view/2024-05-11-distractions).  
+_Designing Medley Interlisp such that it has this fuzzy boundary and can access a web browser and a PDF viewer outside is great;_
+
+- Eugene Zaikonnikov recapped the discovery of the [Interlisp code of Eurisko](https://blog.funcall.org/lisp/2024/03/22/eurisko-lives/), the seminal AI system by Doug Lenat, and shared a video in which Eugene introduces the program and demonstrates it running on Medley.  
 _Truly an Indiana Jones finding the Lost Ark moment._
 
-- [What Were the Differences Between Symbolics Genera and Xerox Interlisp-D](https://news.ycombinator.com/item?id=36713595) asked by Simon Brooke in [Hacker News](https://news.ycombinator.com/news)
+- [What Were the Differences Between Symbolics Genera and Xerox Interlisp-D](https://news.ycombinator.com/item?id=36713595) asked by Simon Brooke in [Hacker News](https://news.ycombinator.com/news)  
 _... I'm curious about the similarities and differences between Symbolics Genera and Xerox Interlisp-D. Why is Genera more hyped than Interlisp-D? Unlike Genera, which is proprietary and is extremely difficult to obtain legally, Interlisp-D is now free, open-source software, and there's a community that has ported Interlisp-D to run on top of modern operating systems._
 
-- [InterLisp Fifteen Puzzle](https://pixel-outlaw.itch.io/interlisp-fifteen-puzle) by Pixel_Outlaw in his blog.
+- [InterLisp Fifteen Puzzle](https://pixel-outlaw.itch.io/interlisp-fifteen-puzle) by Pixel_Outlaw in his blog.  
 _In some ways, this project was the fulfillment of me wanting to see what Xerox PARC brought to the table during the peak of Lisp AI research. It was from a time when what "Lisp" was was still being explored. You see heavy traces of the era in InterLisp._
 
 - [Stringscope, a string listing tool in Interlisp](https://journal.paoloamoroso.com/stringscope-a-string-listing-tool-in-interlisp) by Paolo Amoroso in his [blog](https://journal.paoloamoroso.com/)  

--- a/content/en/project/status/_index.md
+++ b/content/en/project/status/_index.md
@@ -15,6 +15,12 @@ aliases:
 
 Builds of Medley for several operating systems and architectures are generated automatically every week. You can [learn what's changed and download the latest builds](https://github.com/Interlisp/medley/releases). We advise caution as these builds are untested and may have bugs or other issues.
 
+## May 2024 European Lisp Symposium
+
+On May 6, 2024 Andrew Sengul gave the remote talk "The Medley Interlisp Revival" at the [European Lisp Symposium 2024](https://european-lisp-symposium.org/2024/index.html). The video recording is below (from 01:36:19) and the paper is [available online](https://doi.org/10.5281/zenodo.11090093).
+
+<iframe src="https://player.twitch.tv/?video=2138739613&time=1h36m21s&parent=www.example.com" frameborder="0" allowfullscreen="true" scrolling="no" height="378" width="620"></iframe>
+
 ## 2023 Annual Report released!
 
 The [2023 Medley Interlisp Annual Report](/project/status/2023medleyannualreport) is ready! "Read all about it!"

--- a/content/en/project/status/_index.md
+++ b/content/en/project/status/_index.md
@@ -19,7 +19,7 @@ Builds of Medley for several operating systems and architectures are generated a
 
 On May 6, 2024 Andrew Sengul gave the remote talk "The Medley Interlisp Revival" at the [European Lisp Symposium 2024](https://european-lisp-symposium.org/2024/index.html). The video recording is below (from 01:36:19) and the paper is [available online](https://doi.org/10.5281/zenodo.11090093).
 
-<iframe src="https://player.twitch.tv/?video=2138739613&time=1h36m21s&parent=www.example.com" frameborder="0" allowfullscreen="true" scrolling="no" height="378" width="620"></iframe>
+<iframe src="https://player.twitch.tv/?video=2138739613&time=1h36m21s&parent=www.interlisp.org" frameborder="0" allowfullscreen="true" scrolling="no" height="378" width="620"></iframe>
 
 ## 2023 Annual Report released!
 


### PR DESCRIPTION
I suggest updating the [news section](https://interlisp.org/project/status/) of the project site with links to Andrew Sengul's ELS 2024 [video](https://www.twitch.tv/videos/2138739613?t=01h36m19s) and [paper](https://doi.org/10.5281/zenodo.11090093), and adding to the [comments section](https://interlisp.org/project/comments) a link to [Alex Schroeder's post](https://alexschroeder.ch/view/2024-05-11-distractions) on his impressions on Medley.
