### PR TITLE
Update Hugo to version 144.2

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -44,7 +44,7 @@ env:
   # ----------------------------------------------------------------------------
   # Specify the deployment environment:  staging or production
   HUGO_ENVIRONMENT: production
-  HUGO_VERSION: 0.133.1
+  HUGO_VERSION: 0.144.2
 
 jobs:
   # ----------------------------------------------------------------------------


### PR DESCRIPTION
Update Hugo version to latest 144.2.  I have a version running on the staging site at   [Staging](https://stumbo.github.io/InterlispDraft.github.io).  It appears to be operating correctly.  Feel free to check it out prior to approving this PR.