### PR TITLE
Include names of "Editors" when no "Authors" provided in Zotero data

### DIFF
--- a/layouts/shortcodes/bibTable.html
+++ b/layouts/shortcodes/bibTable.html
@@ -182,8 +182,7 @@ var abstractExpanderClose = "Abstract -";
         <tr>
           {{ $itemID := (cond (gt (len .id) 0) (replace .id `/` `_`) `_0`) }}
           <td><div class="bibTitle">{{ if .url }}<a href="{{ .url }}">{{ .title }}</a>{{ else }}{{ .title }}{{ end }}</div>
-          {{ if .author }}<div class="authors">  
-            {{ range $na, $au := .author }}{{ if $na }}; {{ end }}{{ if $au.literal }}{{ $au.literal }}{{ else if and $au.family $au.given }}{{ $au.family }}, {{ $au.given }}{{ else }}{{ $au.family }}{{ $au.given }}{{ end }}{{ end }}
+          {{ if or .author .editor }}<div class="authors">{{ if not .author }}<i>Edited by: </i>{{ end }}{{ range $naE, $auEd := or .author .editor }}{{ if $naE }}; {{ end }}{{ if $auEd.literal }}{{ $auEd.literal }}{{ else if and $auEd.family $auEd.given }}{{ $auEd.family }}, {{ $auEd.given }}{{ else }}{{ $auEd.family }}{{ $auEd.given }}{{ end }}{{ end }}
           </div>{{ end }}
           {{ if .abstract }}<button type="button" class="abstractExpander left" id="A{{$itemID}}">AAA</button>{{ end }}
           {{ if and false .note }}


### PR DESCRIPTION
Include names of "Editors" (if provided) when no "Authors" provided in Zotero json data for a given entry.
Prefix Editor(s) name(s) with "Edited by: " in Bibliography entry.

It looks like this:
![image](https://github.com/user-attachments/assets/1ed5292f-1ebb-496f-be71-7d2c441d68c0)
