### PR TITLE
Fix layout of keystroke table and revise some entries

### DIFF
--- a/content/en/software/using-medley/keystrokes.md
+++ b/content/en/software/using-medley/keystrokes.md
@@ -2,26 +2,27 @@
 title: Keystrokes, Mouse menus and Gestures
 url: /software/using-medley/keystrokes/
 weight: 40
+type: docs
 aliases:
  - /doc/info/Keystrokes.html
 ---
 
-The handling of keyboard and mouse clicks and gestures is different and varied within the Medley environment. This chart shows common keystrokes.
-[Table of Keystrokes](https://docs.google.com/spreadsheets/d/1FOkrr62TtEhhY49m9U0T_6bvqSGRQt9fBRtMDw0YKtY/edit?usp=sharing) more data.
+The handling of keyboard and mouse clicks and gestures is different and varied within the Medley environment. This chart shows common keystrokes. On macOS the Option key is equivalent to Alt. See
+[Table of Keystrokes](https://docs.google.com/spreadsheets/d/1FOkrr62TtEhhY49m9U0T_6bvqSGRQt9fBRtMDw0YKtY/edit?usp=sharing) for more data.
 
 We'd like to improve keyboard handling but haven't yet found a path.
 
-## At an "exec" (i.e., the REPL). 
+## At an "exec" (i.e., the REPL) 
 
 |character |action                          |
 |----------|--------------------------------|
-|backspace | delete the previous character  |
-|ctrl-H    |   (same as backspace)          |
-|enter     |if at end of line, terminate    |
-|ctrl-M    |  (same as enter)               |
-|ctrl-alt-J|move down                       |
-|ctrl-alt-L|move to start of line           |
-|ctrl-alt-Y|"get userexec" ????             |
+|Backspace | delete the previous character  |
+|Ctrl-H    |   (same as backspace)          |
+|Enter     |if terminates a valid expression evaluate, otherwise newline    |
+|Ctrl-M    |  (same as Enter)               |
+|Ctrl-Alt-J|move down                       |
+|Ctrl-Alt-L|move to start of line (some OSes capture this for system functions, e.g. screen lock on Linux)          |
+|Ctrl-Alt-Y| invoke an old-style executive (REPL), but uses the package and readtable of its caller             |
 
 ## Interrupt characters
 
@@ -35,11 +36,8 @@ below take place in the mouse process if it is busy, otherwise the TTY process.
 
 |character|action                                                |
 |---------|-----------------------------------------             |
-|ctrl-B   |stop the process and enter a break window             |
-|ctrl-D   | reset the process, unwind the stack to the top level |
-|ctrl-E   | unwind the stack as if an error occured without break|
-|ctrl-P   | interrupt printing and reset the PRINTLEVEL          |
-
-
-
-
+|Ctrl-B   |stop the process and enter a break window             |
+|Ctrl-D   | reset the process, unwind the stack to the top level |
+|Ctrl-E   | unwind the stack as if an error occured without break|
+|Ctrl-G   | interrupt a non TTY process and open the debugger|
+|Ctrl-P   | interrupt printing and reset the PRINTLEVEL          |


### PR DESCRIPTION
This PR makes the changes to the [Keystrokes, Mouse menus and Gestures](https://interlisp.org/software/using-medley/keystrokes) page discussed in the March 5, 2026 external meeting as well as a few more tweaks: fix the missing sidebars of the page, capitalize key names, add an entry for Ctrl-G, and clarify the Enter, Ctrl-Alt-L, and Ctrl-Alt-Y entries.
