### PR TITLE
Remove `webkit-scrollbar`, `webkit-scrollbar-track` and `webkit-scrollbar-thumb'

### DIFF
--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -58,6 +58,7 @@
   scrollbar-width: 0px;
 }*/
 
+/* Remove scrollbar css interfering with bibliography pages
 *::-webkit-scrollbar {
   width: 0;
 }
@@ -70,6 +71,7 @@
   background: transparent;
   border: none;
 }
+  */
 
 * {
   -ms-overflow-style: none;

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -71,11 +71,11 @@
   background: transparent;
   border: none;
 }
-  */
 
 * {
   -ms-overflow-style: none;
 }
+  */
 
 .carousel ol, .carousel li {
   list-style: none;


### PR DESCRIPTION
These values were set to non-default in `custom.css` and are interferring with the bibliography page (and all other pages in Chrome).

It appears they were set this way with some carousel work that never came to fruition.

I suspect both the `custom.css` and `carousel.css` files are no longer needed and can be removed.  That requires more investigation.