### PR TITLE
Link to CHM PARC Archive

### DIFF
--- a/content/en/history/_index.md
+++ b/content/en/history/_index.md
@@ -27,3 +27,6 @@ When sold as a workstation of the Xerox Office Systems Division, the machines ha
 ### Detailed History
 
 A more extensive history of Interlisp can be found in the [Interlisp Timeline](timeline). The [Interlisp Bibliography](bibliography) has a wealth of historical material.
+
+The Computer History Museum makes available the [Xerox PARC Archive](https://info.computerhistory.org/xerox-parc-archive), a snapshot of files originally stored on servers at Xerox PARC. This collection comprises source code, documents, images, and other files related to projects from the 1980s to 1994, including Interlisp (see section "Interlisp software" on the walkthrough page).
+


### PR DESCRIPTION
As discussed in the March 19, 2026 external meeting this change adds a link to the Computer History Museum PARC Archive from [section Detailed History of the History page](https://interlisp.org/history/#detailed-history) of the website. It addresses [issue #1389](https://github.com/Interlisp/medley/issues/1389).
