### PR TITLE
Fix broken 2025 annual report link

### DIFF
--- a/content/en/project/partners/_index.md
+++ b/content/en/project/partners/_index.md
@@ -40,7 +40,7 @@ University of Alberta
 In 2025 we started a collaboration with the Interim Computer Museum for an Interlisp exhibition.
 
 * The museum set up a space to demonstrate the running Medley system and let visitor try it out
-* We developed ["Museum Mode"](status/2025medleyannualreport#community-outreach) for Medley Online, a facility to support guided demonstrations in museums or other settings
+* We developed ["Museum Mode"](/project/status/2025medleyannualreport#community-outreach) for Medley Online, a facility to support guided demonstrations in museums or other settings
 
 ### Internet Archive
 


### PR DESCRIPTION
A fix for the broken link to the 2025 Medley project annual report I [introduced](https://github.com/Interlisp/Interlisp.github.io/pull/317#issuecomment-3855556578) in PR #317.