### PR TITLE
Remove all empty fields (and the keys) from the downloaded Zotero bibliography data.

### DIFF
--- a/scripts/update_bibliography.sh
+++ b/scripts/update_bibliography.sh
@@ -246,6 +246,13 @@ fi
 showInfo 1 "Got $(jq '. | length' <<< "$items") items"
 
 # Piece-wise processing for debugging:
+items=$(jq 'include "./bib-fns";walk(if type == "object" then removeEmptyKeys end)' <<< $items)
+showInfo 8 "Remove all empty fields and the keys."
+if $debugFiles ; then
+  dfn=$(debugFileName "removeEmptyKeys" $dfn)
+  echo "$items" > "$dfn"
+fi
+
 items=$(jq 'include "./bib-fns";map(semiflatten)' <<< "$items")
 showInfo 8 "Elevate fields in .csljson and .data to the item level."
 if $debugFiles ; then


### PR DESCRIPTION
This is done as the very first thing to avoid overwriting merged (jq "multiplied") fields (e.g. in semiflatten)

This should resolve PR Interlisp/medley#2436