### PR TITLE
Leaving video conferencing platform unspecified

### DIFF
--- a/content/en/project/getInvolved/_index.md
+++ b/content/en/project/getInvolved/_index.md
@@ -50,7 +50,7 @@ The archives are public. The LispCore group gets much more email, and posts from
 * X (Twitter) handle: [interlisp8](https://twitter.com/interlisp8).
 * _Direct email:_ In addition to the email groups listed above, you can email us at [info@interlisp.org](mailto:info@interlisp.org).
 
-## 4. Weekly meetings. We have weekly meetings on Zoom:
+## 4. Weekly meetings. We have weekly video conferencing meetings:
 
 Mondays:    2pm PT/5pm ET. Implementation -- technical discussions  
 Wednesdays: 10am PT/1pm ET. Communication -- website, talks,

--- a/content/en/project/getInvolved/_index.md
+++ b/content/en/project/getInvolved/_index.md
@@ -53,7 +53,7 @@ The archives are public. The LispCore group gets much more email, and posts from
 ## 4. Weekly meetings. We have weekly video conferencing meetings:
 
 Mondays:    2pm PT/5pm ET. Implementation -- technical discussions  
-Wednesdays: 10am PT/1pm ET. Communication -- website, talks,
+Wednesdays: 10:30am PT/1:30pm ET. Communication -- website, talks,
                              documentation, bibliography, etc.  
 
 Meetings are to report accomplishments, status, plans, and problems, and discuss directions. Meetings are recorded, but recordings are not public.


### PR DESCRIPTION
The heading of the section on weekly meetings of the [Get Involved](https://interlisp.org/project/getinvolved) page explicitly says they're held on Zoom. I propose replacing this with a generic indication of video conferencing because what platform we use is incidental, we switched to Google Meet, and we may switch again.
