### PR TITLE
Add Title to hugo.yaml and modify navbar to use it

### DIFF
--- a/config/_default/hugo.yaml
+++ b/config/_default/hugo.yaml
@@ -5,6 +5,9 @@
 # An overview of hugo configuration files can be found at:
 #  https://gohugo.io/getting-started/configuration/#configure-server
 #
+# title: The title that appears in the navbar of every page.  We have 
+#        edited navbar.html to not show the title in the navbar of the home page.
+title: "The Medley Interlisp Project"
 
 # relativeURLs: Enable to force all relative URLs to be relative to content root
 relativeURLs: false

--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -1,0 +1,75 @@
+{{ $cover := and
+	(.HasShortcode "blocks/cover")
+	(not .Site.Params.ui.navbar_translucent_over_cover_disable)
+-}}
+{{ $baseURL := urls.Parse $.Site.Params.Baseurl -}}
+
+<nav class="td-navbar js-navbar-scroll
+					{{- if $cover }} td-navbar-cover {{- end }}" data-bs-theme="dark">
+<div class="container-fluid flex-column flex-md-row">
+<a class="navbar-brand" href="{{ .Site.Home.RelPermalink }}">
+	{{- /**/ -}}
+	<span class="navbar-brand__logo navbar-logo">
+		{{- if ne .Site.Params.ui.navbar_logo false -}}
+			{{ with resources.Get "icons/logo.svg" -}}
+				{{ ( . | minify).Content | safeHTML -}}
+			{{ end -}}
+		{{ end -}}
+	</span>
+	{{- /**/ -}}
+	<span class="navbar-brand__name">
+		<!-- Place the site title on every page header, except the home page -->
+		{{ if not .IsHome }}
+			{{ .Site.Title }}
+		{{ end }}
+
+	</span>
+	{{- /**/ -}}
+</a>
+<div class="td-navbar-nav-scroll ms-md-auto" id="main_navbar">
+	<ul class="navbar-nav">
+		{{ $p := . -}}
+		{{ range .Site.Menus.main -}}
+		<li class="nav-item">
+			{{ $active := or ($p.IsMenuCurrent "main" .) ($p.HasMenuCurrent "main" .) -}}
+			{{ $href := "" -}}
+			{{ with .Page -}}
+				{{ $active = or $active ( $.IsDescendant .) -}}
+				{{ $href = .RelPermalink -}}
+			{{ else -}}
+				{{ $href = .URL | relLangURL -}}
+			{{ end -}}
+			{{ $isExternal := ne $baseURL.Host (urls.Parse .URL).Host -}}
+			<a {{/**/ -}}
+				class="nav-link {{- if $active }} active {{- end }}" {{/**/ -}}
+				href="{{ $href }}"
+				{{- if $isExternal }} target="_blank" rel="noopener" {{- end -}}
+			>
+					{{- .Pre -}}
+					<span>{{ .Name }}</span>
+					{{- .Post -}}
+			</a>
+		</li>
+		{{ end -}}
+		{{ if .Site.Params.versions -}}
+		<li class="nav-item dropdown d-none d-lg-block">
+			{{ partial "navbar-version-selector.html" . -}}
+		</li>
+		{{ end -}}
+		{{ if (gt (len .Site.Home.Translations) 0) -}}
+		<li class="nav-item dropdown d-none d-lg-block">
+			{{ partial "navbar-lang-selector.html" . -}}
+		</li>
+		{{ end -}}
+		{{ if .Site.Params.ui.showLightDarkModeMenu -}}
+		<li class="td-light-dark-menu nav-item dropdown">
+			{{ partial "theme-toggler" . }}
+		</li>
+		{{ end -}}
+	</ul>
+</div>
+<div class="d-none d-lg-block">
+	{{ partial "search-input.html" . }}
+</div>
+</div>
+</nav>


### PR DESCRIPTION
navbar.html by default puts the title on every page. This update modifies navbar.html to not put the title on the home page. The title already is a central part of the text within the page and having it on the home page is redundant.

Defining the title in the config comes in useful for other Hugo templates that want to use the title of the website.  The RSS Feed will make use of this.