### PR TITLE
Fix typos in the Glossary page

### DIFF
--- a/content/en/history/glossary/_index.md
+++ b/content/en/history/glossary/_index.md
@@ -15,7 +15,7 @@ The names “Medley”, "Interlisp-D", “Interlisp.org”, “Common Lisp”, e
 ## Vocabulary and relationships
 
 Alto Lisp
-:  An (unsuccessful) attempt to build a Lisp-based OS for running Interlisp on an Alto
+:  An (unsuccessful) attempt to build a Lisp-based OS for running Interlisp on an Alto.
 
 Carol, Fugue, Harmony, Intermezzo, Koto, Lyric, Medley
 : Named releases of Interlisp-D.  All are obsolete except Medley.
@@ -31,7 +31,7 @@ Common Lisp the Language
 - CLtL2  – second edition, 1029 pages
 
 Common Lisp dpANS
-: The ANSI Standard for Common Lisp
+: The ANSI Standard for Common Lisp.
 
 Starting with the Lyric release of Interlisp-D and then the Medley release, the implementation of Medley included implementations of Common Lisp (CLtL 1) as well as the Interlisp dialect in a single development environment; this was made possible by using the (Common Lisp) “package” feature to allow both dialects to be intermixed.
 
@@ -39,7 +39,7 @@ Dfasl
 : A compiled form of Medley Interlisp files.
 
 DLISP
-: By Warren Teitelman: a first attempt at building a “Display” (GUI) with Interlisp running on Maxc (A PDP-10 clone) a Xerox Alto as a graphics terminal connected to it via Ethernet.`
+: By Warren Teitelman: a first attempt at building a “Display” (GUI) with Interlisp running on Maxc (A PDP-10 clone) a Xerox Alto as a graphics terminal connected to it via Ethernet.
 
 Dorado Lisp
 : The reimplementation of the AltoLisp microcode on the Dorado – a research prototype.
@@ -55,23 +55,23 @@ Intermezzo
 
 Interlisp
 : A GitHub “organization” with ~20 repositories, see <https://github.com/Interlisp>
-: Both a language and, in some cases, the implementation of that language. Usually used with some other wording or refinement
+: Both a language and, in some cases, the implementation of that language. Usually used with some other wording or refinement.
 
 Interlisp: The Language and its usage
-: A book by Steve Kaisler which describes Interlisp of the 1970s & 80s
+: A book by Steve Kaisler which describes Interlisp of the 1970s & 80s.
 
 Interlisp.org
-: A “domain name”, used for some web sites and email addresses
+: A “domain name”, used for some web sites and email addresses.
 
 - <https://interlisp.org>  – the address of the main web site
 - <https://online.interlisp.org> – the address of a service that lets you run Medley
 - <info@interlisp.org>             - an email address of a group that can respond to questions
 
 Interlisp-10
-: The first implementation of “Interlisp” for the DEC PDP-10 / Tenex
+: The first implementation of “Interlisp” for the DEC PDP-10 / Tenex.
 
 Interlisp-360
-: Implemention of Interlisp for the IBM-360
+: Implemention of Interlisp for the IBM-360.
 
 Interlisp-D
 : What Dorado Lisp became.  The D stood for both “Display” and “D-machine”.  An implementation of
@@ -86,7 +86,7 @@ Interlisp-D
   configurations and micro-instructions.
 
 Interlisp-VAX
-: Implementation of Interlisp for Digitial Equipment Corporation VAX systems
+: Implementation of Interlisp for Digitial Equipment Corporation VAX systems.
 
 InterlispOrg
 : A [California-registered](https://rct.doj.ca.gov/Verification/Web/Details.aspx?result=c7aa8cb2-16ec-458a-be56-41f963365258) non-profit organization  (DBA Interlisp.org) Established
@@ -114,13 +114,13 @@ Maiko
        Fuji Xerox.  Subsequently ported to little-endian processors and other operating systems.
 
 SDL
-: Structured Design Language
+: Structured Design Language.
 
 Sysout
-: A file containing the saved state of Interlisp virtual memroy
+: A file containing the saved state of Interlisp virtual memory.
 
 X11
-: The X Window System
+: The X Window System.
 
 ### Organizations
 
@@ -131,16 +131,16 @@ Xerox PARC or just PARC
 : Palo Alto Research Center, which continued in collaboration with BBN on (renamed) Interlisp. PARC developed the Alto and Dorado.  Now part of SRI International.
 
 SRI International
-: non-profit scientific R & D institute
+: non-profit scientific R & D institute.
 
 Xerox Electro-Optical Systems (XEOS)
-: Xerox division supporting classified customers
+: Xerox division supporting classified customers.
 
 Xerox Artificial Intelligence Systems (XAIS)
 : The division working to commercialize Xerox Workstations running Interlisp-D.
 
 Rank Xerox
-: Xerox affiliate in charge of delivering Interlisp-D workstations in Europe
+: Xerox affiliate in charge of delivering Interlisp-D workstations in Europe.
 
 Fuji Xerox
 : Xerox affiliate – joint project of Rank Xerox and Fuji Photo Film company.


### PR DESCRIPTION
A fix of some typos in the [Glossary](https://interlisp.org/history/glossary) page of the website:

- memroy -> memory
- remove a spurious backquote character
- add a full stop at the end of the sentences where it's missing