### PR TITLE
Update publication deadline of LOOPS book 2

### DIFF
--- a/content/en/software/using-medley/_index.md
+++ b/content/en/software/using-medley/_index.md
@@ -82,6 +82,6 @@ These documents were converted from Medley's internal format into PDFs. Watch ou
 - [Interlisp Reference Manual (1993)](/documentation/IRM.pdf)
 - Medley LOOPS Books (LOOPS, the Lisp Object-Oriented Programming System, was an object extension of Interlisp):
   - [Volume I: Medley LOOPS: The Basic System](/documentation/2024-loops-book-1.pdf)
-  - Volume II: Medley LOOPS: Tools and Utilities (coming in the second half of 2025)
+  - Volume II: Medley LOOPS: Tools and Utilities (forthcoming)
   - Volume III: Medley LOOPS: Rule-based Systems and the Truckin Game (coming in the fall of 2025)
 

--- a/content/en/software/using-medley/_index.md
+++ b/content/en/software/using-medley/_index.md
@@ -82,6 +82,6 @@ These documents were converted from Medley's internal format into PDFs. Watch ou
 - [Interlisp Reference Manual (1993)](/documentation/IRM.pdf)
 - Medley LOOPS Books (LOOPS, the Lisp Object-Oriented Programming System, was an object extension of Interlisp):
   - [Volume I: Medley LOOPS: The Basic System](/documentation/2024-loops-book-1.pdf)
-  - Volume II: Medley LOOPS: Tools and Utilities (coming in the late fall of 2024)
+  - Volume II: Medley LOOPS: Tools and Utilities (coming in the second half of 2025)
   - Volume III: Medley LOOPS: Rule-based Systems and the Truckin Game (coming in the fall of 2025)
 


### PR DESCRIPTION
Since @skaisler1 is still working on the book *Medley LOOPS Volume II: Tools and Utilities* this change updates the publication timeframe on the [Documentation page](https://interlisp.org/software/using-medley) from "in the late fall of 2024" to a more conservative "in the second half of 2025".

