### PR TITLE
Cleanup of Page Indexing Issues

### DIFF
--- a/content/en/history/_index.md
+++ b/content/en/history/_index.md
@@ -24,8 +24,6 @@ Each software environment had its own microcode (for each machine)  to implement
 
 When sold as a workstation of the Xerox Office Systems Division, the machines had different numbers -- the Xerox 1108 (Dandelion) was the same as the Xerox 8010. The Xerox 1186 (Daybreak) was the same as the Xerox 6085.
 
-
 ### Detailed History
 
 A more extensive history of Interlisp can be found in the [Interlisp Timeline](timeline). The [Interlisp Bibliography](bibliography) has a wealth of historical material.
-

--- a/content/en/history/bibliography/_index.md
+++ b/content/en/history/bibliography/_index.md
@@ -2,10 +2,6 @@
 title: Bibliography
 weight: 5
 type: docs
-aliases:
- - /bibliography/
- - /medley/history/publications/
- - /medley/history/publications/table/
 
 ---
 

--- a/content/en/history/bibliography/_index.md
+++ b/content/en/history/bibliography/_index.md
@@ -2,6 +2,8 @@
 title: Bibliography
 weight: 5
 type: docs
+aliases:
+ - /bibliography/
 
 ---
 

--- a/content/en/history/glossary/_index.md
+++ b/content/en/history/glossary/_index.md
@@ -1,10 +1,7 @@
 ---
 title: Glossary
 aliases:
- - /medley/project/glossary
- - /medley/project/glossary/
  - /glossary/
- - /project/glossary
  - /medley/project/vocabulary/
 weight: 90
 type: docs

--- a/content/en/project/donate.md
+++ b/content/en/project/donate.md
@@ -2,8 +2,6 @@
 title: Donate
 weight: 15
 type: docs
-aliases:
- - /donate
 ---
 
 ## Why to donate
@@ -29,7 +27,7 @@ You can donate using the following methods:
   </form>
 - [GitHub Sponsors](https://github.com/sponsors/Interlisp): convenient, but they do charge a fee — 3% if done through ACH, 6% for credit card donations.
 - Contact [our donations team](mailto:finance@interlisp.org) for larger amounts.
-- Benevity: for corporate matching donations, find InterlispOrg on the Benevity portal by searching for “Interlisp” or 
+- Benevity: for corporate matching donations, find InterlispOrg on the Benevity portal by searching for “Interlisp” or
   organization number `840-872528093`.
 
 ## Tax deductibility

--- a/content/en/project/getInvolved/_index.md
+++ b/content/en/project/getInvolved/_index.md
@@ -4,7 +4,6 @@ weight: 11
 type: docs
 aliases:
  - /medley/project/getinvolved/
- - /getinvolved/
 ---
 
 There several ways to get involved in the Medley Interlisp Project, depending on your background and interests. These are elaborated below:

--- a/content/en/project/partners/educopia.md
+++ b/content/en/project/partners/educopia.md
@@ -4,7 +4,6 @@ weight: 20
 type: docs
 aliases:
  - /hugo/about/partners/educopia/
- - /medley/project/partners/educopia/
 ---
 [Educopia](https://educopia.org) is a non-profit organization hosting the [Software Preservation Network](/project/partners/spn) and other software preservation groups.
 

--- a/content/en/project/status/2022MedleyAnnualReport.md
+++ b/content/en/project/status/2022MedleyAnnualReport.md
@@ -5,7 +5,6 @@ type: docs
 aliases:
  - /medley/project/status/2022medleyannualreport/
  - /project/news/2022medleyannualrepoort/
- - /news/2022medleyannualreport/
 ---
 
 ### Introduction

--- a/content/en/software/access-online/_index.md
+++ b/content/en/software/access-online/_index.md
@@ -3,10 +3,7 @@ title: Access Medley Online
 weight: 10
 type: docs
 aliases:
-  - /medley/using/running/online/	
   - /medley/using/running/online
-  - /running/online
-  - /running/online/using/online
   - /software/access-online
 ---
 
@@ -29,9 +26,9 @@ Running Medley online is good for experimenting and introducing yourself to the 
 
    * If you are already registered (created an account), log in and start a Medley Interlisp session. Sessions are preserved for users that login with their own account. However, user account sessions may be deleted after 30 days of inactivity.
 
-3. Select the Exec you want to start out with. For example, select `Interlisp`. 
+3. Select the Exec you want to start out with. For example, select `Interlisp`.
 
-4. Leave the `Fill browser window` option set. 
+4. Leave the `Fill browser window` option set.
 
 5. Select `Run Medley`.
 Your browser will open a window that represents the Interlisp Desktop and looks much like this:
@@ -43,4 +40,3 @@ Your browser will open a window that represents the Interlisp Desktop and looks 
   Guide to Using Medley<i class="fas fa-arrow-alt-circle-right ml-2"></i>
  </a>
 </div>
-

--- a/content/en/software/install-and-run/linux/_index.md
+++ b/content/en/software/install-and-run/linux/_index.md
@@ -2,8 +2,6 @@
 title: Install and Run on Linux
 linkTitle: Linux
 weight: 20
-aliases:
- - /software/install-and-run/running-on-linux/
 type: docs
 ---
 <style>.td-content blockquote { border-left: none; color: inherit; padding-left: 2rem;}</style>

--- a/content/en/software/install-and-run/macos/_index.md
+++ b/content/en/software/install-and-run/macos/_index.md
@@ -3,9 +3,6 @@ title: Install and Run on MacOS
 linkTitle: MacOS
 weight: 30
 type: docs
-aliases:
-  - /running/running-on-mac
-  - /software/install-and-run/running-on-mac/
 ---
 
 <style>.td-content blockquote { border-left: none; color: inherit; padding-left: 2rem;}</style>

--- a/content/en/software/install-and-run/windows/native/_index.md
+++ b/content/en/software/install-and-run/windows/native/_index.md
@@ -3,8 +3,6 @@ title: Install and Run on Windows "native"
 linkTitle: native
 weight: 40
 type: docs
-aliases:
- - /software/install-and-run/running-on-win/
 ---
 
 <style>.td-content blockquote { border-left: none; color: inherit; padding-left: 2rem;}</style>

--- a/content/en/software/using-medley/_index.md
+++ b/content/en/software/using-medley/_index.md
@@ -3,19 +3,15 @@ title: Documentation
 weight: 20
 type: docs
 aliases:
- - /medley/using/docs/medley/orientation/
  - /docs/
  - /medley/using/docs/medley/the-medley-interlisp-dsk-file-system/
- - /doc/info/Using.html
  - /doc/info/Using
- - /hugo/documentation
  - /using-medley/
  - /medley/using/
  - /medley/using/docs/medley/orientation/
  - /medley/using/docs/medley/
  - /docs/medley/orientation/
  - /medley/using/docs/medley/tips/
- - /docs/medley/orientation/
  - /software/using-medley/medley/
  - /software/using-medley/IRM.pdf
 ---

--- a/content/en/software/using-medley/il-using.md
+++ b/content/en/software/using-medley/il-using.md
@@ -21,5 +21,4 @@ In an (INTERLISP) Exec window, type the following:
 
 When you complete typing the ending `)` the Interlisp interpreter will perform the calculation and return the result.
 
-One thing you probably noticed, the function name `PLUS` is capitalized. This is traditional -- Interlisp programmers commonly ran with the caps-lock turned on.  It’s not that the developers of Interlisp were always shouting at each other. Rather, when Interlisp was developed computer programming was in its early days and all-caps type-in was common. (It's possible to change the Interlisp exec to automatically capitalize symbols at imput, as is the case with the Common Lisp exec, if that's your preference.)
-
+One thing you probably noticed, the function name `PLUS` is capitalized. This is traditional -- Interlisp programmers commonly ran with the caps-lock turned on.  It’s not that the developers of Interlisp were always shouting at each other. Rather, when Interlisp was developed computer programming was in its early days and all-caps type-in was common. (It's possible to change the Interlisp exec to automatically capitalize symbols at input, as is the case with the Common Lisp exec, if that's your preference.)


### PR DESCRIPTION
This PR removes aliases that are no longer necessary and are resulting in `Excluded by 'noindex' tag` failures.  Removals were limited to URLs flagged as excluded.

There is also so minor markdown cleanup sprinkled in.  No change of content, just removing nonstandard line feeds and spaces.