### PR TITLE
Add lastmod, last modified date of the bibliographic entry

### DIFF
--- a/scripts/bibSplit.pl
+++ b/scripts/bibSplit.pl
@@ -103,7 +103,9 @@ if ($key eq $target) {  # only top level entries
   
   my $urlSource = defined $obj->{url} ? $obj->{url} : '';
 
-  # Some/most/all of these *may* need sanitize_text
+  # Modified date
+  my $dateModified = defined $obj->{dateModified} ? $obj->{dateModified} : '';
+
   # optional fields - ones used vary by value of type
   my $applicationNumber = defined $obj->{applicationNumber} ? qq{"$obj->{applicationNumber}"} : '""';
   my $assignee = defined $obj->{assignee} ? qq{"$obj->{assignees}"} : '""';
@@ -185,6 +187,9 @@ $extraFields
 tags:
 url_source: $urlSource
 zotero_url: "https://www.zotero.org/groups/2914042/items/$key"
+
+# Timestamp of last modification to bibliographic item
+lastmod: $dateModified
 ---
 
 ENDITEM

--- a/scripts/update_bibliography.sh
+++ b/scripts/update_bibliography.sh
@@ -282,7 +282,7 @@ fi
 
 # Remove library, links, and meta objects; and some fields from entries
 # (These are not used any further on, so simplify.)
-items=$(jq 'map(del(.["library", "links", "meta", "accessed", "accessDate", "dateAdded", "dateModified"]))' <<< "$items")
+items=$(jq 'map(del(.["library", "links", "meta", "accessed", "accessDate", "dateAdded"]))' <<< "$items")
 showInfo 8 "Remove library, links, and meta objects and some unnecessary fields"
 if $debugFiles ; then
   dfn=$(debugFileName "noLibraryLinksMeta" $dfn)


### PR DESCRIPTION
`lastmod` is used in `sitemap.xml` to help identify files that have changed and should be recrawled.  Writing `lastmod` into the markdown file's YAML will ensure it takes precedence over the current date field, which represents the publication date of the item, not the last time the bibliographic entry was modified.

Resolves issue [2346](https://github.com/Interlisp/medley/issues/2346)