### PR TITLE
Advise on how to file Medley issues or feature requests

### DIFF
--- a/content/en/project/getInvolved/_index.md
+++ b/content/en/project/getInvolved/_index.md
@@ -20,7 +20,7 @@ There several ways to get involved in the Medley Interlisp Project, depending on
 
 We're actively trying to improve the new user experience, but don't expect a polished commercial product--we're still in the middle of restoration. But things are pretty stable. Reading the [Medley primer](https://primer.interlisp.org) and checking out the system at [online.interlisp.org](https://online.interlisp.org) should get you started. This is an opportunity to [let us know how the primer helps you](https://github.com/Interlisp/medley/issues/new?template=primer.yml) learn the basics of Medley.
 
-To report problems or suggest new features [open an issue against the GitHub repository of Medley](https://github.com/Interlisp/medley/issues/new/choose), even if it's about Maiko or other Medley subsystems or repositories.
+To report problems or suggest new features [open an issue](https://github.com/Interlisp/medley/issues/new/choose) in the Medley GitHub repository. We track all issues against the project from this repository.
 
 ## 2. GitHub
 

--- a/content/en/project/getInvolved/_index.md
+++ b/content/en/project/getInvolved/_index.md
@@ -20,6 +20,8 @@ There several ways to get involved in the Medley Interlisp Project, depending on
 
 We're actively trying to improve the new user experience, but don't expect a polished commercial product--we're still in the middle of restoration. But things are pretty stable. Reading the [Medley primer](https://primer.interlisp.org) and checking out the system at [online.interlisp.org](https://online.interlisp.org) should get you started. This is an opportunity to [let us know how the primer helps you](https://github.com/Interlisp/medley/issues/new?template=primer.yml) learn the basics of Medley.
 
+To report problems or suggest new features [open an issue against the GitHub repository of Medley](https://github.com/Interlisp/medley/issues/new/choose), even if it's about Maiko or other Medley subsystems or repositories.
+
 ## 2. GitHub
 
 We work primarily through [the Interlisp repositories on GitHub](https://github.com/Interlisp). While there are several repositories for the project, issues (problem reports) are to be found in the [medley repo issue list](https://github.com/Interlisp/medley/issues). If you have a GitHub account, you can watch the repositories of interest (medley, maiko, online).


### PR DESCRIPTION
This PR adds to the [Get Involved](https://interlisp.org/project/getinvolved) page instructions on how to report bugs or feature requests. We recommend opening an issue against the Medley GitHub repo even it's about another subsystem or repo as it's our only issue tracker.

We discussed this in the June 24, 2026 external meeting.
