### PR TITLE
Rearranging the News and Status Reports page

### DIFF
--- a/content/en/project/status/_index.md
+++ b/content/en/project/status/_index.md
@@ -14,19 +14,15 @@ aliases:
  - /medley/project/status/
 ---
 
-## 2024 Annual Report released
-
-The [2024 Medley Interlisp Annual Report](/project/status/2024medleyannualreport) has been released.  Another year of progress.
-
-## Build Notes
-
-Builds of Medley for several operating systems and architectures are generated automatically every week. You can [learn what's changed and download the latest builds](https://github.com/Interlisp/medley/releases). We advise caution as these builds are untested and may have bugs or other issues.
-
 ## May 2025 IEEE Canadian Conference on Electrical and Computer Engineering
 
 On May 28, 2025 Eleanor Young presented "The Medley Interlisp Project: Reviving a Historical Software System" at the [2025 IEEE Canadian Conference on Electrical and Computer Engineering and Industry Summit](https://ccece2025.ieee.ca) (CCECE). The paper by Young et al. was accepted for publication.
 
 A [preprint](/documentation/young-ccece2025.pdf) of the paper and the [slides](/documentation/young-ccece2025-slides.pdf) of the talk are available. Please post questions, inquiries or your thoughts on the paper to one of our [social media sites](../getInvolved#3-join-in-the-discussions).
+
+## 2024 Annual Report released
+
+The [2024 Medley Interlisp Annual Report](/project/status/2024medleyannualreport) has been released.  Another year of progress.
 
 ## Larry Masinter at aNONradio in December 2024
 
@@ -46,14 +42,9 @@ On May 6, 2024 Andrew Sengul gave the remote talk "The Medley Interlisp Revival"
 
 <iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/ZBAJukF5mPE?si=nLVT7PRHd4-m0OMp" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 
-## Annual Reports
+## 2023 Annual Report released
 
-The Medley team has produced annual reports documenting their major achievements.
-
-- [2024 Annual Report](/project/status/2024medleyannualreport)
-- [2023 Annual Report](/project/status/2023medleyannualreport)
-- [2022 Annual Report](/project/status/2022medleyannualreport)
-- [2021 Annual Report](/project/status/2021medleyannualreport)
+The [2023 Medley Interlisp Annual Report](/project/status/2023medleyannualreport) was released.
 
 ## November 2023 Computer Conservation Society event
 
@@ -69,6 +60,10 @@ being undertaken by the Medley project.
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/N1MobfEaoWY" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
 
-## Closed Issues
+## 2022 Annual Report released
 
-The [issues closed](https://github.com/Interlisp/medley/issues?q=is%3Aissue+is%3Aclosed) by the team can be found in our GitHub repository.
+The [2022 Medley Interlisp Annual Report](/project/status/2022medleyannualreport) was released.
+
+## 2021 Annual Report released
+
+We released the [2021 Medley Interlisp Annual Report](/project/status/2021medleyannualreport) on the first year of the Medley Interlisp Project.

--- a/content/en/software/install-and-run/_index.md
+++ b/content/en/software/install-and-run/_index.md
@@ -14,3 +14,7 @@ type: docs
 Packaged releases of Medley are available for Linux (most recent distros), macOS and Windows 10/11.  Both x86_64 and ARM64 systems are supported (as well as ARM7 - e.g., Raspberry Pi - for Linux).  Instructions for installing and running Medley on these platforms are linked below.
 
 Medley is capable of running on a variety of other OSes including FreeBSD and Solaris, as well as on other CPU architectures including i386, SPARC, PowerPC, and RISC-V.  To install and run Medley on these platforms, you will need to build Medley (and, optionally, its underlying virtual machine, *Maiko*) from the sources available in the Interlisp repos on [GitHub.com](https://github.com/interlisp/).  Instructions for building Medley and Maiko can be found on GitHub in the [*README* for Maiko](https://github.com/interlisp/maiko) and the [*README* for Medley](https://github.com/interlisp/medley).
+
+## Release Notes
+
+Builds of Medley for several operating systems and architectures are generated automatically every week. You can [learn what's changed and download the latest builds](https://github.com/Interlisp/medley/releases). We advise caution as these builds are untested and may have bugs or other issues.


### PR DESCRIPTION
This change rearranges the [News and Status Reports](https://interlisp.org/project/status) page in reverse chronological order and moves section Build Notes, renamed as Release Notes, to page [Install and Run](https://interlisp.org/software/install-and-run) where it's more relevant.

I also deleted section Closed Issues of the News and Status Reports page, as the information is irrelevant to the majority of users and those interested in this level of detail likely know where to look.
