### PR TITLE
Move unimplemented history pages to DRAFT

### DIFF
--- a/content/en/history/d-machines/_index.md
+++ b/content/en/history/d-machines/_index.md
@@ -2,4 +2,6 @@
 title: D-Machines*
 type: docs
 weight: 20
+
+draft: true
 ---

--- a/content/en/history/guis/_index.md
+++ b/content/en/history/guis/_index.md
@@ -2,4 +2,6 @@
 title: History of Graphical User Interfaces*
 type: docs
 weight: 40
+
+draft: true
 ---

--- a/content/en/history/lisp/_index.md
+++ b/content/en/history/lisp/_index.md
@@ -2,4 +2,6 @@
 title: History of Lisp*
 type: docs
 weight: 50
+
+draft: true
 ---

--- a/content/en/history/medley/_index.md
+++ b/content/en/history/medley/_index.md
@@ -2,4 +2,6 @@
 title: Development of Medley*
 type: docs
 weight: 30
+
+draft: true
 ---

--- a/content/en/history/parc-alto/_index.md
+++ b/content/en/history/parc-alto/_index.md
@@ -2,4 +2,6 @@
 title: Xerox PARC and Alto*
 type: docs
 weight: 10
+
+draft: true
 ---


### PR DESCRIPTION
Draft pages still exist in the repo but are not build into the Website.  We can leave them as draft until they are implemented.