### PR TITLE
Bs21 gha version updates

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -186,7 +186,7 @@ jobs:
         run: hugo --cleanDestinationDir -e $HUGO_ENVIRONMENT
         
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@v5.0.0
         with:
           path: ./public
 

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -49,6 +49,8 @@ env:
   # Specify the deployment environment:  staging or production
   HUGO_ENVIRONMENT: ${{ vars.HUGO_ENVIRONMENT || 'staging' }}
   HUGO_VERSION: 0.155.3
+  # Temporary to validate Node.js 24 works correctly
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
   # ----------------------------------------------------------------------------
@@ -65,14 +67,14 @@ jobs:
 
       - name: Get Zotero Version Information
         id: zoteroVersion
-        uses: fjogeleit/http-request-action@v1
+        uses: fjogeleit/http-request-action@v2
         with:
           url: https://api.zotero.org/groups/2914042/items?format=versions
           method: GET
         
       - name: Cache Zotero Bibliography
         id: cache-zotero
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5.0.3
         with:
           lookup-only: true
           path: |
@@ -87,7 +89,7 @@ jobs:
     if: github.event_name == 'push' || github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Check Hugo version consistency
         run: |
@@ -121,14 +123,14 @@ jobs:
     if: always() && (github.event_name == 'push' || github.event_name == 'pull_request' || needs.check.outputs.cacheHit != 'true') && (needs.validate-docs.result == 'success' || needs.validate-docs.result == 'skipped') && (needs.check.result == 'success' || needs.check.result == 'skipped')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: recursive
           fetch-depth: 0
 
       - name: Cache Zotero Bibliography
         id: cache-bib
-        uses: actions/cache@v4
+        uses: actions/cache@v5.0.3
         with:
           path: |
             static/data/bibliography.json
@@ -157,9 +159,9 @@ jobs:
         uses: actions/configure-pages@v5
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: 18
+          node-version: 24
       
       - run: npm install -g autoprefixer --save-dev  
       - run: npm install -g postcss-cli --save-dev
@@ -172,7 +174,7 @@ jobs:
         run: hugo --cleanDestinationDir -e $HUGO_ENVIRONMENT
         
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v4
         with:
           path: ./public
 

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -53,8 +53,6 @@ env:
   # Specify the deployment environment:  staging or production
   HUGO_ENVIRONMENT: ${{ vars.HUGO_ENVIRONMENT || 'staging' }}
   HUGO_VERSION: 0.155.3
-  # Temporary to validate Node.js 24 works correctly
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
   # ----------------------------------------------------------------------------

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -54,7 +54,7 @@ env:
   HUGO_ENVIRONMENT: ${{ vars.HUGO_ENVIRONMENT || 'staging' }}
   HUGO_VERSION: 0.155.3
   # Temporary to validate Node.js 24 works correctly
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 
 jobs:
   # ----------------------------------------------------------------------------

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -177,8 +177,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          npm install -g autoprefixer postcss-cli
-          npm install
+          npm ci
 
       - name: Build
         env:

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -40,6 +40,10 @@ permissions:
     pages: write
     id-token: write
 
+concurrency:
+  group: pages-${{ github.ref }}
+  cancel-in-progress: true
+
 defaults:
     run:
         shell: bash
@@ -60,7 +64,7 @@ jobs:
   check:
     outputs:
       zoteroVersion: ${{ steps.zoteroVersion.outputs.version }}
-      cacheHit: ${{ steps.cache-zotero-bib.outputs.cache-hit }}
+      cacheHit: ${{ steps.cache-zotero.outputs.cache-hit }}
 
     runs-on: ubuntu-latest
     steps:
@@ -76,7 +80,7 @@ jobs:
 
       - name: Cache Zotero Bibliography
         id: cache-zotero
-        uses: actions/cache/restore@v5.0.3
+        uses: actions/cache/restore@v5
         with:
           lookup-only: true
           path: |
@@ -132,7 +136,7 @@ jobs:
 
       - name: Cache Zotero Bibliography
         id: cache-bib
-        uses: actions/cache@v5.0.3
+        uses: actions/cache@v5
         with:
           path: |
             static/data/bibliography.json
@@ -164,15 +168,17 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: 24
-      
-      - run: npm install -g autoprefixer --save-dev  
-      - run: npm install -g postcss-cli --save-dev
-      - run: npm install --verbose
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: |
+          npm install -g autoprefixer postcss-cli
+          npm install
 
       - name: Build
         env:
           HUGO_CACHEDIR: ${{ runner.temp }}/hugo_cache
-          TZ: America/New York
+          TZ: America/New_York
         run: hugo --cleanDestinationDir -e $HUGO_ENVIRONMENT
         
       - name: Upload artifact

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -201,5 +201,5 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5
       

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -54,7 +54,7 @@ env:
   HUGO_ENVIRONMENT: ${{ vars.HUGO_ENVIRONMENT || 'staging' }}
   HUGO_VERSION: 0.155.3
   # Temporary to validate Node.js 24 works correctly
-
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
   # ----------------------------------------------------------------------------

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -167,7 +167,7 @@ jobs:
 
       - name: Setup Pages
         id: pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6.0.0
 
       - name: Setup Node
         uses: actions/setup-node@v6

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -59,7 +59,7 @@ jobs:
   #
   check:
     outputs:
-      zoteroVersion: ${{ fromJson(steps.zoteroVersion.outputs.headers).last-modified-version }}
+      zoteroVersion: ${{ steps.zoteroVersion.outputs.version }}
       cacheHit: ${{ steps.cache-zotero-bib.outputs.cache-hit }}
 
     runs-on: ubuntu-latest
@@ -67,11 +67,13 @@ jobs:
 
       - name: Get Zotero Version Information
         id: zoteroVersion
-        uses: fjogeleit/http-request-action@v2
-        with:
-          url: https://api.zotero.org/groups/2914042/items?format=versions
-          method: GET
-        
+        run: |
+          VERSION=$(curl -sI "https://api.zotero.org/groups/2914042/items?format=versions" \
+            | grep -i "last-modified-version" \
+            | cut -d: -f2 \
+            | tr -d '\r ' )
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
       - name: Cache Zotero Bibliography
         id: cache-zotero
         uses: actions/cache/restore@v5.0.3

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -72,11 +72,16 @@ jobs:
       - name: Get Zotero Version Information
         id: zoteroVersion
         run: |
-          VERSION=$(curl -sI "https://api.zotero.org/groups/2914042/items?format=versions" \
+          set -euo pipefail
+          VERSION=$(curl -fsSLI "https://api.zotero.org/groups/2914042/items?format=versions" \
             | grep -i "last-modified-version" \
             | cut -d: -f2 \
-            | tr -d '\r ' )
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
+            | tr -d $'\r ' )
+          if [[ -z "${VERSION:-}" ]]; then
+            echo "Error: Failed to determine Zotero Last-Modified-Version from API response." >&2
+            exit 1
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Cache Zotero Bibliography
         id: cache-zotero

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -81,7 +81,7 @@ jobs:
           lookup-only: true
           path: |
             content/en/history/bibliography
-          key: bib-${{ fromJson(steps.zoteroVersion.outputs.headers).last-modified-version }}
+          key: bib-${{ steps.zoteroVersion.outputs.version }}
 
   # ----------------------------------------------------------------------------
   # Validate that README.md references the correct Hugo version.

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -71,7 +71,7 @@ jobs:
         id: zoteroVersion
         run: |
           set -euo pipefail
-          VERSION=$(curl -fsSLI "https://api.zotero.org/groups/2914042/items?format=versions" \
+            VERSION=$(curl -fsSLI "https://api.zotero.org/groups/2914042/items?format=versions" \
             | grep -i "last-modified-version" \
             | cut -d: -f2 \
             | tr -d $'\r ' )

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -72,9 +72,9 @@ jobs:
         run: |
           set -euo pipefail
             VERSION=$(curl -fsSLI "https://api.zotero.org/groups/2914042/items?format=versions" \
-            | grep -i "last-modified-version" \
-            | cut -d: -f2 \
-            | tr -d $'\r ' )
+            | { grep -i "last-modified-version" \
+                | cut -d: -f2 \
+                | tr -d $'\r ' || true; })
           if [[ -z "${VERSION:-}" ]]; then
             echo "Error: Failed to determine Zotero Last-Modified-Version from API response." >&2
             exit 1


### PR DESCRIPTION
On June 2, 2026 GitHub will be moving to Node.js 24.  This PR updates several of the actions we use to versions that support Node.js 24.  In addition, I replaced one action, `fjogeleit/http-request-action` with a basic `curl` command.  The action was using a deprecated function and maintenance on the action appeared to be minimal.  This removes the reliance on node.js and preserves the needed functionality.

I also made a couple minor enhancements and potential bug fixes based on Copilot's recommendations.

There currently is an environment variable, `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` that needs to be removed prior to merging.  This forces it to run with Node.js 24.  I have the action currently deployed on my staging site.  It all appears to be working correctly.  I'll leave it running there to make sure I didn't miss anything.

~~There are two actions that will need to be updated once new versions are released:~~
~~- actions/configure-pages~~
 ~~- actions/upload-artifact~~
As of April 11, 2026 both of these actions have been updated and are now Node.js 24 compliant.

While they appear to run correctly on Node.js 24 I would prefer to have actions that are built with this version.