### PR TITLE
Update WASM Medley description

### DIFF
--- a/content/en/software/_index.md
+++ b/content/en/software/_index.md
@@ -17,6 +17,8 @@ Once you are up and running, see "[Using Medley](using-medley)" for some basics 
 
 * [Run Medley in the browser](http://wasm.interlisp.org/medley.html)
 
-We are making an earlier version of Interlisp-D run in the browser, an example of software preservation that lets you access a technology artifact of historical significance.
+We are making an earlier version of Interlisp-D run in the browser, an experimental port based on a version of the Maiko virtual machine compiled to WebAssembly with Emscripten. To end a session just close the browser tab.
 
-This experimental port is based on a version of the Maiko virtual machine compiled to WebAssembly with Emscripten. It currently doesn't support a file system and **can't save files**. To end a session just close the browser tab.
+Although this is an example of software preservation that lets you access a technology artifact of historical significance, we don't recommend it as it doesn't support a file system, **can't save files**, and there are more functional ways of running early Interlisp-D versions.
+
+We acknowledge these limitations and are exploring alternate approaches to running Medley online or in the browser. We welcome help and feedback.

--- a/content/en/software/_index.md
+++ b/content/en/software/_index.md
@@ -17,8 +17,6 @@ Once you are up and running, see "[Using Medley](using-medley)" for some basics 
 
 * [Run Medley in the browser](http://wasm.interlisp.org/medley.html)
 
-We are making an earlier version of Interlisp-D run in the browser, an experimental port based on a version of the Maiko virtual machine compiled to WebAssembly with Emscripten. To end a session just close the browser tab.
+We are making a build of Medley run in the browser, an experimental port based on the Maiko virtual machine compiled to WebAssembly with Emscripten. To end a session just close the browser tab.
 
-Although this is an example of software preservation that lets you access a technology artifact of historical significance, we don't recommend it as it doesn't support a file system, **can't save files**, and there are more functional ways of running early Interlisp-D versions.
-
-We acknowledge these limitations and are exploring alternate approaches to running Medley online or in the browser. We welcome help and feedback.
+We don't recommend this build as it doesn't support a file system and **can't save files**. We acknowledge these limitations and are exploring alternate approaches to running Medley online or in the browser. We welcome help and feedback.

--- a/content/en/software/_index.md
+++ b/content/en/software/_index.md
@@ -15,6 +15,8 @@ There are two main ways of running Medley: accessing it online in a web browser 
 
 Once you are up and running, see "[Using Medley](using-medley)" for some basics and pointers to other documentation.
 
-* *Coming*: [Running Medley in the browser!!](https://groups.google.com/g/lispcore/c/tiD2PUzBLCo/m/HuqWV63_AQAJ)
+* [Run Medley in the browser](http://wasm.interlisp.org/medley.html)
 
-We are working on making earlier version of Interlisp-D run in the browser. This example of software preservation will let you access a technology artifact of historical significance.
+We are making an earlier version of Interlisp-D run in the browser, an example of software preservation that lets you access a technology artifact of historical significance.
+
+This experimental port is based on a version of the Maiko virtual machine compiled to WebAssembly with Emscripten. It currently doesn't support a file system and **can't save files**. To end a session just close the browser tab.


### PR DESCRIPTION
This PR updates the [Software](https://interlisp.org/software) page of the project site to describe and link to a running instance of WebAssembly Medley. It addresses [Medley issue #2019](https://github.com/Interlisp/medley/issues/2019).
