### PR TITLE
Mentioning the GitHub Discussions board

### DIFF
--- a/content/en/project/getInvolved/_index.md
+++ b/content/en/project/getInvolved/_index.md
@@ -32,6 +32,10 @@ Bug reports, feature requests, documentation problems, and questions are posted 
 
 ## 3. Join in the discussions
 
+### Discussion board
+
+The [discussion board on GitHub](https://github.com/orgs/Interlisp/discussions) is for general discussions and questions on the Medley environment, the Interlisp language, and Lisp development on the Medley system.
+
 ### EMail
 
 There are two Google groups (mailing lists):


### PR DESCRIPTION
The [Get Involved](https://interlisp.org/project/getinvolved) page of the project site doesn't mention the GitHub Discussions board. This PR describes and links to the board.