### PR TITLE
Fix decade headings in timeline.

### DIFF
--- a/content/en/history/timeline/_index.md
+++ b/content/en/history/timeline/_index.md
@@ -126,7 +126,7 @@ Bob Sproull came up with the idea for what would turn out to be the first client
 
 In 1979, PARC began the design of the Dorado, a high performance personal workstation. The availability of the Dorado also made possible building a Lisp with a native display capability, which led to the Interlisp-D project.
 
-### 1980s
+## 1980s
 
 - Teitelman & Masinter, IEEE Computer, “[The Interlisp Programming Environment](https://larrymasinter.net/interlisp-ieee.pdf)” April 1981.
 - [1983 Stanford University Medical Experiment Computer](https://github.com/Interlisp/history/tree/master/1980s/1983-sumex-lisp)
@@ -177,7 +177,7 @@ In 1979, PARC began the design of the Dorado, a high performance personal workst
 
 ### 1993
 
-## 2000
+## 2000s
 
 The ADVISE/advice idea and names carried through to the Aspect/J system, and on into contemporary, mainstream Java frameworks.
 


### PR DESCRIPTION
Set 1980s to correct formatting level. Make 2000 plural to match other decade formatting.  Result is:
<img width="72" height="666" alt="image" src="https://github.com/user-attachments/assets/918d9c48-aed3-45a6-9b0b-bf55a455a896" />
