### PR TITLE
Fix a few bibliography display issues

### DIFF
--- a/layouts/bibliography/list.html
+++ b/layouts/bibliography/list.html
@@ -62,8 +62,7 @@
       {{- $rendered = $rendered | htmlEscape -}}
       <a href="{{ .RelPermalink }}"><span><strong>{{- $rendered | safeHTML -}}</strong></span></a><br>
 
-      {{- /* Safe date: use front matter date only if non-empty & matches basic pattern */ -}}
-            {{- $authors := .Params.authors -}}
+      {{- $authors := .Params.authors -}}
       {{- $editors := .Params.editors -}}
       {{- $isPatent := eq .Params.item_type "patent" -}}
       {{- /* warnf "authors: %v" $authors */ -}}
@@ -91,17 +90,19 @@
       <br>
       {{- end -}}
 
+      {{- /* Safe date: use front matter date only if non-empty & matches basic pattern */ -}}
       {{- $d := .Date -}}
+      {{- $fmtDate := .Params.readabledate -}}
       {{- with .Params.date -}}
-        {{- $datestr := trim . " " -}}
-        {{- if and (ne $datestr "") (findRE `^\d{4}-\d{2}-\d{2}` $datestr) -}}
-          {{- $d = time $datestr -}}
+        {{- $isoDate := trim . " " -}}
+        {{- if and (ne $isoDate "") (findRE `^\d{4}-\d{2}-\d{2}` $isoDate) -}}
+          {{- $d = time $isoDate -}}
         {{- end -}}
-      {{- end -}}
+      {{- end }}
       {{- $d = $d.Format "2006-01-02" -}}
       {{- /* Don't display bogus date */ -}}
       {{- if (ne $d "0001-01-01") }}
-        <time datetime="{{ $d }}">{{ $d }}</time><br>
+        <time datetime="{{ $d }}">{{ $fmtDate }}</time>
       {{ end -}}
 
       {{ with .Params.abstract -}}
@@ -114,7 +115,7 @@
           {{- $previewWords := split $plain " " | first $previewWordLimit -}}
           {{- $preview = delimit $previewWords " " -}}
         {{- else -}}
-          {{- $preview = replace . "\n" "<br>" -}}
+          {{- $preview = replace (. | htmlEscape) "\n" "<br>" -}}
         {{- end -}}
         <br>
         <div>{{ $preview | safeHTML }}{{ if $previewing }}…{{ end }}</div>

--- a/layouts/bibliography/single.html
+++ b/layouts/bibliography/single.html
@@ -32,16 +32,17 @@
 
 <p>
   {{- $d := .Date -}}
+      {{- $fmtDate := .Params.readabledate -}}
   {{- with .Params.date -}}
-    {{- $datestr := trim . " " -}}
-    {{- if and (ne $datestr "") (findRE `^\d{4}-\d{2}-\d{2}` $datestr) -}}
-      {{- $d = time $datestr -}}
+    {{- $isoDate := trim . " " -}}
+    {{- if and (ne $isoDate "") (findRE `^\d{4}-\d{2}-\d{2}` $isoDate) -}}
+      {{- $d = time $isoDate -}}
     {{- end -}}
   {{- end }}
   {{- $d = $d.Format "2006-01-02" -}}
   {{- /* Don't display bogus date */ -}}
   {{- if (ne $d "0001-01-01") }}
-    <time datetime="{{ $d }}">{{ $d }}</time>
+    <time datetime="{{ $d }}">{{ $fmtDate }}</time>
   {{ end -}}
 </p>
 <p>
@@ -56,7 +57,7 @@
     <strong>Abstract</strong>
     <br>
     {{ with .Params.abstract }}
-      {{ . | markdownify }}
+      {{ . | htmlEscape | markdownify }}
     {{ else }}
       No abstract available.
     {{ end }}

--- a/scripts/bib-fns.jq
+++ b/scripts/bib-fns.jq
@@ -30,6 +30,14 @@ def issued_iso_string:
     . 
   end;
 
+def issued_date_readable:
+  if nonBlankKey("issued") and (.issued | nonBlankKey("date-parts")) then 
+    setpath(["readableDateString"]; 
+    (.issued["date-parts"][0]) as $p | $p | map(pad2) | join("-"))
+  else 
+    . 
+  end;
+  
 def format_person_name:
       if (has("family") and .family != null and (.family|tostring|length)>0) then
         .family

--- a/scripts/update_bibliography.sh
+++ b/scripts/update_bibliography.sh
@@ -7,13 +7,16 @@ function usage () {
   echo -e "Usage: $0 [ options ] [ input_items_file ]\n"
   echo -e "Options:"
   echo -e "  -h | --help               \tDisplay this message and exit."
-  echo -e "  -r | --rawitems           \tSave the complete downloaded JSON as '00-rawItems.json' (See 'input_items_file' below.)."
+  echo -e "  -r | --rawitems           \tSave the complete downloaded JSON as '00-rawItems.json'"
+  echo -e "                            \t(See 'input_items_file' below.)."
   echo -e "  -g | --tagsfile           \tGenerate 'tags.json' containing all tags on the 'cleaned-up' set of entries."
   echo -e "  -y | --typefiles          \tGenerate item type information JSON files. (See below.)"
   echo -e "  -c | --collectionsfiles   \tGenerate two JSON files containing info about each of the Zotero collections."
-  echo -e "  -u | --curlfiles          \tGenerate files in the 'curl/' directory with the output of each call to curl. Very low level debugging."
+  echo -e "  -u | --curlfiles          \tGenerate files in the 'curl/' directory with the output of each call to curl."
+  echo -e "                            \t(Very low level debugging.)"
   echo -e "  -d | --debugfiles         \tGenerate numbered files with the intermediate processing step output JASON."
-  echo -e "  -i N | --infolevel N      \tSet the level of display of informational messages. N is 0-10 (Default = 2.). (See below.)"
+  echo -e "  -i N | --infolevel N      \tSet the level of display of informational messages. N is 0-10 (Default = 2.)."
+  echo -e "                            \t(See below.)"
   echo -e "\n typefiles: These 3 files contain the type and itemType information for the entries with different level of details."
   echo -e "\n infolevel: The infolevel controls how much detail is presented during processing."
   echo -e "   0: NO info messages."
@@ -374,11 +377,11 @@ if $debugFiles ; then
 fi
 finalCount=$(jq '. | length' <<< "$items")
 
-items=$(jq 'include "./bib-fns";map(issued_iso_string)' <<< "$items")
+items=$(jq 'include "./bib-fns";map(issued_iso_string | issued_date_readable | add_author_string | add_editor_string)' <<< "$items")
 
-items=$(jq 'include "./bib-fns";map(add_author_string)' <<< "$items")
+#items=$(jq 'include "./bib-fns";map(add_author_string)' <<< "$items")
 
-items=$(jq 'include "./bib-fns";map(add_editor_string)' <<< "$items")
+#items=$(jq 'include "./bib-fns";map(add_editor_string)' <<< "$items")
 # if $removeChildrenFromFinalFile; then
 #   # Remove .children arrays, if any. Save space.
 #   items=$(jq 'map(del(.children))' <<< "$items")


### PR DESCRIPTION
Fix a few bibliography display issues: 
1. Accented characters mis-encoded -- resolves Interlisp/medley#2339
2. HTMLish "tags" improperly removed -- resolves Interlisp/medley#2340
3. display dates as originally set in Zotero -- resolves Interlisp/medley#2342

**Note:** there **_may_** be additional bibliography item metadata fields that _could_ contain the issues 1 and 2 above. We could wait until we discover them, or we could add these changes to those we _suspect_ are likely to contain them.
