### PR TITLE
New Medley primer

### DIFF
--- a/content/en/_index.html
+++ b/content/en/_index.html
@@ -28,6 +28,8 @@ aliases:
 
 <p>The <a href="project/status/2024medleyannualreport/">2024 Medley Interlisp Annual Report</a> describes our recent activities.</p>
 
+<p>We encourage you to read the <a href="https://primer.interlisp.org">Medley primer</a> and try out the Interlisp environment. The primer, designed for modern users, assumes no prior knowledge of Lisp and will ease you into the system.</p>
+
 <p>Feeling confused by the jargon? Don't worry, we've got you covered. <a href="history/glossary/">Check out our glossary</a> to learn the terms associated with our project.</p>
 
 <p>Most software in this project is licensed under the terms of the <a href="https://github.com/Interlisp/medley/blob/master/LICENSE">MIT license</a>.</p>

--- a/content/en/project/status/_index.md
+++ b/content/en/project/status/_index.md
@@ -16,7 +16,7 @@ aliases:
 
 ## New Medley Primer
 
-In november of 2025 we published [Medley Interlisp for the Newcomer](https://primer.interlisp.org) by Abhik Hasnain, an introductory guide to Interlisp and the Medley environment.
+In November of 2025 we published [Medley Interlisp for the Newcomer](https://primer.interlisp.org) by Abhik Hasnain, an introductory guide to Interlisp and the Medley environment.
 
 ## Autumn Lisp Game Jam 2025
 

--- a/content/en/project/status/_index.md
+++ b/content/en/project/status/_index.md
@@ -14,6 +14,10 @@ aliases:
  - /medley/project/status/
 ---
 
+## New Medley Primer
+
+In november of 2025 we published [Medley Interlisp for the Newcomer](https://primer.interlisp.org) by Abhik Hasnain, an introductory guide to Interlisp and the Medley environment.
+
 ## Autumn Lisp Game Jam 2025
 
 On November 10, 2025 Ryan Burnside entered the [Autumn Lisp Game Jam 2025](https://itch.io/jam/autumn-lisp-game-jam-2025) with the [Interlisp Hungarian Rings](https://itch.io/jam/autumn-lisp-game-jam-2025/rate/4015363) puzzle written in Interlisp.

--- a/content/en/software/using-medley/_index.md
+++ b/content/en/software/using-medley/_index.md
@@ -34,7 +34,7 @@ Note: locations of documents are likely to change. Best to bookmark this page, w
 2. [Medley Basics for Common Lisp users](cl-using). 
 If you are familiar with Common Lisp, this guide points out some differences.
 3. [Using Medley Online](online-using) -- additional introduction primarily for online users
-1. [Medley for the Novice](/documentation/Medley-Primer.pdf) (also known as Medley Primer).  An introductory guide to the basics of Medley such as executing commands, using menus and files, manipulating windows, editing and saving Lisp code, using the development tools, and more. Read it in full. The code in chapter 20 "Free Menus" doesn't work and some illustrations are missing.
+1. [Medley Interlisp for the Newcomer](https://primer.interlisp.org) (also known as the new Medley Primer). An introductory guide to the basics of Interlisp and the Medley environment that doesn't assume prior knowledge of Lisp. Read it in full. Written in 2025, the guide is designed to ease modern users into the system and replace the [old primer](/documentation/Medley-Primer.pdf) published in 1992, now obsolete and ridden with errors.
 1. [SEdit — The Lisp Editor](https://drive.google.com/file/d/12LW5zCZauJvC63NRMJhjNv5qJkuuCflb/view?usp=sharing). The manual of SEdit, the default Lisp code editor.
 
 1. [LispCourse notes](https://interlisp.org/documentation/lispcourse.pdf). The notes of a beginner course on the Interlisp environment that goes from the basics of interacting with the system to programming in Lisp. Highly recommended. Skip the sections on printing and the network as modern Medley doesn't fully implement the described functionality. The formatting of the text is partially broken and some sections are missing. 

--- a/content/en/software/using-medley/_index.md
+++ b/content/en/software/using-medley/_index.md
@@ -30,13 +30,10 @@ Note: locations of documents are likely to change. Best to bookmark this page, w
 
 #### Introductory material
 
-1. [Interlisp Basics](il-using)
-2. [Medley Basics for Common Lisp users](cl-using). 
+1. [Medley Interlisp for the Newcomer](https://primer.interlisp.org) (also known as the new Medley Primer). An introductory guide to the basics of Interlisp and the Medley environment that doesn't assume prior knowledge of Lisp. Read it in full. Written in 2025, the guide is designed to ease modern users into the system and replace the [old primer](/documentation/Medley-Primer.pdf) published in 1992, now obsolete.
+1. [Medley Basics for Common Lisp users](cl-using). 
 If you are familiar with Common Lisp, this guide points out some differences.
-3. [Using Medley Online](online-using) -- additional introduction primarily for online users
-1. [Medley Interlisp for the Newcomer](https://primer.interlisp.org) (also known as the new Medley Primer). An introductory guide to the basics of Interlisp and the Medley environment that doesn't assume prior knowledge of Lisp. Read it in full. Written in 2025, the guide is designed to ease modern users into the system and replace the [old primer](/documentation/Medley-Primer.pdf) published in 1992, now obsolete and ridden with errors.
 1. [SEdit — The Lisp Editor](https://drive.google.com/file/d/12LW5zCZauJvC63NRMJhjNv5qJkuuCflb/view?usp=sharing). The manual of SEdit, the default Lisp code editor.
-
 1. [LispCourse notes](https://interlisp.org/documentation/lispcourse.pdf). The notes of a beginner course on the Interlisp environment that goes from the basics of interacting with the system to programming in Lisp. Highly recommended. Skip the sections on printing and the network as modern Medley doesn't fully implement the described functionality. The formatting of the text is partially broken and some sections are missing. 
 
 #### Advanced material


### PR DESCRIPTION
This PR changes the [documentation page](https://interlisp.org/software/using-medley) to link to the new Medley primer [Medley Interlisp for the Newcomer](https://primer.interlisp.org), mentions it on the [home page](https://interlisp.org), and announces the primer on the [News and Status Reports](https://interlisp.org/project/status) page.
