### PR TITLE
Bs4 fix layout

### DIFF
--- a/layouts/bibliography/baseof.html
+++ b/layouts/bibliography/baseof.html
@@ -13,7 +13,7 @@
     <div class="container-fluid td-outer">
       <div class="td-main" {{- .Section | safeHTMLAttr }}>
         <div class="row flex-xl-nowrap">
-          <aside class="d-none d-xl-block col-xl-2 td-sidebar-toc d-print-none">
+          <aside class="d-none d-xl-block col-xl-4 td-sidebar-toc d-print-none">
             {{ partial "page-meta-links.html" . }}
             {{ partial "toc.html" . }}
             {{ partial "taxonomy_terms_clouds.html" . }}


### PR DESCRIPTION
Fix sidebar with author names to use all available space:
<img width="971" height="304" alt="image" src="https://github.com/user-attachments/assets/e2ea3571-fcfb-4b9d-b264-e625c5bfd538" />

Sidebar is responsive and will grow and shrink with window size.  