### PR TITLE
Bs15 capitalization fix

### DIFF
--- a/config/_default/hugo.yaml
+++ b/config/_default/hugo.yaml
@@ -9,6 +9,11 @@
 #        edited navbar.html to not show the title in the navbar of the home page.
 title: "The Medley Interlisp Project"
 
+# Hugo by default converts page titles to title case (first letter or each word capitalized).
+# Since we have instances where this is incorrect, we disable it and rely on the content 
+# authors to use the correct case in the title field of the front matter.
+titleCaseStyle: none
+
 # relativeURLs: Enable to force all relative URLs to be relative to content root
 relativeURLs: false
 

--- a/layouts/taxonomy.html
+++ b/layouts/taxonomy.html
@@ -1,0 +1,10 @@
+{{- /* Override of Docsy taxonomy.html to title-case the taxonomy name */ -}}
+{{- /* Hugo's title function is disabled by titleCaseStyle: none, so we manually capitalize */ -}}
+{{ define "main" -}}
+<div class="td-content">
+  <main class="taxonomy-terms-page">
+    <h1>{{ .Title | strings.FirstUpper }}</h1>
+    {{ partial "taxonomy_terms_cloud.html" (dict "context" . "taxo" ( lower .Title ) ) -}}
+  </main>
+</div>
+{{- end }}


### PR DESCRIPTION
Fixes capitalization issues with author's names.  Issue [#2477](https://github.com/Interlisp/medley/issues/2477)

1) Disable title capitalization, `titleCaseStyle: none` .  Default value is AP style.  Other options are Chicago and First Letter
2) Create custom `taxonomy.html`, this page duplicates the taxonomy.html page from Docsy but capitalizes the title of the page listing all the authors.