### PR TITLE
Turn off dumping the "00-rawItems.json" file when update_bibliography.sh is run.

### DIFF
--- a/scripts/update_bibliography.sh
+++ b/scripts/update_bibliography.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-rawItemsFile=true
+rawItemsFile=false
 debugFiles=false
 tagFiles=false
 typeFiles=false


### PR DESCRIPTION
I forgot to turn it off before committing the `mth2-use-DOI-for-url-bibliography` branch, and creating the PR #242.