### PR TITLE
Fix broken links to obituaries of Warren Teitelman and Daniel Bobrow

### DIFF
--- a/content/en/history/in-memoriam.md
+++ b/content/en/history/in-memoriam.md
@@ -5,9 +5,9 @@ type: docs
 ---
 Some of the key contributors to Interlisp who are no longer with us. This page is to honor and appreciate them for the contributions they made.
 
-#### [Warren Teitelman](https://en.wikipedia.org/wiki/Warren_Teitelman) ([Obituary](http://warrenteitelman.com))
+#### [Warren Teitelman](https://en.wikipedia.org/wiki/Warren_Teitelman) ([Obituary](https://web.archive.org/web/20250317210326/http://warrenteitelman.com/))
 
-#### [Danny Bobrow](https://en.wikipedia.org/wiki/Daniel_G._Bobrow) ([Obituary](https://www.paloaltoonline.com/obituaries/memorials/daniel-danny-g-bobrow-phd?o=4957))
+#### [Danny Bobrow](https://en.wikipedia.org/wiki/Daniel_G._Bobrow) ([Obituary](https://web.archive.org/web/20231002012901/https://www.paloaltoonline.com/obituaries/memorials/daniel-danny-g-bobrow-phd?o=4957))
 
 #### [John Sybalsky](http://www.sybalsky.net)
 


### PR DESCRIPTION
The links to the obituaries of Warren Teitelman and Daniel Bobrow in the [In Memoriam](https://interlisp.org/history/in-memoriam) page are broken. This PR replaces them with the corresponding links to the Wayback Machine captures.