### PR TITLE
Update docsy version to 0.10.0

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -77,7 +77,7 @@ jobs:
         env:
           cache-name: cache-zotero_bib
         with:
-          path: ~/data
+          path: ~/static/data
           key: ${{ needs.check.outputs.zoteroVersion }}
           restore-keys: |
             ${{ needs.check.outputs.zoteroVersion }}
@@ -88,14 +88,14 @@ jobs:
         run: |
           if [[ "$CACHE_HIT" == 'true' ]]; then
             echo "Use Cache"
-            sudo cp --recursive ~/data ${GITHUB_WORKSPACE}
-            ls -la ${GITHUB_WORKSPACE}/data
+            sudo cp --recursive ~/static/data ${GITHUB_WORKSPACE}
+            ls -la ${GITHUB_WORKSPACE}/static/data
           else
             echo "Retrieve bibliography"
             cd scripts
             chmod +x ./update_bibliography.sh
             ./update_bibliography.sh
-            sudo cp --recursive ${GITHUB_WORKSPACE}/data ~/data
+            sudo cp --recursive ${GITHUB_WORKSPACE}/static/data ~/static/data
           fi 
         shell: bash
 

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -51,7 +51,7 @@ jobs:
         
       - name: Cache Zotero Bibliography
         id: cache-zotero-bib
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         env:
           cache-name: cache-zotero_bib
         with:
@@ -73,11 +73,11 @@ jobs:
 
       - name: Cache Zotero Bibliography
         id: cache-zotero-bib
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         env:
           cache-name: cache-zotero_bib
         with:
-          path: ~/static/data
+          path: ~/data
           key: ${{ needs.check.outputs.zoteroVersion }}
           restore-keys: |
             ${{ needs.check.outputs.zoteroVersion }}
@@ -88,25 +88,25 @@ jobs:
         run: |
           if [[ "$CACHE_HIT" == 'true' ]]; then
             echo "Use Cache"
-            sudo cp --recursive ~/static/data ${GITHUB_WORKSPACE}
+            sudo cp --recursive ~/data ${GITHUB_WORKSPACE}/static
             ls -la ${GITHUB_WORKSPACE}/static/data
           else
             echo "Retrieve bibliography"
             cd scripts
             chmod +x ./update_bibliography.sh
             ./update_bibliography.sh
-            sudo cp --recursive ${GITHUB_WORKSPACE}/static/data ~/static/data
+            sudo cp --recursive ${GITHUB_WORKSPACE}/static/data ~/data
           fi 
         shell: bash
 
       - name: Setup Hugo
-        uses: peaceiris/actions-hugo@v2
+        uses: peaceiris/actions-hugo@v3
         with:
           hugo-version: '0.122.0'
           extended: true
 
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 18
       
@@ -118,7 +118,7 @@ jobs:
         run: hugo
 
       - name: Deploy
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4
         if: github.ref == 'refs/heads/main'
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/config/development/server.yaml
+++ b/config/development/server.yaml
@@ -1,0 +1,13 @@
+headers:
+- for: /**
+  values:
+    Content-Security-Policy: script-src 'unsafe-inline' 'unsafe-eval' localhost:1313 https://code.jquery.com https://*.google.com http://*.google.com https://partner.googleadservices.com
+    Referrer-Policy: strict-origin-when-cross-origin
+    X-Content-Type-Options: nosniff
+    X-Frame-Options: DENY
+    X-XSS-Protection: 1; mode=block
+
+redirects:
+- from: /**
+  status: 404
+  to: /404.html

--- a/content/en/_index.html
+++ b/content/en/_index.html
@@ -4,7 +4,7 @@ aliases:
  - /hugo
 ---
 
-{{< blocks/cover title="The Medley Interlisp Project" subtitle="a retrofuturistic software system" image_anchor="smart" color="orange" height="min">}}
+{{< blocks/cover title="The Medley Interlisp Project" subtitle="a retrofuturistic software system" image_anchor="smart" color="primary" height="min">}}
 <div class="top-summary">
   What did we leave behind on the path to developing today's computer systems? Could there be lessons for the future of computing hidden in the past? Enter the Medley software environment to explore these questions.
 </div>
@@ -49,7 +49,7 @@ aliases:
   
 {{< /blocks/section >}}
 
-{{< blocks/section color="primary" >}}
+{{< blocks/section color="primary" type="row" >}}
 
 {{% blocks/feature icon="fas fa-feather" title="History of Interlisp" %}}
  <p>

--- a/content/en/history/bibliography/_index.md
+++ b/content/en/history/bibliography/_index.md
@@ -13,5 +13,4 @@ aliases:
 
 (This bibliography is kept in sync with our [Zotero](https://www.zotero.org/) collection [Library](https://www.zotero.org/groups/2914042/interlisp/library).
 
-
 {{< bibTable >}}

--- a/content/en/project/credits.md
+++ b/content/en/project/credits.md
@@ -2,7 +2,6 @@
 title: Credits
 weight: 80
 type: docs
-markup: mmark
 ---
 
 Interlisp was a joint effort of many people -- likely more than one hundred -- from its initial beginnings through its heyday until its virtual disappearance. There are more than we can name. There were contributions by employees of BBN, Xerox, and Fuji Xerox and later, employees of Envos and Venue. There are initials in the source code with date of last edit, but who wrote what is sometimes a mystery.

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/Interlisp/Interlisp.github.io
 
 go 1.20
 
-require github.com/google/docsy v0.6.0 // indirect
+require (
+	github.com/google/docsy v0.10.0 // indirect
+	github.com/google/docsy/dependencies v0.7.2 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,9 @@
-github.com/FortAwesome/Font-Awesome v0.0.0-20220831210243-d3a7818c253f/go.mod h1:IUgezN/MFpCDIlFezw3L8j83oeiIuYoj28Miwr/KUYo=
-github.com/google/docsy v0.6.0 h1:43bVF18t2JihAamelQjjGzx1vO2ljCilVrBgetCA8oI=
-github.com/google/docsy v0.6.0/go.mod h1:VKKLqD8PQ7AglJc98yBorATfW7GrNVsn0kGXVYF6G+M=
-github.com/google/docsy/dependencies v0.6.0/go.mod h1:EDGc2znMbGUw0RW5kWwy2oGgLt0iVXBmoq4UOqstuNE=
+github.com/FortAwesome/Font-Awesome v0.0.0-20230327165841-0698449d50f2/go.mod h1:IUgezN/MFpCDIlFezw3L8j83oeiIuYoj28Miwr/KUYo=
+github.com/FortAwesome/Font-Awesome v0.0.0-20240402185447-c0f460dca7f7/go.mod h1:IUgezN/MFpCDIlFezw3L8j83oeiIuYoj28Miwr/KUYo=
+github.com/google/docsy v0.10.0 h1:6tMDacPwAyRWNCfvsn/9qGOZDQ8b0aRzjRZvnZPY5dg=
+github.com/google/docsy v0.10.0/go.mod h1:c0nIAqmRTOuJ01F85U/wJPQtc3Zj9N58Kea9bOT2AJc=
+github.com/google/docsy/dependencies v0.7.2 h1:+t5ufoADQAj4XneFphz4A+UU0ICAxmNaRHVWtMYXPSI=
+github.com/google/docsy/dependencies v0.7.2/go.mod h1:gihhs5gmgeO+wuoay4FwOzob+jYJVyQbNaQOh788lD4=
 github.com/twbs/bootstrap v4.6.2+incompatible/go.mod h1:fZTSrkpSf0/HkL0IIJzvVspTt1r9zuf7XlZau8kpcY0=
+github.com/twbs/bootstrap v5.2.3+incompatible/go.mod h1:fZTSrkpSf0/HkL0IIJzvVspTt1r9zuf7XlZau8kpcY0=
+github.com/twbs/bootstrap v5.3.3+incompatible/go.mod h1:fZTSrkpSf0/HkL0IIJzvVspTt1r9zuf7XlZau8kpcY0=

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,11 @@
 github.com/FortAwesome/Font-Awesome v0.0.0-20230327165841-0698449d50f2/go.mod h1:IUgezN/MFpCDIlFezw3L8j83oeiIuYoj28Miwr/KUYo=
+github.com/FortAwesome/Font-Awesome v0.0.0-20240108205627-a1232e345536/go.mod h1:IUgezN/MFpCDIlFezw3L8j83oeiIuYoj28Miwr/KUYo=
 github.com/FortAwesome/Font-Awesome v0.0.0-20240402185447-c0f460dca7f7/go.mod h1:IUgezN/MFpCDIlFezw3L8j83oeiIuYoj28Miwr/KUYo=
+github.com/google/docsy v0.9.1 h1:+jqges1YCd+yHeuZ1BUvD8V8mEGVtPxULg5j/vaJ984=
+github.com/google/docsy v0.9.1/go.mod h1:saOqKEUOn07Bc0orM/JdIF3VkOanHta9LU5Y53bwN2U=
 github.com/google/docsy v0.10.0 h1:6tMDacPwAyRWNCfvsn/9qGOZDQ8b0aRzjRZvnZPY5dg=
 github.com/google/docsy v0.10.0/go.mod h1:c0nIAqmRTOuJ01F85U/wJPQtc3Zj9N58Kea9bOT2AJc=
+github.com/google/docsy/dependencies v0.6.0/go.mod h1:EDGc2znMbGUw0RW5kWwy2oGgLt0iVXBmoq4UOqstuNE=
 github.com/google/docsy/dependencies v0.7.2 h1:+t5ufoADQAj4XneFphz4A+UU0ICAxmNaRHVWtMYXPSI=
 github.com/google/docsy/dependencies v0.7.2/go.mod h1:gihhs5gmgeO+wuoay4FwOzob+jYJVyQbNaQOh788lD4=
 github.com/twbs/bootstrap v4.6.2+incompatible/go.mod h1:fZTSrkpSf0/HkL0IIJzvVspTt1r9zuf7XlZau8kpcY0=

--- a/hugo.toml
+++ b/hugo.toml
@@ -7,6 +7,8 @@ enableRobotsTXT = true
 
 assetDir = "static"
 
+
+
 # ****************************************************************************
 #
 # Docsy
@@ -214,6 +216,7 @@ sidebar_search_disable = false
 navbar_logo = true
 # Set to true to disable the About link in the site footer
 footer_about_enable = false
+
 # Turn off transparency in nav bar
 navbar_translucent_over_cover_disable = true
 
@@ -278,3 +281,10 @@ enable = false
 #   url = "https://example.org/mail"
 #   icon = "fa fa-envelope"
 #   desc = "Discuss development issues around the project"
+
+[params.cdn]
+  jquery = 'https://code.jquery.com/jquery-3.7.1.min.js'
+	jquery_hash = 'sha256-/JqT3SQfawRcv/BIHPThkBvs0OEvtFFmqPF/lYI/Cxo='
+
+[params.csp]
+  scriptsrc = ["'self'", "'unsafe-inline'", "https://code.jquery.com"]

--- a/hugo.toml
+++ b/hugo.toml
@@ -255,8 +255,8 @@ enable = false
 [[params.links.user]]
   name ="Twitter"
   url = "https://twitter.com/interlisp8"
-  icon = "fab fa-twitter"
-  desc = "Follow us on Twitter to get the latest news!"
+  icon = "fab fa-x-twitter"
+  desc = "Follow us on X to get the latest news!"
 # [[params.links.user]]
 #  name = "Stack Overflow"
 #  url = "https://stackoverflow.com/questions/tagged/graphviz"

--- a/hugo.toml
+++ b/hugo.toml
@@ -23,7 +23,7 @@ defaultContentLanguageInSubdir = false
 # Useful when translating.
 enableMissingTranslationPlaceholders = true
 
-disableKinds = ["taxonomy", "taxonomyTerm", "RSS"]
+disableKinds = ["taxonomy", "RSS"]
 
 # ****************************************************************************
 #
@@ -116,7 +116,7 @@ anchor = "smart"
 
 [languages]
   [languages.en]
-    description = "Dedicated to restoring and preserving the Interlisp experience"
+#    description = "Dedicated to restoring and preserving the Interlisp experience"
     languageName ="English"
     # Weight used for sorting.
     weight = 1
@@ -213,7 +213,7 @@ sidebar_search_disable = false
 #  Set to false if you don't want to display a logo (/assets/icons/logo.svg) in the top nav bar
 navbar_logo = true
 # Set to true to disable the About link in the site footer
-footer_about_disable = true # false
+footer_about_enable = false
 # Turn off transparency in nav bar
 navbar_translucent_over_cover_disable = true
 

--- a/hugo.toml
+++ b/hugo.toml
@@ -281,10 +281,3 @@ enable = false
 #   url = "https://example.org/mail"
 #   icon = "fa fa-envelope"
 #   desc = "Discuss development issues around the project"
-
-[params.cdn]
-  jquery = 'https://code.jquery.com/jquery-3.7.1.min.js'
-	jquery_hash = 'sha256-/JqT3SQfawRcv/BIHPThkBvs0OEvtFFmqPF/lYI/Cxo='
-
-[params.csp]
-  scriptsrc = ["'self'", "'unsafe-inline'", "https://code.jquery.com"]

--- a/layouts/partials/hooks/body-end.html
+++ b/layouts/partials/hooks/body-end.html
@@ -1,4 +1,3 @@
 <!-- ><script type="text/javascript" src="/js/carousel.js"></script>
-	<script src="https://code.jquery.com/jquery-3.7.1.min.js" integrity="sha256-/JqT3SQfawRcv/BIHPThkBvs0OEvtFFmqPF/lYI/Cxo=" crossorigin="anonymous"></script>
 <link rel="stylesheet" href="/css/carousel.css"> -->
 <link rel="stylesheet" href="/css/custom.css">

--- a/layouts/partials/hooks/body-end.html
+++ b/layouts/partials/hooks/body-end.html
@@ -1,3 +1,4 @@
 <!-- ><script type="text/javascript" src="/js/carousel.js"></script>
+	<script src="https://code.jquery.com/jquery-3.7.1.min.js" integrity="sha256-/JqT3SQfawRcv/BIHPThkBvs0OEvtFFmqPF/lYI/Cxo=" crossorigin="anonymous"></script>
 <link rel="stylesheet" href="/css/carousel.css"> -->
 <link rel="stylesheet" href="/css/custom.css">

--- a/layouts/shortcodes/bibTable.html
+++ b/layouts/shortcodes/bibTable.html
@@ -165,7 +165,15 @@ var abstractExpanderClose = "Abstract -";
       </tr>
     </thead>
     <tbody style="overflow:auto">
-      {{ $years_items := getJSON "data/bibliography.json" }}
+      {{ $years_items := dict }}
+      {{ $bib := resources.Get "data/bibliography.json" }}
+      {{ with $bib }}
+        {{ with . | transform.Unmarshal }}
+          {{ $years_items = . }}
+        {{ end }}
+      {{ else }}
+        {{ errorf "Unable to get global resource 'data/bibliography.json'" }}
+      {{ end }}
       {{ range $year, $items := $years_items }}
         <tr>
           <th class="year"><b>{{ $year }}</b></th>

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,8 @@
 
       "dependencies": {
 
+        "jquery": "^3.7.1",
+
         "tabpanel": "^0.2.0"
 
       },
@@ -953,6 +955,16 @@
         "node": ">=0.12.0"
 
       }
+
+    },
+
+    "node_modules/jquery": {
+
+      "version": "3.7.1",
+
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.7.1.tgz",
+
+      "integrity": "sha512-m4avr8yL8kmFN8psrbFFFmB/If14iN5o9nw/NgnnM+kybDJpRsAynV2BsfpTYrTRysYUdADVD7CkUUizgkpLfg=="
 
     },
 
@@ -2541,6 +2553,16 @@
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
 
       "dev": true
+
+    },
+
+    "jquery": {
+
+      "version": "3.7.1",
+
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.7.1.tgz",
+
+      "integrity": "sha512-m4avr8yL8kmFN8psrbFFFmB/If14iN5o9nw/NgnnM+kybDJpRsAynV2BsfpTYrTRysYUdADVD7CkUUizgkpLfg=="
 
     },
 

--- a/package.json
+++ b/package.json
@@ -12,9 +12,11 @@
 
   "dependencies": {
 
+    "jquery": "^3.7.1",
+
     "tabpanel": "^0.2.0"
 
   }
-  
+
 }
 

--- a/scripts/update_bibliography.sh
+++ b/scripts/update_bibliography.sh
@@ -102,4 +102,4 @@ items=$(jq 'include "./bib-fns";map(reconstituteGroupedEntries) | from_entries' 
 
 echo "Outputting CSL JSON"
 echo "$finalCount entries"
-echo "$items" > "$(dirname "$0")/../data/bibliography.json"
+echo "$items" > "$(dirname "$0")/../static/data/bibliography.json"


### PR DESCRIPTION
Update Docsy version, cleaned up home page due to block handling changes.  Replaced twitter icon with X.

- Docsy Version bumped to 0.10.0
- Github action updates
  - peaceiris hugo action version  update -> v3
  - peaceiris gh-pages action version update -> v4
  - github cache action version update -> v4
  - github setup-node action version update -> v4
- Replaced deprecated `getJSON` call with `resources.Get`
  - Moved `data` directory location to `static/data`  so it would be treated as a resource location
  - Updated `update_bibliography.sh` script to build in new location
  - Update `bibTable` shortcut to use `resources.Get` method
  - Miscellaneous updates to fix minor style changes, primarily adding in values that are no longer defaulted
- Updates to `hugo.toml`
  - Removed deprecated type `taxonomyTerm` 
  - Removed deprecated `description` section in `[languages.en]`
  - `footer_about_disable` replaced by `footer_about_enable`
  - Twitter logo replaced with X logo
  