### PR TITLE
Recommend the Medley primer as a way of getting involved

### DIFF
--- a/content/en/project/getInvolved/_index.md
+++ b/content/en/project/getInvolved/_index.md
@@ -18,7 +18,7 @@ There several ways to get involved in the Medley Interlisp Project, depending on
 
 ## 1. Try it!
 
-We're actively trying to improve the new user experience, but don't expect a polished commercial product--we're still in the middle of restoration. But things are pretty stable. Reading the [Medley primer](https://primer.interlisp.org) and checking out the system at [online.interlisp.org](https://online.interlisp.org) should get you started.
+We're actively trying to improve the new user experience, but don't expect a polished commercial product--we're still in the middle of restoration. But things are pretty stable. Reading the [Medley primer](https://primer.interlisp.org) and checking out the system at [online.interlisp.org](https://online.interlisp.org) should get you started. This is an opportunity to [let us know how the primer helps you](https://github.com/Interlisp/medley/issues/new?template=primer.yml) learn the basics of Medley.
 
 ## 2. GitHub
 

--- a/content/en/project/getInvolved/_index.md
+++ b/content/en/project/getInvolved/_index.md
@@ -18,7 +18,7 @@ There several ways to get involved in the Medley Interlisp Project, depending on
 
 ## 1. Try it!
 
-We're actively trying to improve the new user experience, but don't expect a polished commercial product--we're still in the middle of restoration. But things are pretty stable. [online.interlisp.org](https://online.interlisp.org) should get you started. Type in (+ 1 2 3).
+We're actively trying to improve the new user experience, but don't expect a polished commercial product--we're still in the middle of restoration. But things are pretty stable. Reading the [Medley primer](https://primer.interlisp.org) and checking out the system at [online.interlisp.org](https://online.interlisp.org) should get you started.
 
 ## 2. GitHub
 


### PR DESCRIPTION
This PR recommends under [section Try it! of the Get Involved page](https://interlisp.org/project/getinvolved/#1-try-it) to read the Medley primer as a way of getting involved. We discussed the change in the April 29, 2026 external meeting.
