### PR TITLE
Set Bibliography Index page to noindex

### DIFF
--- a/content/en/history/bibliography/_index.md
+++ b/content/en/history/bibliography/_index.md
@@ -2,6 +2,7 @@
 title: Bibliography
 heading: Interlisp Bibliography
 type: bibliography
+robots: "noindex, follow"
 cascade:
     type: bibliography
     toc_hide: true

--- a/layouts/_partials/hooks/head-end.html
+++ b/layouts/_partials/hooks/head-end.html
@@ -1,3 +1,11 @@
 <link rel="canonical" href="{{ .Permalink }}">
 <link rel="me" href="https://fosstodon.org/@interlisp">
+{{- /* Emit a page-level robots directive when front matter sets `robots`.
+       Docsy's head.html already emits "index, follow" for production pages;
+       when both tags are present, search engines apply the most restrictive
+       rule, so a `noindex` value here wins. See the bibliography section's
+       _index.md. */ -}}
+{{ with .Params.robots }}
+<meta name="robots" content="{{ . | htmlEscape }}">
+{{ end }}
 {{ partial "bibliography-json-ld.html" . }}

--- a/layouts/bibliography/list.html
+++ b/layouts/bibliography/list.html
@@ -107,9 +107,9 @@
           {{- $previewing := gt (countwords $plain) $previewWordLimit -}}
           {{- if $previewing }}
             {{- $previewWords := split $plain " " | first $previewWordLimit -}}
-            <div class="mt-2 small">{{ delimit $previewWords " " | safeHTML }}…</div>
+            <div class="mt-2 small" data-nosnippet>{{ delimit $previewWords " " | safeHTML }}…</div>
           {{- else }}
-            <div class="mt-2 small">{{ replace (. | htmlEscape) "\n" "<br>" | safeHTML }}</div>
+            <div class="mt-2 small" data-nosnippet>{{ replace (. | htmlEscape) "\n" "<br>" | safeHTML }}</div>
           {{- end }}
         {{ end }}
       </li>

--- a/layouts/sitemap.xml
+++ b/layouts/sitemap.xml
@@ -2,6 +2,7 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
   xmlns:xhtml="http://www.w3.org/1999/xhtml">
   {{ range (where .Data.Pages "Type" "!=" "redirect") }}
+  {{- if not (strings.Contains (.Params.robots | default "") "noindex") }}
   <url>
     <loc>{{ .Permalink }}</loc>{{ if not .Lastmod.IsZero }}
     <lastmod>{{ safeHTML ( .Lastmod.Format "2006-01-02T15:04:05-07:00" ) }}</lastmod>{{ end }}{{ with .Sitemap.ChangeFreq }}
@@ -18,5 +19,6 @@
                 href="{{ .Permalink }}"
                 />{{ end }}
   </url>
+  {{- end }}
   {{ end }}
 </urlset>


### PR DESCRIPTION
Search results currently favor the bibliography index page listing all the items in the bibliography.  These changes set this page to `noindex`, follow instructing robots not to index the page but to index the child pages.  This will help surface the individual pages when searches are performed on items covered in bibliographic entries.

- Add a new tag to the bibliography _index.md page setting it to `noindex, follow`
- Add code to head-end.html to recognize front matter tag and inscribe the appropriate value into the generated page
- Add `data-nosnippet` around preview text in generated bibliography entries on the index page.  This is a secondary change that tells a search engine not to use the preview text in returned results.  Given we don't want the page indexed, it may be overkill.
- Add page level `noindex` information to sitemap.