### PR TITLE
Get HUGO_ENVIRONMENT from GitHub repo defined variable

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -43,7 +43,7 @@ defaults:
 env:
   # ----------------------------------------------------------------------------
   # Specify the deployment environment:  staging or production
-  HUGO_ENVIRONMENT: production
+  HUGO_ENVIRONMENT: ${{ vars.HUGO_ENVIRONMENT || 'staging' }}
   HUGO_VERSION: 0.144.2
 
 jobs:


### PR DESCRIPTION
If HUGO_ENVIRONMENT is defined as a GitHub repository variable use it, if not default to staging.  This change allows me to move from production to staging without having to edit gh-pages.yml.

Note:  I added an environment variable to the Interlisp.github.io repository.  So when merged the production site will continue to operate as expected.