### PR TITLE
Rss feed fix

### DIFF
--- a/config/_default/params.yaml
+++ b/config/_default/params.yaml
@@ -67,10 +67,10 @@ gcs_engine_id: 33ef4cbe0703b4f3a
 #   icon:  icon to display
 links:
   user:
-  - name: "User mailing list"
-    url: "mailto:Interlisp@googlegroups.com"
+  - name: "Email"
+    url: "mailto:info@interlisp.org"
     icon: "fa fa-envelope"
-    desc:  "Discussion and help from your fellow users"
+    desc:  "Contact us for general information or inquiries"
   - name: "Mastodon"
     url: "https://fosstodon.org/@interlisp"
     icon: "fa-brands fa-mastodon"
@@ -79,6 +79,10 @@ links:
     url: "https://bsky.app/profile/interlisp.org"
     icon: "fa-brands fa-bluesky"
     desc: "We're on Bluesky too!"
+  - name: "YouTube"
+    url: "https://www.youtube.com/@Interlisp"
+    icon: "fa-brands fa-youtube"
+    desc: "Subscribe to our YouTube channel"
   - name: "RSS Feed"
     url: "project/status/rss.xml"
     icon: "fa fa-rss"

--- a/layouts/_default/rss.xml
+++ b/layouts/_default/rss.xml
@@ -1,3 +1,6 @@
+<!-- Print XML declaration -->
+{{- printf "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"yes\"?>" | safeHTML }}
+
 {{- $authorName := "" }}
 {{- with .Site.Params.author }}
   {{- if reflect.IsMap . }}
@@ -9,33 +12,42 @@
   {{- end }}
 {{- end }}
 
-{{- $pctx := . }}
-{{- if .IsHome }}{{ $pctx = .Site }}{{ end }}
-
 <!-- Iterate through all sections and include both sections and
      pages in the rss feed. The default rss.xml only includes
      pages. -->
 {{- $pages := slice }}
-{{- $mainPages := where .Pages "Kind" "in" (slice "page" "section") }}
+
+<!-- Include the current list page (_index.md) if we're on home or a section -->
+{{- $pages = $pages | union (slice .) }}
+{{- $mainPages := where .Pages "Kind" "in" (slice "page" ) }}
 {{- $pages = $pages | union $mainPages }}
 
+
+<!-- Loop through each section and add it's _index.md and child pages -->
 {{- range .Sections }}
-  {{- $sectionPages := where .Pages "Kind" "in" (slice "page" "section") }}
+  {{- $sectionPages := where .Pages "Kind" "in" (slice "page") }}
+  {{- $pages = $pages | union (slice .) }}
   {{- $pages = $pages | union $sectionPages }}
+  <!-- Loop through any subsections adding their _index.md and child pages -->
   {{- range .Sections }}
-    {{- $subSectionPages := where .Pages "Kind" "in" (slice "page" "section") }}
+    {{- $subSectionPages := where .Pages "Kind" "in" (slice "page") }}
+    {{- $pages = $pages | union (slice .) }}
     {{- $pages = $pages | union $subSectionPages }}
   {{- end }}
 {{- end }}
+
+<!-- order entries by PublishDate-->
+{{- $pages = sort $pages "PublishDate" "desc" }}
 
 {{- $limit := .Site.Config.Services.RSS.Limit }}
 {{- if ge $limit 1 }}
   {{- $pages = $pages | first $limit }}
 {{- end }}
 
+<!-- Build the actual feed using the page list-->
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
   <channel>
-    <title>Updates from the Medley Interlisp Project</title>
+    <title>Updates from the new Medley Interlisp Project</title>
     <link>{{ .Permalink }}</link>
     <description>Updates from the Medley Interlisp Project</description>
     <generator>Hugo -- gohugo.io</generator>{{ with .Site.LanguageCode }}


### PR DESCRIPTION
Fixes rss feed.  Changes to _index.md are now included.
The code was including all the pages within a section but not the
section index, _index.md.

The rss feed generated looks like this (presently):

```
<rss version="2.0">
<channel>
<title>Updates from the new Medley Interlisp Project</title>
<link>//localhost:1313/project/status/</link>
<description>Updates from the Medley Interlisp Project</description>
<generator>Hugo -- gohugo.io</generator>
<language>en</language>
<lastBuildDate>Fri, 08 Aug 2025 05:17:35 +0200</lastBuildDate>
<atom:link href="//localhost:1313/project/status/rss.xml" rel="self" type="application/rss+xml"/>
<item>
<title>News and Status Reports</title>
<link>//localhost:1313/project/status/</link>
<pubDate>Fri, 08 Aug 2025 05:17:35 +0200</pubDate>
<guid>//localhost:1313/project/status/</guid>
<description>
<h2 id="june-august-2025-videos">June-August 2025 videos</h2> <p>We published new videos to our <a href="https://www.youtube.com/@Interlisp">YouTube channel</a>:</p> <ul> <li><a href="https://www.youtube.com/watch?v=4icjACQQgN8">PARC Forum — Frank Halasz Lectures on Notecards (September 1986)</a></li> <li><a href="https://www.youtube.com/watch?v=gY_p8ZIa4Kk">Notecards System Overview — Robert Spinrad and Frank Halasz (June 1986)</a></li> <li><a href="https://www.youtube.com/watch?v=KS0yNjZE5ew">Introduction to Notecards — Tom Moran and Frank Halasz (January 1985)</a></li> <li><a href="https://www.youtube.com/watch?v=CZCitxFlnqQ">Notecards Part 1 — Basic System (May 1985)</a></li> <li><a href="https://www.youtube.com/watch?v=MsYGDON_7Ds">Notecards Part 2 — Research Issues (May 1985)</a></li> <li><a href="https://www.youtube.com/watch?v=qtC5-Zq-UCg">Notecards Examples &ndash; Frank Halasz (1986)</a></li> <li><a href="https://www.youtube.com/watch?v=pXwzh1Q2GeQ">Trillium Forum: Austin Henderson (1984)</a></li> <li><a href="https://www.youtube.com/watch?v=HmPA1hHi7RM">Herb Jellinek: Meeting Analyst Workstation</a></li> <li><a href="https://www.youtube.com/watch?v=KzBj13OSVzM">Colab Cognoter Tool Demonstration Reels (1988)</a></li> <li><a href="https://www.youtube.com/watch?v=TXujD1bF1NI">Applications of Interlisp-D &ndash; PARC Forum (1981)</a></li> </ul> <h2 id="may-2025-ieee-canadian-conference-on-electrical-and-computer-engineering">May 2025 IEEE Canadian Conference on Electrical and Computer Engineering</h2> <p>On May 28, 2025 Eleanor Young presented &ldquo;The Medley Interlisp Project: Reviving a Historical Software System&rdquo; at the <a href="https://ccece2025.ieee.ca">2025 IEEE Canadian Conference on Electrical and Computer Engineering and Industry Summit</a> (CCECE). The paper by Young et al. was accepted for publication.</p>
</description>
</item>
<item>
<title>2024 Medley Interlisp Annual Report</title>
<link>
//localhost:1313/project/status/2024medleyannualreport/
</link>
<pubDate>Wed, 23 Jul 2025 20:55:35 -0400</pubDate>
<guid>
//localhost:1313/project/status/2024medleyannualreport/
</guid>
<description>
<p><img src="//localhost:1313/Resources/logo_red_no_border_568x385.png" width="284" height="194"></img></p> <h2 id="overview"><strong>Overview</strong></h2> <p>Interlisp-D (and the Medley version of it) were originally developed at the Xerox Palo Alto Research Center (PARC) in the 1970’s and 80’s. It was a software environment for rapid prototyping, research and Artificial Intelligence, combining the power of the Lisp language and system elements with the now common PARC-born Windows/Icon/Mouse/Pointer graphical user interface.</p> <p>The Medley Interlisp project was started in 2020 by a few of the original developers, focusing on reviving the software, making it usable and useful on modern systems. With permission from the last licensee of the software, we are able to release the system as open source. This report highlights the accomplishments and continuing projects over 2024.</p>
</description>
</item>
<item>
<title>2023 Annual Report</title>
<link>
//localhost:1313/project/status/2023medleyannualreport/
</link>
<pubDate>Wed, 23 Jul 2025 20:55:35 -0400</pubDate>
<guid>
</guid>
<description>
<p><img src="//localhost:1313/Resources/logo_red_no_border_568x385.png" width="284" height="194"></img></p> <h3 id="overview"><strong>Overview</strong></h3> <p>The Medley Interlisp Project has made significant progress toward its goals of preserving, extending, and documenting the “experience” of Interlisp for now and for the future. This annual report highlights our achievements and ongoing efforts.</p> <h3 id="key-accomplishments"><strong>Key Accomplishments</strong></h3> <p>We’ve structured our work around project objectives: lower barriers to entry, adapt to modern environments and user expectations, complete “work in progress”, demonstrate applications built in and for the system.</p> <h4 id="lower-barriers-to-entry"><strong>Lower Barriers to Entry</strong></h4> <p>We want to allow newcomers to experience the system and ease of use without complex setup and configuration, so that more individuals can participate.</p>
</description>
</item>
<item>
<title>2021 Medley Interlisp Annual Report</title>
<link>
//localhost:1313/project/status/2021medleyannualreport/
</link>
<pubDate>Wed, 23 Jul 2025 20:55:35 -0400</pubDate>
<guid>
//localhost:1313/project/status/2021medleyannualreport/
</guid>
<description>
<p>November 15, 2021</p> <p>Join <a href="https://groups.google.com/g/interlisp">Interlisp group</a> or follow @<a href="https://github.com/Interlisp">interlisp on GitHub</a></p> <h3 id="introduction">Introduction</h3> <p>To “revive” something is to make it live again. Making Medley Interlisp live again means putting the system in order so that others without a previous deep background in Interlisp can use and appreciate it (if only as a virtual antique).</p> <p>The Medley Interlisp project started in earnest in March of 2020 (at the beginning of the pandemic). This report focuses on activities and accomplishments since the December 2020 virtual meeting of <a href="https://lispnyc.org/">LispNYC</a> (recording at: <a href="https://www.youtube.com/watch?v=x6-b%5c_hazcyk">https://www.youtube.com/watch?v=x6-b_hazcyk</a>).</p>
</description>
</item>
<item>
<title>2022 Medley Interlisp Annual Report</title>
<link>
//localhost:1313/project/status/2022medleyannualreport/
</link>
<pubDate>Wed, 25 Jun 2025 13:38:11 -0400</pubDate>
<guid>
//localhost:1313/project/status/2022medleyannualreport/
</guid>
<description>
<h3 id="introduction">Introduction</h3> <p>We have made considerable progress on the Interlisp software preservation project, and we want to offer tours and collaboration for those engaged in similar or related software preservation efforts.</p> <p>Interlisp was an early and unique software development environment (IDE) developed in the 1970’s and 1980’s at Xerox PARC, and a testbed for novel software development tools. The Medley version of Interlisp-D was built as a portable Virtual Machine, which has allowed us to bring the system forward to run on a wide variety of modern hardware and operating systems.</p>
</description>
</item>
</channel>
</rss>
```