### PR TITLE
Linking to the latest YouTube videos of the project channel

### DIFF
--- a/content/en/project/status/_index.md
+++ b/content/en/project/status/_index.md
@@ -14,6 +14,21 @@ aliases:
  - /medley/project/status/
 ---
 
+## June-August 2025 videos
+
+We published new videos to our [YouTube channel](https://www.youtube.com/@Interlisp):
+
+* [PARC Forum — Frank Halasz Lectures on Notecards (September 1986)](https://www.youtube.com/watch?v=4icjACQQgN8)
+* [Notecards System Overview — Robert Spinrad and Frank Halasz (June 1986)](https://www.youtube.com/watch?v=gY_p8ZIa4Kk)
+* [Introduction to Notecards — Tom Moran and Frank Halasz (January 1985)](https://www.youtube.com/watch?v=KS0yNjZE5ew)
+* [Notecards Part 1 — Basic System (May 1985)](https://www.youtube.com/watch?v=CZCitxFlnqQ)
+* [Notecards Part 2 — Research Issues (May 1985)](https://www.youtube.com/watch?v=MsYGDON_7Ds)
+* [Notecards Examples -- Frank Halasz (1986)](https://www.youtube.com/watch?v=qtC5-Zq-UCg)
+* [Trillium Forum: Austin Henderson (1984)](https://www.youtube.com/watch?v=pXwzh1Q2GeQ)
+* [Herb Jellinek: Meeting Analyst Workstation](https://www.youtube.com/watch?v=HmPA1hHi7RM)
+* [Colab Cognoter Tool Demonstration Reels (1988)](https://www.youtube.com/watch?v=KzBj13OSVzM)
+* [Applications of Interlisp-D -- PARC Forum (1981)](https://www.youtube.com/watch?v=TXujD1bF1NI)
+
 ## May 2025 IEEE Canadian Conference on Electrical and Computer Engineering
 
 On May 28, 2025 Eleanor Young presented "The Medley Interlisp Project: Reviving a Historical Software System" at the [2025 IEEE Canadian Conference on Electrical and Computer Engineering and Industry Summit](https://ccece2025.ieee.ca) (CCECE). The paper by Young et al. was accepted for publication.


### PR DESCRIPTION
As a starting point for regular updates on the videos we publish on YouTube, this PR adds to the [News and Status Reports](https://interlisp.org/project/status) page the new section "June-August 2025 videos" with links to the videos we published to our channel in that time range. The change addresses [issue #2239](https://github.com/Interlisp/medley/issues/2239).
